### PR TITLE
Remove cert fixes closes #4

### DIFF
--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -66,7 +66,7 @@ function Remove-TppCertificate {
         [String] $Path,
 
         [Parameter()]
-        [switch] $RemoveConsumer,
+        [switch] $KeepAssociatedApps,
 
         [Parameter()]
         [VenafiSession] $VenafiSession = $script:VenafiSession
@@ -87,7 +87,7 @@ function Remove-TppCertificate {
         $params.UriLeaf = "Certificates/$guid"
 
         if ( $PSCmdlet.ShouldProcess($Path, 'Remove certificate and all associations') ) {
-            if ($RemoveConsumer) {
+            if ($KeepAssociatedApps) {
                 $associatedApps = $Path | Get-TppAttribute -Attribute "Consumers" -Effective -VenafiSession $VenafiSession | Select-Object -ExpandProperty Value
                 if ( $associatedApps ) {
                     Remove-TppCertificateAssociation -Path $Path -ApplicationPath $associatedApps -VenafiSession $VenafiSession -Confirm:$false

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -6,9 +6,6 @@ Remove a certificate
 Removes a Certificate object, all associated objects including pending workflow tickets, and the corresponding Secret Store vault information.
 You must either be a Master Admin or have Delete permission to the objects and have certificate:delete token scope.
 
-.PARAMETER InputObject
-TppObject which represents a unique object
-
 .PARAMETER Path
 Path to the certificate to remove
 
@@ -19,7 +16,7 @@ Provide this switch to remove associations prior to certificate removal
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
 
 .INPUTS
-InputObject or Path
+Path
 
 .OUTPUTS
 None
@@ -56,7 +53,8 @@ function Remove-TppCertificate {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -75,16 +73,19 @@ function Remove-TppCertificate {
 
         $params = @{
             VenafiSession = $VenafiSession
-            Method     = 'Delete'
-            UriLeaf    = 'placeholder'
+            Method        = 'Delete'
+            UriLeaf       = 'placeholder'
         }
+
+        # use in shouldprocess messaging below
+        $appsMessage = if ($KeepAssociatedApps) { 'but keep associated apps' } else { 'and associated apps' }
     }
 
     process {
         $guid = $Path | ConvertTo-TppGuid -VenafiSession $VenafiSession
         $params.UriLeaf = "Certificates/$guid"
 
-        if ( $PSCmdlet.ShouldProcess($Path, 'Remove certificate and all associations') ) {
+        if ( $PSCmdlet.ShouldProcess($Path, "Remove certificate $appsMessage") ) {
             if ($KeepAssociatedApps) {
                 $associatedApps = $Path | Get-TppAttribute -Attribute "Consumers" -Effective -VenafiSession $VenafiSession | Select-Object -ExpandProperty Value
                 if ( $associatedApps ) {

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -91,9 +91,6 @@ function Remove-TppCertificate {
                 $associatedApps = $Path | Get-TppAttribute -Attribute "Consumers" -Effective -VenafiSession $VenafiSession | Select-Object -ExpandProperty Value
                 if ( $associatedApps ) {
                     Remove-TppCertificateAssociation -Path $Path -ApplicationPath $associatedApps -VenafiSession $VenafiSession -Confirm:$false
-                } else {
-                    Write-Error ("Path '{0}' has associations and cannot be removed.  Provide -Force to override." -f $Path)
-                    Return
                 }
             }
 

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -4,9 +4,7 @@ Remove a certificate
 
 .DESCRIPTION
 Removes a Certificate object, all associated objects including pending workflow tickets, and the corresponding Secret Store vault information.
-All associations must be removed for the certificate to be removed.
-You must either be a Master Admin or have Delete permission to the Certificate object
-and to the Application and Device objects if they are to be deleted automatically with -Force
+You must either be a Master Admin or have Delete permission to the objects and have certificate:delete token scope.
 
 .PARAMETER InputObject
 TppObject which represents a unique object
@@ -14,8 +12,8 @@ TppObject which represents a unique object
 .PARAMETER Path
 Path to the certificate to remove
 
-.PARAMETER Force
-Provide this switch to force all associations to be removed prior to certificate removal
+.PARAMETER KeepAssociatedApps
+Provide this switch to remove associations prior to certificate removal
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
@@ -32,11 +30,11 @@ Remove a certificate via pipeline
 
 .EXAMPLE
 Remove-TppCertificate -Path '\ved\policy\my cert'
-Remove a certificate
+Remove a certificate and any associated app
 
 .EXAMPLE
-Remove-TppCertificate -Path '\ved\policy\my cert' -force
-Remove a certificate and automatically remove all associations
+Remove-TppCertificate -Path '\ved\policy\my cert' -KeepAssociatedApps
+Remove a certificate and first remove all associations, keeping the apps
 
 .LINK
 http://VenafiPS.readthedocs.io/en/latest/functions/Remove-TppCertificate/


### PR DESCRIPTION
Updates Remove-TppCertificate to provide for the use case of disassociating the apps on a certificate before deleting it, therefore preserving the device and app (using the KeepAssociatedApps switch) or the use case of removing the certificate and all associated apps & devices.
Note: The behavior of the delete certificate and all devices/apps follows the logic of removing them only if no other association exists. This means that if a device has a second app with a separate associated certificate it will not be removed.