### PR TITLE
support double slash paths, AsValue param, CountOnly as int

### DIFF
--- a/VenafiPS/Classes/TppObject.ps1
+++ b/VenafiPS/Classes/TppObject.ps1
@@ -9,16 +9,15 @@ class TppObject {
         [string] $TypeName,
         [guid] $Guid
     ) {
-        $this.Path = $Path
+        $this.Path = $Path.Replace('\\', '\')
         $this.TypeName = $TypeName
         $this.Guid = $Guid
         $this | Add-Member -MemberType ScriptProperty -Name Name -Value {
-            Split-Path $this.Path -Leaf
+            Split-Path -Path $this.Path -Leaf
         }
         $this | Add-Member -MemberType ScriptProperty -Name ParentPath -Value {
-            $leafName = Split-Path $this.Path -Leaf
             # split-path -parent doesn't work on this path so use this workaround
-            return $this.Path.Replace(("\{0}" -f $leafName), "")
+            $this.Path -replace ('\\+{0}' -f $this.Name), ''
         }
         $this | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.Path } -Force
     }

--- a/VenafiPS/Private/Test-TppDnPath.ps1
+++ b/VenafiPS/Private/Test-TppDnPath.ps1
@@ -11,11 +11,11 @@ function Test-TppDnPath {
     )
 
     process {
-        if ( $PSBoundParameters.ContainsKey('AllowRoot') ) {
-            $_ -match '^[\\|//]VED([\\|//].+)*$'
+        if ( $AllowRoot ) {
+            $_ -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)*$'
         }
         else {
-            $_ -match '^[\\|//]VED([\\|//].+)+$'
+            $_ -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)+$'
         }
     }
 }

