### PR TITLE
Add support for vault access token. Closes #81

### DIFF
--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -5,7 +5,7 @@ Test if a Tpp token is valid
 .DESCRIPTION
 Use the TPP API call 'Authorize/Verify' to test if the current token is valid.
 
-.PARAMETER Server
+.PARAMETER AuthServer
 Auth server or url, venafi.company.com or https://venafi.company.com.
 This will be used to access vedauth for token-based authentication.
 If just the server name is provided, https:// will be appended.
@@ -49,12 +49,16 @@ $TppToken | Test-TppToken
 Verify that token object from pipeline is valid. Can be used to validate directly object from New-TppToken.
 
 .EXAMPLE
-Test-TppToken -Server venafitpp.mycompany.com -AccessToken $cred
+Test-TppToken -AuthServer venafi.mycompany.com -AccessToken $cred
 Verify that PsCredential object containing accesstoken is valid.
 
 .EXAMPLE
 Test-TppToken -VaultAccessTokenName access-token
-Verify access token stored in VenafiPS vault
+Verify access token stored in VenafiPS vault, metadata stored with secret
+
+.EXAMPLE
+Test-TppToken -VaultAccessTokenName access-token -AuthServer venafi.mycompany.com
+Verify access token stored in VenafiPS vault providing server to authenticate against
 
 .EXAMPLE
 Test-TppToken -GrantDetail
@@ -118,7 +122,7 @@ function Test-TppToken {
         if ( $serverUrl -notlike 'https://*') {
             $serverUrl = 'https://{0}' -f $serverUrl
         }
-}
+    }
 
     process {
 

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -15,6 +15,8 @@ Access token retrieved outside this module.  Provide a credential object with th
 
 .PARAMETER VaultAccessTokenName
 Name of the SecretManagement vault entry for the access token; the name of the vault must be VenafiPS.
+Note: '-Server' parameter is required if the vault does not contain saved metadata. See
+New-VenafiSession -VaultMetaData
 
 .PARAMETER TppToken
 Token object obtained from New-TppToken
@@ -85,8 +87,8 @@ function Test-TppToken {
                 }
             }
         )]
-        [Alias('ServerUrl')]
-        [string] $Server,
+        [Alias('Server')]
+        [string] $AuthServer,
 
         [Parameter(Mandatory, ParameterSetName = 'AccessToken', ValueFromPipeline)]
         [PSCredential] $AccessToken,
@@ -95,7 +97,6 @@ function Test-TppToken {
         [pscustomobject] $TppToken,
 
         [Parameter(Mandatory, ParameterSetName = 'VaultAccessToken')]
-        [Parameter(ParameterSetName = 'AccessToken')]
         [string] $VaultAccessTokenName,
 
         [Parameter()]
@@ -163,7 +164,7 @@ function Test-TppToken {
                 $secretInfo = Get-SecretInfo -Name $VaultAccessTokenName -Vault 'VenafiPS' -ErrorAction SilentlyContinue
 
                 if ( $secretInfo.Metadata.Count -gt 0 ) {
-                    $params.Server = $secretInfo.Metadata.Server
+                    $params.Server = $secretInfo.Metadata.AuthServer
                     $params.Header = @{'Authorization' = 'Bearer {0}' -f $tokenSecret.GetNetworkCredential().password }
                 }
                 else {

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -112,7 +112,13 @@ function Test-TppToken {
             UriRoot = 'vedauth'
             UriLeaf = 'Authorize/Verify'
         }
-    }
+
+        $serverUrl = $AuthServer
+        # add prefix if just server url was provided
+        if ( $serverUrl -notlike 'https://*') {
+            $serverUrl = 'https://{0}' -f $serverUrl
+        }
+}
 
     process {
 
@@ -134,12 +140,6 @@ function Test-TppToken {
             }
 
             'AccessToken' {
-                $serverUrl = $AuthServer
-                # add prefix if just server url was provided
-                if ( $AuthServer -notlike 'https://*') {
-                    $serverUrl = 'https://{0}' -f $serverUrl
-                }
-
                 $params.Server = $serverUrl
                 $params.Header = @{'Authorization' = 'Bearer {0}' -f $AccessToken.GetNetworkCredential().password }
             }
@@ -171,11 +171,6 @@ function Test-TppToken {
                         throw '-AuthServer is a required parameter as it wasn''t stored with New-VenafiSession -VaultMetadata'
                     }
 
-                    $serverUrl = $AuthServer
-                    # add prefix if just server url was provided
-                    if ( $AuthServer -notlike 'https://*') {
-                        $serverUrl = 'https://{0}' -f $serverUrl
-                    }
                     $params.Server = $serverUrl
                 }
                 $params.Header = @{'Authorization' = 'Bearer {0}' -f $tokenSecret.GetNetworkCredential().password }

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -15,8 +15,8 @@ Access token retrieved outside this module.  Provide a credential object with th
 
 .PARAMETER VaultAccessTokenName
 Name of the SecretManagement vault entry for the access token; the name of the vault must be VenafiPS.
-Note: '-Server' parameter is required if the vault does not contain saved metadata. See
-New-VenafiSession -VaultMetaData
+Note: '-Server' parameter is required if the vault does not contain saved metadata.
+See New-VenafiSession -VaultMetaData
 
 .PARAMETER TppToken
 Token object obtained from New-TppToken
@@ -134,9 +134,9 @@ function Test-TppToken {
             }
 
             'AccessToken' {
-                $serverUrl = $Server
+                $serverUrl = $AuthServer
                 # add prefix if just server url was provided
-                if ( $Server -notlike 'https://*') {
+                if ( $AuthServer -notlike 'https://*') {
                     $serverUrl = 'https://{0}' -f $serverUrl
                 }
 
@@ -165,16 +165,20 @@ function Test-TppToken {
 
                 if ( $secretInfo.Metadata.Count -gt 0 ) {
                     $params.Server = $secretInfo.Metadata.AuthServer
-                    $params.Header = @{'Authorization' = 'Bearer {0}' -f $tokenSecret.GetNetworkCredential().password }
                 }
                 else {
-                    if ( -not $Server ) {
-                        throw '-Server is a required parameter as it wasn''t stored with -VaultMetadata'
+                    if ( -not $AuthServer ) {
+                        throw '-AuthServer is a required parameter as it wasn''t stored with New-VenafiSession -VaultMetadata'
                     }
 
-                    $params.Server  = $ServerUrl
-                    $params.Header = @{'Authorization' = 'Bearer {0}' -f $tokenSecret.GetNetworkCredential().password }
+                    $serverUrl = $AuthServer
+                    # add prefix if just server url was provided
+                    if ( $AuthServer -notlike 'https://*') {
+                        $serverUrl = 'https://{0}' -f $serverUrl
+                    }
+                    $params.Server = $serverUrl
                 }
+                $params.Header = @{'Authorization' = 'Bearer {0}' -f $tokenSecret.GetNetworkCredential().password }
             }
 
             'TppToken' {
@@ -195,7 +199,7 @@ function Test-TppToken {
 
         $response = Invoke-VenafiRestMethod @params -FullResponse
 
-        if ( $GrantDetail.IsPresent ) {
+        if ( $GrantDetail ) {
 
             switch ([int]$response.StatusCode) {
 


### PR DESCRIPTION
Adds support for parameter 'VaultAccessTokenName' which can be used to validate access tokens stored in VenafiPS vault.

Fixes #81 