### PR TITLE
Variable scope fix, export vaas cert fix, PS v5/v7 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  Testing:
+  test-pssa:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       - name: Lint with PSScriptAnalyzer
         shell: pwsh
         run: |
-          Invoke-ScriptAnalyzer -Path . -Recurse -Outvariable issues
+          Invoke-ScriptAnalyzer -Path ./VenafiPS -Recurse -Outvariable issues
           $issues | ConvertTo-Json -Depth 2 | Set-Content -Path '${{ github.workspace }}/pssa.json'
           $errors   = $issues.Where({$_.Severity -eq 'Error'})
           $warnings = $issues.Where({$_.Severity -eq 'Warning'})
@@ -31,6 +31,53 @@ jobs:
         with:
           name: pssa-results
           path: ${{ github.workspace }}/pssa.json
-      # - name: Test with Pester
-      #   shell: pwsh
-      #   run: Invoke-Pester Unit.Tests.ps1 -Passthru | Export-CliXml -Path Unit.Tests.xml
+
+  test-pwsh:
+      strategy:
+        matrix:
+          platform: [ubuntu-latest, macos-latest, windows-latest]
+      runs-on: ${{ matrix.platform }}
+      steps:
+      - uses: actions/checkout@v2
+      - name: Run Pester tests (pwsh)
+        run: |
+          Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+          Set-PSRepository psgallery -InstallationPolicy trusted
+          Install-Module -Name Pester -RequiredVersion 5.0.4 -confirm:$false -Force
+          import-module Pester
+          $config = [PesterConfiguration]::Default
+          $config.Run.Path = '${{ github.workspace }}/Tests'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = 'test_result.xml'
+          Invoke-Pester -Configuration $config
+        shell: pwsh
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Powershell (v7) Pester Test Results ${{ matrix.platform }}
+          path: test_result.xml
+
+  test-posh:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Pester tests (PowerShell)
+      run: |
+        Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+        Set-PSRepository psgallery -InstallationPolicy trusted
+        Install-Module -Name Pester -RequiredVersion 5.0.4 -Confirm:$false -Force
+        import-module Pester
+        $config = [PesterConfiguration]::Default
+        $config.Run.Path = '${{ github.workspace }}/Tests'
+        $config.TestResult.Enabled = $true
+        $config.TestResult.OutputPath = 'test_result.xml'
+        Invoke-Pester -Configuration $config
+        if ($Error[0].Fullyqualifiederrorid -eq 'PesterAssertionFailed') {exit 1}
+      shell: powershell
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Windows Powershell (v5) Pester Test Results
+        path: test_result.xml

--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,0 +1,2 @@
+test_result.xml
+coverage.xml

--- a/Tests/New-VenafiSession.Tests.ps1
+++ b/Tests/New-VenafiSession.Tests.ps1
@@ -1,0 +1,24 @@
+BeforeAll {
+    Remove-Module 'VenafiPS' -Force -ErrorAction SilentlyContinue
+    Import-Module ./VenafiPS/VenafiPS.psd1
+}
+Describe 'New-VenafiSession' {
+    BeforeAll {
+        $cred = New-Object System.Management.Automation.PSCredential('AccessToken', ('9655b66c-8e5e-4b2b-b43e-edfa33b70e5f' | ConvertTo-SecureString -AsPlainText -Force))
+    }
+    Context 'VaaS key' {
+        BeforeAll {
+            $sess = New-VenafiSession -VaasKey $cred -PassThru
+        }
+        It 'should set platform to VaaS' {
+            $sess.Platform | Should -Be 'VaaS'
+        }
+        It 'should set AuthType to Key' {
+            $sess.AuthType | Should -Be 'Key'
+        }
+        It 'should set key to the credential provided' {
+            $sess.Key | Should -Be $cred
+        }
+    }
+
+}

--- a/VenafiPS/Classes/VenafiSession.ps1
+++ b/VenafiPS/Classes/VenafiSession.ps1
@@ -156,7 +156,7 @@ class VenafiSession {
         }
 
         $this | Add-Member -MemberType ScriptProperty -Name Platform -Value {
-            if ( $this.Server -eq $script:CloudUrl ) {
+            if ( $this.Server -eq 'https://api.venafi.cloud' ) {
                 'VaaS'
             }
             else {

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -186,11 +186,13 @@ function Export-VenafiCertificate {
 
     process {
 
-        if ( $authType -eq 'vaas' ) {
+        if ( $VenafiSession.Platform -eq 'VaaS' ) {
             $params.UriRoot = 'outagedetection/v1'
             $params.UriLeaf = "certificates/$CertificateId/contents"
             $params.Method = 'Get'
-            Invoke-TppRestMethod @params
+            $params.FullResponse = $true
+            $response = Invoke-TppRestMethod @params
+            $response.Content
         }
         else {
             $params.Method = 'Post'


### PR DESCRIPTION
- Fix PS v5 class not able to access module variable ClourUrl and reporting the session platform incorrectly.  Not an issue on PS v7.
- Fix `Export-VenafiCertificate` for VaaS failing with ConvertTo-Json error
- Add PS v5 and v7 testing on PRs
- Add test to catch platform error