--- a/VenafiPS/Public/Find-TppCertificate.ps1
+++ b/VenafiPS/Public/Find-TppCertificate.ps1
@@ -538,10 +538,6 @@ function Find-TppCertificate {
 
         $response = Invoke-VenafiRestMethod @params
 
-        if ( $CountOnly ) {
-            return $response.Headers.'X-Record-Count'
-        }
-
         $totalRecordCount = 0
         if ($PSVersionTable.PSVersion.Major -lt 6) {
             $totalRecordCount = [int]$response.Headers.'X-Record-Count'
@@ -549,12 +545,16 @@ function Find-TppCertificate {
         else {
             $totalRecordCount = [int]($response.Headers.'X-Record-Count'[0])
         }
+
+        if ( $CountOnly ) {
+            return $totalRecordCount
+        }
+
         Write-Verbose "Total number of records for this query: $totalRecordCount"
 
         $content = $response.content | ConvertFrom-Json
         $content.Certificates.ForEach{
             [TppObject] @{
-                Name     = $_.Name
                 TypeName = $_.SchemaClass
                 Path     = $_.DN
                 Guid     = [guid] $_.Guid
@@ -591,7 +591,6 @@ function Find-TppCertificate {
                 $content = $response.content | ConvertFrom-Json
                 $content.Certificates.ForEach{
                     [TppObject] @{
-                        Name     = $_.Name
                         TypeName = $_.SchemaClass
                         Path     = $_.DN
                         Guid     = [guid] $_.Guid

--- a/VenafiPS/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignProject.ps1
@@ -75,7 +75,6 @@ function Find-TppCodeSignProject {
         if ( $response.Success ) {
             $allProjects += foreach ($thisProject in $response.Projects) {
                 [TppObject] @{
-                    Name     = Split-Path $thisProject.DN -Leaf
                     TypeName = 'Code Signing Project'
                     Path     = $thisProject.DN
                     Guid     = $thisProject.Guid

--- a/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
@@ -75,7 +75,6 @@ function Find-TppCodeSignTemplate {
         if ( $response.Success ) {
             $allTemplates += foreach ($thisTemplate in $response.CertificateTemplates) {
                 [TppObject] @{
-                    Name     = Split-Path $thisTemplate.DN -Leaf
                     TypeName = $thisTemplate.Type
                     Path     = $thisTemplate.DN
                     Guid     = $thisTemplate.Guid

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -135,6 +135,9 @@ function Get-TppAttribute {
         [string] $ClassName,
 
         [Parameter()]
+        [switch] $AsValue,
+
+        [Parameter()]
         [VenafiSession] $VenafiSession = $script:VenafiSession
     )
 
@@ -242,6 +245,10 @@ function Get-TppAttribute {
         if ( $configValues ) {
 
             $configValues = @($configValues)
+
+            if ( $configValues.Count -eq 1 -and $AsValue ) {
+                return $configValues.Value
+            }
 
             # convert custom field guids to names
             foreach ($thisConfigValue in $configValues) {

--- a/VenafiPS/Public/Get-TppObject.ps1
+++ b/VenafiPS/Public/Get-TppObject.ps1
@@ -42,12 +42,13 @@ function Get-TppObject {
     [CmdletBinding()]
 
     param (
-        [Parameter(Mandatory, ParameterSetName = 'ByPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ByPath', ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -71,7 +72,8 @@ function Get-TppObject {
 
         if ( $PSCmdLet.ParameterSetName -eq 'ByPath' ) {
             $inputObject = $Path
-        } else {
+        }
+        else {
             $inputObject = $Guid
         }
 

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -204,8 +204,9 @@ function New-TppCapiApplication {
         if ( -not $PSBoundParameters.ContainsKey('SkipExistenceCheck') ) {
 
             if ( $PSBoundParameters.ContainsKey('CertificatePath') ) {
-                $certPath = (Split-Path $CertificatePath -Parent)
-                $certName = (Split-Path $CertificatePath -Leaf)
+                $certName = (Split-Path -Path $CertificatePath -Leaf)
+                $certPath -replace ('\\+{0}' -f $certName), ''
+
                 $certObject = Find-TppCertificate -Path $certPath -VenafiSession $VenafiSession
 
                 if ( -not $certObject -or ($certName -notin $certObject.Name) ) {

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -110,7 +110,8 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -125,7 +126,8 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -137,7 +139,8 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -205,7 +208,7 @@ function New-TppCapiApplication {
 
             if ( $PSBoundParameters.ContainsKey('CertificatePath') ) {
                 $certName = (Split-Path -Path $CertificatePath -Leaf)
-                $certPath -replace ('\\+{0}' -f $certName), ''
+                $certPath = $CertificatePath -replace ('\\+{0}' -f $certName), ''
 
                 $certObject = Find-TppCertificate -Path $certPath -VenafiSession $VenafiSession
 
@@ -226,12 +229,12 @@ function New-TppCapiApplication {
         }
 
         $params = @{
-            Path       = ''
-            Class      = 'CAPI'
-            Attribute  = @{
+            Path          = ''
+            Class         = 'CAPI'
+            Attribute     = @{
                 'Driver Name' = 'appcapi'
             }
-            PassThru   = $true
+            PassThru      = $true
             VenafiSession = $VenafiSession
         }
 
@@ -284,8 +287,9 @@ function New-TppCapiApplication {
             # ensure the parent path exists and is of type device
             if ( $PSBoundParameters.ContainsKey('ApplicationName') ) {
                 $devicePath = $Path
-            } else {
-                $devicePath = (Split-Path $Path -Parent)
+            }
+            else {
+                $devicePath = $Path -replace ('\\+{0}' -f (Split-Path $Path -Leaf)), ''
             }
 
             $device = Get-TppObject -Path $devicePath -VenafiSession $VenafiSession
@@ -294,7 +298,8 @@ function New-TppCapiApplication {
                 if ( $device.TypeName -ne 'Device' ) {
                     throw ('A device object could not be found at ''{0}''' -f $devicePath)
                 }
-            } else {
+            }
+            else {
                 throw ('No object was found at the parent path ''{0}''' -f $devicePath)
             }
         }
@@ -303,7 +308,8 @@ function New-TppCapiApplication {
             $appPaths = $ApplicationName | ForEach-Object {
                 $Path + "\$_"
             }
-        } else {
+        }
+        else {
             $appPaths = @($Path)
         }
 
@@ -324,7 +330,7 @@ function New-TppCapiApplication {
                 $params = @{
                     CertificatePath = $CertificatePath
                     ApplicationPath = $appPaths
-                    VenafiSession      = $VenafiSession
+                    VenafiSession   = $VenafiSession
                 }
 
                 Invoke-TppCertificatePush @params

--- a/VenafiPS/Public/New-TppObject.ps1
+++ b/VenafiPS/Public/New-TppObject.ps1
@@ -99,16 +99,6 @@ function New-TppObject {
 
     $VenafiSession.Validate('TPP')
 
-    # ensure the object doesn't already exist
-    # if ( Test-TppObject -Path $Path -ExistOnly -VenafiSession $VenafiSession ) {
-    #     throw ("New object to be created, {0}, already exists" -f $Path)
-    # }
-
-    # ensure the parent folder exists
-    # if ( -not (Test-TppObject -Path (Split-Path -Path $Path -Parent) -ExistOnly -VenafiSession $VenafiSession) ) {
-    #     throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path -Path $Path -Parent))
-    # }
-
     if ( $PushCertificate.IsPresent -and (-not $Attribute.Certificate) ) {
         Write-Warning 'A ''Certificate'' key containing the certificate path must be provided for Attribute when using PushCertificate, eg. -Attribute @{''Certificate''=''\Ved\Policy\mycert.com''}.  Certificate provisioning will not take place.'
     }


### PR DESCRIPTION
- Add support for double slash paths used by the adaptable framework.  Closes #75 
- Add `AsValue` parameter to `Get-TppAttribute` making it easy to retrieve just the value when 1 attribute is requested
- Update return type when using `Find-TppCertificate -CountOnly` from string to int