### PR TITLE
devops enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,31 +35,30 @@ VenafiPS is published to the PowerShell Gallery.  The most recent version is lis
 
 As the module supports both TPP and Venafi as a Service, you will note different names for the functions.  Functions with `-Tpp` are for TPP only, `-Vaas` are for Venafi as a Service only, and `-Venafi` are for both.
 
-Start a new PowerShell prompt (even if you have one from the Install Module step) and create a new VenafiPS session with
+Start a new PowerShell prompt (even if you have one from the install-module step) and create a new VenafiPS session with
 
 ```powershell
 $cred = Get-Credential
+
+# obtain new oauth token
 New-VenafiSession -Server 'venafi.mycompany.com' -Credential $cred -ClientId 'MyApp' -Scope @{'certificate'='manage'}
 
-# to store access token for later use
+# obtain new oauth token and store access token for later use
 New-VenafiSession -Server 'venafi.mycompany.com' -Credential $cred -ClientId 'MyApp' -Scope @{'certificate'='manage'} -VaultAccessTokenName TppAccessToken
 
-# to store refresh token for later use
+# obtain new oauth token and store refresh token for later use
 New-VenafiSession -Server 'venafi.mycompany.com' -Credential $cred -ClientId 'MyApp' -Scope @{'certificate'='manage'} -VaultRefreshTokenName TppRefreshToken
+
+# create a session for VaaS
+New-VenafiSession -VaasKey $cred
 ```
 
-This will create a session which will be used by default in other functions.
-You can also use integrated authentication, simply exclude `-Credential $cred`.
+The above will create a session which will be used by default in other functions.
+View the help on all the ways you can create a new Venafi session with `help New-VenafiSession -full`.
 
-Beginning with v3.0, you can connect to Venafi as a Service; simply provide a credential with your api key as the password:
+For VaaS, your API key can be found in your user profile->preferences.
 
-```
-New-VenafiSession -VaasKey $apikeyCred
-```
-
-Your API key can be found in your user profile->preferences.  View the help on all the ways you can create a new Venafi session with `help New-VenafiSession -full`.
-
-Helpful with devops scenarios including pipelines, you can now provide either a VaaS key or TPP token for `-VenafiSession` for all function calls with no need to execute `New-VenafiSession`.
+Helpful with devops scenarios including pipelines, you can provide either a VaaS key or TPP token for `-VenafiSession` for all function calls with no need to execute `New-VenafiSession` first.  If using TPP, an environment variable named `TppServer` must be set first.
 
 ### Examples
 One of the easiest ways to get started is to use `Find-TppObject`:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ New-VenafiSession -VaasKey $apikeyCred
 
 Your API key can be found in your user profile->preferences.  View the help on all the ways you can create a new Venafi session with `help New-VenafiSession -full`.
 
+Helpful with devops scenarios including pipelines, you can now provide either a VaaS key or TPP token for `-VenafiSession` for all function calls with no need to execute `New-VenafiSession`.
+
 ### Examples
 One of the easiest ways to get started is to use `Find-TppObject`:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-- Update `Find-TppCertificate` to `Find-VenafiCertificate` and add VaaS certificate search functionality
-- Add `-Policy` to `New-VenafiTeam` so a team can be associated with one or more policies
-- Fix `PolicyPath` property of `TppObject` not returning the proper value due to special characters
+- Add authentication options, VaaS key or TPP token, in addition to VenafiSession to be provided directly to any function that supports that platform.  This better enables devops scenarios so 1 call can be made for a function as opposed to executing New-VenafiSession first.  Note, if using this with TPP, an environment variable named TppServer with the url of the server must be set.
+- Add `Test-VenafiSession` private function to add support for the new authentication methods as VenafiSession.Validate isn't used.  `Invoke-VenafiRestMethod` has been updated to accept these new authentication methods as well.
+- Add option to export from VaaS in JKS format

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -1,0 +1,69 @@
+function Test-VenafiSession {
+
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Alias('Key', 'AccessToken')]
+        [psobject] $VenafiSession,
+
+        [Parameter(Mandatory, ParameterSetName = 'Platform')]
+        [Parameter(Mandatory, ParameterSetName = 'AuthType')]
+        [string] $Platform,
+
+        [Parameter(Mandatory, ParameterSetName = 'AuthType')]
+        [string] $AuthType
+
+    )
+
+    process {
+
+        switch ($VenafiSession.GetType().Name) {
+            'VenafiSession' {
+
+                Write-Verbose 'Session is VenafiSession'
+
+                if ( $AuthType ) {
+                    $VenafiSession.Validate($Platform, $AuthType)
+                }
+                elseif ($Platform) {
+                    $VenafiSession.Validate($Platform)
+                }
+                else {
+                    $VenafiSession.Validate()
+                }
+
+                break
+            }
+
+            'String' {
+                $objectGuid = [System.Guid]::empty
+
+                if ( [System.Guid]::TryParse($VenafiSession, [System.Management.Automation.PSReference]$objectGuid) ) {
+
+                    Write-Verbose 'Session is VaaS key'
+
+                    if ( $Platform -and $Platform -ne 'VaaS' ) {
+                        throw "This function or parameter set is only accessible for $Platform"
+                    }
+                }
+                else {
+
+                    # TPP access token
+                    Write-Verbose 'Session is TPP token'
+                    if ( $Platform -and $Platform -ne 'TPP' ) {
+                        throw "This function or parameter set is only accessible for $Platform"
+                    }
+                    # get server from environment variable
+                    if ( -not $env:TppServer ) {
+                        throw 'TPP token provided for VenafiSession, but TppServer environment variable was not found'
+                    }
+                }
+            }
+
+            Default {
+                throw "Unknown session '$VenafiSession'.  Please run New-VenafiSession or provide a VaaS key or TPP token."
+            }
+        }
+    }
+}

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -26,6 +26,10 @@ Test-VenafiSession -VenafiSession $VenafiSession
 Test a session
 
 .EXAMPLE
+Test-VenafiSession -VenafiSession $VenafiSession -PassThru
+Test a session and return the platform type found
+
+.EXAMPLE
 Test-VenafiSession -VenafiSession $key
 Test a VaaS key
 

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -49,16 +49,17 @@ function Test-VenafiSession {
 
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowNull()]
         [Alias('Key', 'AccessToken')]
         [psobject] $VenafiSession,
 
         [Parameter(Mandatory, ParameterSetName = 'Platform')]
         [Parameter(Mandatory, ParameterSetName = 'AuthType')]
-        [Alias('VaaS', 'TPP')]
+        [ValidateSet('VaaS', 'TPP')]
         [string] $Platform,
 
         [Parameter(Mandatory, ParameterSetName = 'AuthType')]
-        [Alias('Key', 'Token')]
+        [ValidateSet('Key', 'Token')]
         [string] $AuthType,
 
         [Parameter()]
@@ -66,6 +67,10 @@ function Test-VenafiSession {
     )
 
     process {
+
+        if ( -not $VenafiSession ) {
+            throw 'Please run New-VenafiSession or provide a VaaS key or TPP token.'
+        }
 
         switch ($VenafiSession.GetType().Name) {
             'VenafiSession' {

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -1,3 +1,44 @@
+<#
+.SYNOPSIS
+Validate authentication session/key/token
+
+.DESCRIPTION
+Validate authentication session from New-VenafiSession, a VaaS key, or TPP token.
+
+.PARAMETER VenafiSession
+Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
+
+.PARAMETER Platform
+Platform, either TPP or Vaas, to validate VenafiSession against.
+
+.PARAMETER AuthType
+Authentication type, either Key or Token, to validate VenafiSession against.
+
+.PARAMETER PassThru
+Provide the determined platform from VenafiSession
+
+.OUTPUTS
+String - if PassThru provided
+
+.EXAMPLE
+Test-VenafiSession -VenafiSession $VenafiSession
+Test a session
+
+.EXAMPLE
+Test-VenafiSession -VenafiSession $key
+Test a VaaS key
+
+.EXAMPLE
+Test-VenafiSession -VenafiSession $VenafiSession -Platform TPP
+Test session ensuring the platform is TPP
+
+.EXAMPLE
+Test-VenafiSession -VenafiSession $VenafiSession -Platform TPP -AuthType Token
+Test session ensuring the platform is TPP and authentication type is token
+
+#>
+
 function Test-VenafiSession {
 
     [CmdletBinding(DefaultParameterSetName = 'All')]
@@ -9,14 +50,15 @@ function Test-VenafiSession {
 
         [Parameter(Mandatory, ParameterSetName = 'Platform')]
         [Parameter(Mandatory, ParameterSetName = 'AuthType')]
+        [Alias('VaaS', 'TPP')]
         [string] $Platform,
 
         [Parameter(Mandatory, ParameterSetName = 'AuthType')]
+        [Alias('Key', 'Token')]
         [string] $AuthType,
 
         [Parameter()]
         [switch] $PassThru
-
     )
 
     process {

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -12,7 +12,10 @@ function Test-VenafiSession {
         [string] $Platform,
 
         [Parameter(Mandatory, ParameterSetName = 'AuthType')]
-        [string] $AuthType
+        [string] $AuthType,
+
+        [Parameter()]
+        [switch] $PassThru
 
     )
 
@@ -33,6 +36,7 @@ function Test-VenafiSession {
                     $VenafiSession.Validate()
                 }
 
+                $platformOut = $VenafiSession.Platform
                 break
             }
 
@@ -46,6 +50,8 @@ function Test-VenafiSession {
                     if ( $Platform -and $Platform -ne 'VaaS' ) {
                         throw "This function or parameter set is only accessible for $Platform"
                     }
+
+                    $platformOut = 'VaaS'
                 }
                 else {
 
@@ -58,12 +64,18 @@ function Test-VenafiSession {
                     if ( -not $env:TppServer ) {
                         throw 'TPP token provided for VenafiSession, but TppServer environment variable was not found'
                     }
+
+                    $platformOut = 'TPP'
                 }
             }
 
             Default {
                 throw "Unknown session '$VenafiSession'.  Please run New-VenafiSession or provide a VaaS key or TPP token."
             }
+        }
+
+        if ( $PassThru ) {
+            $platformOut
         }
     }
 }

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -6,8 +6,10 @@ Validate authentication session/key/token
 Validate authentication session from New-VenafiSession, a VaaS key, or TPP token.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .PARAMETER Platform
 Platform, either TPP or Vaas, to validate VenafiSession against.

--- a/VenafiPS/Public/Add-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-TppCertificateAssociation.ps1
@@ -86,11 +86,11 @@ function Add-TppCertificateAssociation {
         [switch] $PushCertificate,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Add-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-TppCertificateAssociation.ps1
@@ -20,8 +20,10 @@ Push the certificate after associating it to the Application objects.
 This will only be successful if the certificate management type is Provisioning and is not disabled, in error, or a push is already in process.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 InputObject, Path

--- a/VenafiPS/Public/Add-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-TppCertificateAssociation.ps1
@@ -21,6 +21,7 @@ This will only be successful if the certificate management type is Provisioning 
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 InputObject, Path

--- a/VenafiPS/Public/Add-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamMember.ps1
@@ -54,7 +54,7 @@ function Add-VenafiTeamMember {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -63,7 +63,7 @@ function Add-VenafiTeamMember {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             $params.Method = 'Post'
             $params.UriLeaf = "teams/$ID/members"

--- a/VenafiPS/Public/Add-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamMember.ps1
@@ -16,8 +16,10 @@ For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
 For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Add-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamMember.ps1
@@ -17,6 +17,7 @@ For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIde
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Add-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamMember.ps1
@@ -50,11 +50,11 @@ function Add-VenafiTeamMember {
         [string[]] $Member,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Add-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamOwner.ps1
@@ -16,8 +16,10 @@ For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
 For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Add-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamOwner.ps1
@@ -17,6 +17,7 @@ For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIde
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Add-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamOwner.ps1
@@ -54,7 +54,7 @@ function Add-VenafiTeamOwner {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -63,7 +63,7 @@ function Add-VenafiTeamOwner {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             $params.Method = 'Post'
             $params.UriLeaf = "teams/$ID/owners"

--- a/VenafiPS/Public/Add-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VenafiTeamOwner.ps1
@@ -50,11 +50,11 @@ function Add-VenafiTeamOwner {
         [string[]] $Owner,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Convert-TppObject.ps1
+++ b/VenafiPS/Public/Convert-TppObject.ps1
@@ -68,12 +68,12 @@ function Convert-TppObject {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Convert-TppObject.ps1
+++ b/VenafiPS/Public/Convert-TppObject.ps1
@@ -17,8 +17,10 @@ New class/type
 Return a TppObject representing the newly converted object
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Convert-TppObject.ps1
+++ b/VenafiPS/Public/Convert-TppObject.ps1
@@ -18,6 +18,7 @@ Return a TppObject representing the newly converted object
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/ConvertTo-TppGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-TppGuid.ps1
@@ -10,6 +10,7 @@ DN path representing an object
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/ConvertTo-TppGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-TppGuid.ps1
@@ -9,8 +9,10 @@ Convert DN path to GUID
 DN path representing an object
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/ConvertTo-TppGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-TppGuid.ps1
@@ -43,11 +43,11 @@ function ConvertTo-TppGuid {
         [switch] $IncludeType,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        # $VenafiSession.Validate()
+        # Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/ConvertTo-TppPath.ps1
+++ b/VenafiPS/Public/ConvertTo-TppPath.ps1
@@ -10,6 +10,7 @@ Guid type, [guid] 'xyxyxyxy-xyxy-xyxy-xyxy-xyxyxyxyxyxy'
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Guid

--- a/VenafiPS/Public/ConvertTo-TppPath.ps1
+++ b/VenafiPS/Public/ConvertTo-TppPath.ps1
@@ -9,8 +9,10 @@ Convert GUID to Path
 Guid type, [guid] 'xyxyxyxy-xyxy-xyxy-xyxy-xyxyxyxyxyxy'
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Guid

--- a/VenafiPS/Public/ConvertTo-TppPath.ps1
+++ b/VenafiPS/Public/ConvertTo-TppPath.ps1
@@ -32,12 +32,12 @@ function ConvertTo-TppPath {
         [switch] $IncludeType,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        # $VenafiSession.Validate()
+        # Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -45,6 +45,7 @@ You must adhere to the following rules:
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 CertificateId/Path from TppObject

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -122,7 +122,7 @@ function Export-VenafiCertificate {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -131,10 +131,10 @@ function Export-VenafiCertificate {
             }
         }
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
-            if ( $Format -notin 'PEM', 'DER') {
-                throw 'Venafi as a Service only supports PEM and DER formats'
+            if ( $Format -notin 'PEM', 'DER', 'JKS') {
+                throw "Venafi as a Service does not support the format $Format"
             }
         }
         else {
@@ -186,7 +186,7 @@ function Export-VenafiCertificate {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
             $params.UriRoot = 'outagedetection/v1'
             $params.UriLeaf = "certificates/$CertificateId/contents"
             $params.Method = 'Get'

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -44,8 +44,10 @@ You must adhere to the following rules:
     - Special characters
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 CertificateId/Path from TppObject

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -118,11 +118,11 @@ function Export-VenafiCertificate {
         [Security.SecureString] $KeystorePassword,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Find-TppClient.ps1
+++ b/VenafiPS/Public/Find-TppClient.ps1
@@ -11,6 +11,7 @@ Allowed values include VenafiAgent, AgentJuniorMachine, AgentJuniorUser, Portal,
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppClient.ps1
+++ b/VenafiPS/Public/Find-TppClient.ps1
@@ -46,11 +46,11 @@ function Find-TppClient {
         [String] $ClientType,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Find-TppClient.ps1
+++ b/VenafiPS/Public/Find-TppClient.ps1
@@ -10,8 +10,10 @@ The client type.
 Allowed values include VenafiAgent, AgentJuniorMachine, AgentJuniorUser, Portal, Agentless, PreEnrollment, iOS, Android
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
@@ -10,6 +10,7 @@ Name of the environment to search for
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
@@ -9,8 +9,10 @@ Search for specific code sign environments that match a name you provide or get 
 Name of the environment to search for
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignEnvironment.ps1
@@ -43,11 +43,11 @@ function Find-TppCodeSignEnvironment {
         [String] $Name,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
         $projects = Find-TppCodeSignProject | Get-TppCodeSignProject
     }
 

--- a/VenafiPS/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignProject.ps1
@@ -10,6 +10,7 @@ Name of the project to search for
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignProject.ps1
@@ -9,8 +9,10 @@ Search for specific code sign projects or return all
 Name of the project to search for
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignProject.ps1
@@ -43,11 +43,11 @@ function Find-TppCodeSignProject {
         [String] $Name,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
@@ -10,6 +10,7 @@ Name of the project to search for
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
@@ -43,11 +43,11 @@ function Find-TppCodeSignTemplate {
         [String] $Name,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiPS/Public/Find-TppCodeSignTemplate.ps1
@@ -9,8 +9,10 @@ Search for specific code sign projects or return all
 Name of the project to search for
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Find-TppIdentity.ps1
+++ b/VenafiPS/Public/Find-TppIdentity.ps1
@@ -26,6 +26,7 @@ Returns the identity of the authenticated user and all associated identities.  W
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Name

--- a/VenafiPS/Public/Find-TppIdentity.ps1
+++ b/VenafiPS/Public/Find-TppIdentity.ps1
@@ -25,8 +25,10 @@ Include distribution group identity type in search
 Returns the identity of the authenticated user and all associated identities.  Will be deprecated in a future release, use Get-TppIdentity -Me instead.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Name

--- a/VenafiPS/Public/Find-TppIdentity.ps1
+++ b/VenafiPS/Public/Find-TppIdentity.ps1
@@ -78,11 +78,11 @@ function Find-TppIdentity {
         [Switch] $Me,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $identityType = 0
         # determine settings to use

--- a/VenafiPS/Public/Find-TppObject.ps1
+++ b/VenafiPS/Public/Find-TppObject.ps1
@@ -133,11 +133,11 @@ function Find-TppObject {
         [switch] $Recursive,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
     }
 
     process {

--- a/VenafiPS/Public/Find-TppObject.ps1
+++ b/VenafiPS/Public/Find-TppObject.ps1
@@ -28,8 +28,10 @@ A list of attribute names to limit the search against.  Only valid when searchin
 Searches the subordinates of the object specified in Path.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Find-TppObject.ps1
+++ b/VenafiPS/Public/Find-TppObject.ps1
@@ -29,6 +29,7 @@ Searches the subordinates of the object specified in Path.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Find-TppVaultId.ps1
+++ b/VenafiPS/Public/Find-TppVaultId.ps1
@@ -10,8 +10,10 @@ Name and value to search.
 See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Secretstore-lookupbyassociation.php for more details.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Attribute

--- a/VenafiPS/Public/Find-TppVaultId.ps1
+++ b/VenafiPS/Public/Find-TppVaultId.ps1
@@ -11,6 +11,7 @@ See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Se
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Attribute

--- a/VenafiPS/Public/Find-TppVaultId.ps1
+++ b/VenafiPS/Public/Find-TppVaultId.ps1
@@ -42,11 +42,11 @@ function Find-TppVaultId {
         [hashtable] $Attribute,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -404,7 +404,6 @@ function Find-VenafiCertificate {
         else {
             # validate based on the paramset
             $platform = Test-VenafiSession -VenafiSession $VenafiSession -Platform $PSCmdlet.ParameterSetName -PassThru
-            # $VenafiSession.Validate($PSCmdlet.ParameterSetName)
         }
 
         if ( $platform -eq 'VaaS' ) {

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -145,6 +145,7 @@ Return the count of certificates found from the query as opposed to the certific
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -388,7 +388,7 @@ function Find-VenafiCertificate {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
@@ -396,7 +396,7 @@ function Find-VenafiCertificate {
         # have a different default param set for this
         if ( $PSCmdlet.ParameterSetName -eq 'NoParams' ) {
             # validate based on the session platform
-            $VenafiSession.Validate()
+            Test-VenafiSession -VenafiSession $VenafiSession
         } else {
             # validate based on the paramset
             $VenafiSession.Validate($PSCmdlet.ParameterSetName)

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -396,13 +396,15 @@ function Find-VenafiCertificate {
         # have a different default param set for this
         if ( $PSCmdlet.ParameterSetName -eq 'NoParams' ) {
             # validate based on the session platform
-            Test-VenafiSession -VenafiSession $VenafiSession
-        } else {
+            $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
+        }
+        else {
             # validate based on the paramset
-            $VenafiSession.Validate($PSCmdlet.ParameterSetName)
+            $platform = Test-VenafiSession -VenafiSession $VenafiSession -Platform $PSCmdlet.ParameterSetName -PassThru
+            # $VenafiSession.Validate($PSCmdlet.ParameterSetName)
         }
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
             if ( $PSBoundParameters.Keys -contains 'Skip' -or $PSBoundParameters.Keys -contains 'IncludeTotalCount' ) {
                 Write-Warning '-Skip and -IncludeTotalCount not implemented yet'
             }
@@ -579,7 +581,7 @@ function Find-VenafiCertificate {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
             $response = Invoke-VenafiRestMethod @params
 
             if ( $CountOnly ) {

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -144,8 +144,10 @@ You can also provide a hashtable with the field name as the key and either asc o
 Return the count of certificates found from the query as opposed to the certificates themselves
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -39,6 +39,7 @@ If unsure of the class name, add the value through the TPP UI and go to Support-
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -38,8 +38,10 @@ Required when getting policy attributes.  Provide the class name to retrieve the
 If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -138,12 +138,12 @@ function Get-TppAttribute {
         [switch] $AsValue,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         if ( $Guid ) {
             Write-Warning '-Guid will be deprecated in a future release.  Please use -Path instead.'

--- a/VenafiPS/Public/Get-TppClassAttribute.ps1
+++ b/VenafiPS/Public/Get-TppClassAttribute.ps1
@@ -22,6 +22,8 @@ function Get-TppClassAttribute {
     )
 
     begin {
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
+
         $allAttributes = [System.Collections.Generic.List[object]]::new()
     }
 

--- a/VenafiPS/Public/Get-TppClassAttribute.ps1
+++ b/VenafiPS/Public/Get-TppClassAttribute.ps1
@@ -18,7 +18,7 @@ function Get-TppClassAttribute {
         [string] $ClassName,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {

--- a/VenafiPS/Public/Get-TppCodeSignConfig.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignConfig.ps1
@@ -6,8 +6,10 @@ Get CodeSign Protect project settings
 Get CodeSign Protect project settings.  Must have token with scope codesign:manage.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Get-TppCodeSignConfig.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignConfig.ps1
@@ -42,11 +42,11 @@ function Get-TppCodeSignConfig {
 
     param (
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppCodeSignConfig.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignConfig.ps1
@@ -7,6 +7,7 @@ Get CodeSign Protect project settings.  Must have token with scope codesign:mana
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
@@ -9,8 +9,10 @@ Get code sign environment details
 Path of the environment to get
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
@@ -10,6 +10,7 @@ Path of the environment to get
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignEnvironment.ps1
@@ -77,11 +77,11 @@ function Get-TppCodeSignEnvironment {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignProject.ps1
@@ -65,11 +65,11 @@ function Get-TppCodeSignProject {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignProject.ps1
@@ -9,8 +9,10 @@ Get code sign project details
 Path of the project to get
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Get-TppCodeSignProject.ps1
@@ -10,6 +10,7 @@ Path of the project to get
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCredential.ps1
+++ b/VenafiPS/Public/Get-TppCredential.ps1
@@ -10,8 +10,10 @@ Object returned will depend on the credential type.
 The full path to the credential object
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCredential.ps1
+++ b/VenafiPS/Public/Get-TppCredential.ps1
@@ -11,6 +11,7 @@ The full path to the credential object
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Get-TppCredential.ps1
+++ b/VenafiPS/Public/Get-TppCredential.ps1
@@ -49,11 +49,11 @@ function Get-TppCredential {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppCustomField.ps1
+++ b/VenafiPS/Public/Get-TppCustomField.ps1
@@ -55,11 +55,11 @@ function Get-TppCustomField {
         [string] $Class,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
     }
 
     process {

--- a/VenafiPS/Public/Get-TppCustomField.ps1
+++ b/VenafiPS/Public/Get-TppCustomField.ps1
@@ -10,6 +10,7 @@ Class to get details on
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Get-TppCustomField.ps1
+++ b/VenafiPS/Public/Get-TppCustomField.ps1
@@ -9,8 +9,10 @@ Get details about custom fields
 Class to get details on
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/Get-TppIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-TppIdentityAttribute.ps1
@@ -13,6 +13,7 @@ Retrieve identity attribute values for the users and groups.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-TppIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-TppIdentityAttribute.ps1
@@ -12,8 +12,10 @@ The id that represents the user or group.  Use Find-TppIdentity to get the id.
 Retrieve identity attribute values for the users and groups.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-TppIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-TppIdentityAttribute.ps1
@@ -57,11 +57,11 @@ function Get-TppIdentityAttribute {
         [string[]] $Attribute,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        # $VenafiSession.Validate()
+        # Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppObject.ps1
+++ b/VenafiPS/Public/Get-TppObject.ps1
@@ -13,6 +13,7 @@ Guid of the object
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path, Guid

--- a/VenafiPS/Public/Get-TppObject.ps1
+++ b/VenafiPS/Public/Get-TppObject.ps1
@@ -12,8 +12,10 @@ The full path to the object
 Guid of the object
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path, Guid

--- a/VenafiPS/Public/Get-TppObject.ps1
+++ b/VenafiPS/Public/Get-TppObject.ps1
@@ -61,11 +61,11 @@ function Get-TppObject {
         [guid[]] $Guid,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
     }
 
     process {

--- a/VenafiPS/Public/Get-TppPermission.ps1
+++ b/VenafiPS/Public/Get-TppPermission.ps1
@@ -29,8 +29,10 @@ Attributes include Group Membership, Name, Internet Email Address, Given Name, S
 This parameter will be deprecated in a future release.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 InputObject, Path, Guid, IdentityId

--- a/VenafiPS/Public/Get-TppPermission.ps1
+++ b/VenafiPS/Public/Get-TppPermission.ps1
@@ -132,11 +132,11 @@ function Get-TppPermission {
         [string[]] $Attribute,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppPermission.ps1
+++ b/VenafiPS/Public/Get-TppPermission.ps1
@@ -30,6 +30,7 @@ This parameter will be deprecated in a future release.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 InputObject, Path, Guid, IdentityId

--- a/VenafiPS/Public/Get-TppSystemStatus.ps1
+++ b/VenafiPS/Public/Get-TppSystemStatus.ps1
@@ -32,12 +32,12 @@ function Get-TppSystemStatus {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     Write-Warning "Possible bug with Venafi TPP API causing this to fail"
 
-    $VenafiSession.Validate('TPP')
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     $params = @{
         VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppSystemStatus.ps1
+++ b/VenafiPS/Public/Get-TppSystemStatus.ps1
@@ -6,8 +6,10 @@ Get the TPP system status
 Returns service module statuses for Trust Protection Platform, Log Server, and Trust Protection Platform services that run on Microsoft Internet Information Services (IIS)
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Get-TppSystemStatus.ps1
+++ b/VenafiPS/Public/Get-TppSystemStatus.ps1
@@ -7,6 +7,7 @@ Returns service module statuses for Trust Protection Platform, Log Server, and T
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Get-TppVersion.ps1
+++ b/VenafiPS/Public/Get-TppVersion.ps1
@@ -35,10 +35,10 @@ function Get-TppVersion {
 
     param (
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
-    $VenafiSession.Validate('TPP')
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     $params = @{
         VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-TppVersion.ps1
+++ b/VenafiPS/Public/Get-TppVersion.ps1
@@ -7,6 +7,7 @@ Returns the TPP version
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Get-TppVersion.ps1
+++ b/VenafiPS/Public/Get-TppVersion.ps1
@@ -6,8 +6,10 @@ Get the TPP version
 Returns the TPP version
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Get-TppWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-TppWorkflowTicket.ps1
@@ -81,11 +81,11 @@ function Get-TppWorkflowTicket {
         [Guid[]] $Guid,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
         Write-Verbose ("Parameter set {0}" -f $PsCmdlet.ParameterSetName)
     }
 

--- a/VenafiPS/Public/Get-TppWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-TppWorkflowTicket.ps1
@@ -15,8 +15,10 @@ Path to the certificate
 Certificate guid
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 InputObject, Path, or Guid

--- a/VenafiPS/Public/Get-TppWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-TppWorkflowTicket.ps1
@@ -16,6 +16,7 @@ Certificate guid
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 InputObject, Path, or Guid

--- a/VenafiPS/Public/Get-VaasApplication.ps1
+++ b/VenafiPS/Public/Get-VaasApplication.ps1
@@ -35,11 +35,11 @@ function Get-VaasApplication {
         [guid] $ApplicationId,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('VaaS')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-VaasApplication.ps1
+++ b/VenafiPS/Public/Get-VaasApplication.ps1
@@ -10,6 +10,7 @@ Id to get info for a specific application
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ApplicationId

--- a/VenafiPS/Public/Get-VaasApplication.ps1
+++ b/VenafiPS/Public/Get-VaasApplication.ps1
@@ -9,8 +9,10 @@ Get info for either a specific application or all applications.  Venafi as a Ser
 Id to get info for a specific application
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ApplicationId

--- a/VenafiPS/Public/Get-VaasOrgUnit.ps1
+++ b/VenafiPS/Public/Get-VaasOrgUnit.ps1
@@ -35,11 +35,11 @@ function Get-VaasOrgUnit {
         [guid] $OrgUnitId,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('VaaS')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-VaasOrgUnit.ps1
+++ b/VenafiPS/Public/Get-VaasOrgUnit.ps1
@@ -10,6 +10,7 @@ Id to get info for a specific OrgUnit
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 OrgUnitId

--- a/VenafiPS/Public/Get-VaasOrgUnit.ps1
+++ b/VenafiPS/Public/Get-VaasOrgUnit.ps1
@@ -9,8 +9,10 @@ Get info for either a specific org unit or all org units.  Venafi as a Service o
 Id to get info for a specific OrgUnit
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 OrgUnitId

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -22,6 +22,7 @@ Can only be used with the IncludePreviousVersions parameter.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 CertificateId/Path from TppObject

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -77,12 +77,12 @@ function Get-VenafiCertificate {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -82,7 +82,7 @@ function Get-VenafiCertificate {
 
     begin {
 
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -120,7 +120,7 @@ function Get-VenafiCertificate {
 
     process {
 
-        switch ($VenafiSession.Platform) {
+        switch ($platform) {
             'VaaS' {
                 $params.UriRoot = 'outagedetection/v1'
                 $params.UriLeaf = "certificates"

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -21,8 +21,10 @@ Omits revoked versions of the previous (historical) versions of a certificate (o
 Can only be used with the IncludePreviousVersions parameter.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 CertificateId/Path from TppObject

--- a/VenafiPS/Public/Get-VenafiIdentity.ps1
+++ b/VenafiPS/Public/Get-VenafiIdentity.ps1
@@ -149,9 +149,9 @@ function Get-VenafiIdentity {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
-        Write-Verbose ('{0} : {1} : Parameterset {2}' -f $PsCmdlet.MyInvocation.MyCommand, $VenafiSession.Platform, $PsCmdlet.ParameterSetName)
+        Write-Verbose ('{0} : {1} : Parameterset {2}' -f $PsCmdlet.MyInvocation.MyCommand, $platform, $PsCmdlet.ParameterSetName)
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -162,7 +162,7 @@ function Get-VenafiIdentity {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             if ( $IncludeAssociated -or $IncludeMembers ) {
                 Write-Warning '-IncludeAssociated and -IncludeMembers are only applicable to TPP'

--- a/VenafiPS/Public/Get-VenafiIdentity.ps1
+++ b/VenafiPS/Public/Get-VenafiIdentity.ps1
@@ -25,6 +25,7 @@ Return a complete list of users.  VaaS only.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-VenafiIdentity.ps1
+++ b/VenafiPS/Public/Get-VenafiIdentity.ps1
@@ -145,11 +145,11 @@ function Get-VenafiIdentity {
         [Switch] $IncludeMembers,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         Write-Verbose ('{0} : {1} : Parameterset {2}' -f $PsCmdlet.MyInvocation.MyCommand, $VenafiSession.Platform, $PsCmdlet.ParameterSetName)
 

--- a/VenafiPS/Public/Get-VenafiIdentity.ps1
+++ b/VenafiPS/Public/Get-VenafiIdentity.ps1
@@ -24,8 +24,10 @@ Returns the identity of the authenticated/current user
 Return a complete list of users.  VaaS only.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -17,7 +17,6 @@ Provide this switch to get all teams
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
 A TPP token or VaaS key can also provided.
-A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -65,11 +65,12 @@ function Get-VenafiTeam {
         [switch] $All,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [Alias('Key', 'AccessToken')]
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -70,7 +70,7 @@ function Get-VenafiTeam {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -80,7 +80,7 @@ function Get-VenafiTeam {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             if ( $Id ) {
                 $params.UriLeaf = "teams/$ID"

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -16,6 +16,8 @@ Provide this switch to get all teams
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -15,8 +15,10 @@ For TPP, this is the local prefixed universal ID.  You can find the group ID wit
 Provide this switch to get all teams
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -46,6 +46,7 @@ Return a TppObject representing the newly imported object.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .EXAMPLE
 Import-TppCertificate -PolicyPath \ved\policy\mycerts -CertificatePath c:\www.VenafiPS.com.cer

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -45,8 +45,10 @@ See https://github.com/Venafi/VenafiPS/issues/88#issuecomment-600134145 for a fl
 Return a TppObject representing the newly imported object.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .EXAMPLE
 Import-TppCertificate -PolicyPath \ved\policy\mycerts -CertificatePath c:\www.VenafiPS.com.cer

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -121,12 +121,12 @@ function Import-TppCertificate {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     }
 

--- a/VenafiPS/Public/Invoke-TppCertificatePush.ps1
+++ b/VenafiPS/Public/Invoke-TppCertificatePush.ps1
@@ -72,11 +72,11 @@ function Invoke-TppCertificatePush {
         [String[]] $ApplicationPath,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Invoke-TppCertificatePush.ps1
+++ b/VenafiPS/Public/Invoke-TppCertificatePush.ps1
@@ -14,8 +14,10 @@ List of application object paths to push to.
 If not provided, all associated applications will be pushed.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Invoke-TppCertificatePush.ps1
+++ b/VenafiPS/Public/Invoke-TppCertificatePush.ps1
@@ -15,6 +15,7 @@ If not provided, all associated applications will be pushed.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Invoke-TppCertificateRenewal.ps1
+++ b/VenafiPS/Public/Invoke-TppCertificateRenewal.ps1
@@ -68,11 +68,11 @@ function Invoke-TppCertificateRenewal {
         [string] $Csr,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -35,6 +35,7 @@ See the api documentation for appropriate items, many are in the links in this h
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 CertificateId

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -34,8 +34,10 @@ Additional items specific to the action being taken, if needed.
 See the api documentation for appropriate items, many are in the links in this help.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 CertificateId

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -115,7 +115,7 @@ function Invoke-VenafiCertificateAction {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
     }
 
     process {
@@ -131,7 +131,7 @@ function Invoke-VenafiCertificateAction {
             Method        = 'Post'
         }
 
-        switch ($VenafiSession.Platform) {
+        switch ($platform) {
             'VaaS' {
 
                 $params.UriRoot = 'outagedetection/v1'

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -111,11 +111,11 @@ function Invoke-VenafiCertificateAction {
         [hashtable] $AdditionalParameters,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
     }
 
     process {

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -38,11 +38,14 @@ Api call with optional payload
 
 #>
 function Invoke-VenafiRestMethod {
+
     [CmdletBinding(DefaultParameterSetName = 'Session')]
+
     param (
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession,
+        [Alias('Key', 'AccessToken')]
+        [psobject] $VenafiSession = $script:VenafiSession,
 
         [Parameter(Mandatory, ParameterSetName = 'URL')]
         [ValidateNotNullOrEmpty()]
@@ -77,30 +80,76 @@ function Invoke-VenafiRestMethod {
         [switch] $FullResponse
     )
 
-    if ( $PSCmdLet.ParameterSetName -eq 'Session' ) {
-        $Server = $VenafiSession.Server
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
-            $hdr = @{
-                "tppl-api-key" = $VenafiSession.Key.GetNetworkCredential().password
+    if ( $PSCmdLet.ParameterSetName -eq 'Session' ) {
+
+        switch ($VenafiSession.GetType().Name) {
+            'VenafiSession' {
+                $Server = $VenafiSession.Server
+                if ( $VenafiSession.Platform -eq 'VaaS' ) {
+                    $platform = 'VaaS'
+                    $auth = $VenafiSession.Key.GetNetworkCredential().password
+                }
+                else {
+                    # TPP
+                    if ( $VenafiSession.AuthType -eq 'Token' ) {
+                        $platform = 'TppToken'
+                        $auth = $VenafiSession.Token.AccessToken.GetNetworkCredential().password
+                    }
+                    else {
+                        $platform = 'TppKey'
+                        $auth = $VenafiSession.Key.ApiKey
+                    }
+                }
+                break
             }
-            if ( -not $PSBoundParameters.ContainsKey('UriRoot') ) {
-                $UriRoot = 'v1'
+
+            'String' {
+                $auth = $VenafiSession
+                $objectGuid = [System.Guid]::empty
+                if ( [System.Guid]::TryParse($VenafiSession, [System.Management.Automation.PSReference]$objectGuid) ) {
+                    $Server = $script:CloudUrl
+                    $platform = 'VaaS'
+                }
+                else {
+                    # TPP access token
+                    # get server from environment variable
+                    if ( -not $env:TppServer ) {
+                        throw 'TppServer environment variable was not found'
+                    }
+                    $Server = $env:TppServer
+                    $platform = 'TppToken'
+                }
+            }
+
+            Default {
+                throw "Unknown session '$VenafiSession'.  Please run New-VenafiSession or provide a VaaS key or TPP token."
             }
         }
-        else {
-            # TPP
-            if ( $VenafiSession.AuthType -eq 'Token' ) {
+
+        switch ($platform) {
+            'VaaS' {
                 $hdr = @{
-                    'Authorization' = 'Bearer {0}' -f $VenafiSession.Token.AccessToken.GetNetworkCredential().password
+                    "tppl-api-key" = $auth
+                }
+                if ( -not $PSBoundParameters.ContainsKey('UriRoot') ) {
+                    $UriRoot = 'v1'
                 }
             }
-            else {
-                # key based tpp
+
+            'TppToken' {
                 $hdr = @{
-                    "X-Venafi-Api-Key" = $VenafiSession.Key.ApiKey
+                    'Authorization' = 'Bearer {0}' -f $auth
                 }
             }
+
+            'TppKey' {
+                $hdr = @{
+                    "X-Venafi-Api-Key" = $auth
+                }
+            }
+
+            Default {}
         }
     }
 

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -83,6 +83,10 @@ function Invoke-VenafiRestMethod {
 
     if ( $PSCmdLet.ParameterSetName -eq 'Session' ) {
 
+        if ( -not $VenafiSession ) {
+            throw 'Please run New-VenafiSession or provide a VaaS key or TPP token.'
+        }
+
         switch ($VenafiSession.GetType().Name) {
             'VenafiSession' {
                 $Server = $VenafiSession.Server

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -13,6 +13,7 @@ New path
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 SourcePath (Path)

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -69,11 +69,11 @@ function Move-TppObject {
         [String] $TargetPath,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
     }
 
     process {

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -12,8 +12,10 @@ Full path to an object in TPP
 New path
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 SourcePath (Path)

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -193,12 +193,12 @@ function New-TppCapiApplication {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         if ( $PushCertificate.IsPresent -and (-not $PSBoundParameters.ContainsKey('CertificatePath')) ) {
             throw 'A CertificatePath must be provided when using PushCertificate'

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -57,6 +57,7 @@ Return a TppObject representing the newly created capi app.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -56,8 +56,10 @@ Specify this switch to bypass this check.
 Return a TppObject representing the newly created capi app.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppCertificate.ps1
+++ b/VenafiPS/Public/New-TppCertificate.ps1
@@ -189,12 +189,12 @@ function New-TppCertificate {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         if ( $PSBoundParameters.ContainsKey('SubjectAltName') ) {
 

--- a/VenafiPS/Public/New-TppCertificate.ps1
+++ b/VenafiPS/Public/New-TppCertificate.ps1
@@ -68,6 +68,7 @@ If devices and/or applications were created, a 'Device' property will be availab
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/New-TppCertificate.ps1
+++ b/VenafiPS/Public/New-TppCertificate.ps1
@@ -67,8 +67,10 @@ Return a TppObject representing the newly created certificate.
 If devices and/or applications were created, a 'Device' property will be available as well.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/New-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/New-TppCodeSignProject.ps1
@@ -9,8 +9,10 @@ Create a new code sign project which will be empty.
 Path of the project to create
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/New-TppCodeSignProject.ps1
@@ -10,6 +10,7 @@ Path of the project to create
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/New-TppCodeSignProject.ps1
@@ -61,11 +61,11 @@ function New-TppCodeSignProject {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/New-TppCustomField.ps1
+++ b/VenafiPS/Public/New-TppCustomField.ps1
@@ -160,11 +160,11 @@ function New-TppCustomField {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $resultObj = @()
 

--- a/VenafiPS/Public/New-TppCustomField.ps1
+++ b/VenafiPS/Public/New-TppCustomField.ps1
@@ -78,8 +78,10 @@ Return a PSCustomObject with the following properties:
     Type
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 None

--- a/VenafiPS/Public/New-TppCustomField.ps1
+++ b/VenafiPS/Public/New-TppCustomField.ps1
@@ -79,6 +79,7 @@ Return a PSCustomObject with the following properties:
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 None

--- a/VenafiPS/Public/New-TppDevice.ps1
+++ b/VenafiPS/Public/New-TppDevice.ps1
@@ -26,6 +26,7 @@ Return a TppObject representing the newly created policy.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppDevice.ps1
+++ b/VenafiPS/Public/New-TppDevice.ps1
@@ -100,7 +100,7 @@ function New-TppDevice {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {

--- a/VenafiPS/Public/New-TppDevice.ps1
+++ b/VenafiPS/Public/New-TppDevice.ps1
@@ -25,8 +25,10 @@ Hostname or IP Address of the device
 Return a TppObject representing the newly created policy.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppObject.ps1
+++ b/VenafiPS/Public/New-TppObject.ps1
@@ -25,8 +25,10 @@ Please note, this feature was added in v18.3.
 Return a TppObject representing the newly created object.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .EXAMPLE
 New-TppObject -Path '\VED\Policy\Test Device' -Class 'Device' -Attribute @{'Description'='new device testing'}

--- a/VenafiPS/Public/New-TppObject.ps1
+++ b/VenafiPS/Public/New-TppObject.ps1
@@ -94,10 +94,10 @@ function New-TppObject {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
-    $VenafiSession.Validate('TPP')
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     if ( $PushCertificate.IsPresent -and (-not $Attribute.Certificate) ) {
         Write-Warning 'A ''Certificate'' key containing the certificate path must be provided for Attribute when using PushCertificate, eg. -Attribute @{''Certificate''=''\Ved\Policy\mycert.com''}.  Certificate provisioning will not take place.'

--- a/VenafiPS/Public/New-TppObject.ps1
+++ b/VenafiPS/Public/New-TppObject.ps1
@@ -26,6 +26,7 @@ Return a TppObject representing the newly created object.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .EXAMPLE
 New-TppObject -Path '\VED\Policy\Test Device' -Class 'Device' -Attribute @{'Description'='new device testing'}

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -70,11 +70,11 @@ function New-TppPolicy {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        # $VenafiSession.Validate()
+        # Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             Path       = ''

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -15,8 +15,10 @@ Policy description
 Return a TppObject representing the newly created policy.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -77,7 +77,6 @@ function New-TppPolicy {
     )
 
     begin {
-        # Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             Path       = ''

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -16,6 +16,7 @@ Return a TppObject representing the newly created policy.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/New-VenafiTeam.ps1
+++ b/VenafiPS/Public/New-VenafiTeam.ps1
@@ -131,7 +131,7 @@ function New-VenafiTeam {
         [switch] $PassThru,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     $VenafiSession.Validate($PSCmdlet.ParameterSetName)

--- a/VenafiPS/Public/New-VenafiTeam.ps1
+++ b/VenafiPS/Public/New-VenafiTeam.ps1
@@ -32,6 +32,7 @@ Team description or purpose.  TPP only.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .EXAMPLE
 New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin'

--- a/VenafiPS/Public/New-VenafiTeam.ps1
+++ b/VenafiPS/Public/New-VenafiTeam.ps1
@@ -134,13 +134,13 @@ function New-VenafiTeam {
         [psobject] $VenafiSession = $script:VenafiSession
     )
 
-    $VenafiSession.Validate($PSCmdlet.ParameterSetName)
+    $platform = Test-VenafiSession -VenafiSession $VenafiSession -Platform $PSCmdlet.ParameterSetName -PassThru
 
     $params = @{
         VenafiSession = $VenafiSession
     }
 
-    if ( $VenafiSession.Platform -eq 'VaaS' ) {
+    if ( $platform -eq 'VaaS' ) {
 
         $params.Method = 'Post'
         $params.UriLeaf = "teams"

--- a/VenafiPS/Public/New-VenafiTeam.ps1
+++ b/VenafiPS/Public/New-VenafiTeam.ps1
@@ -31,8 +31,10 @@ Team role, either 'System Admin', 'PKI Admin', 'Resource Owner' or 'Guest'.  Vaa
 Team description or purpose.  TPP only.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .EXAMPLE
 New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin'

--- a/VenafiPS/Public/Read-VenafiLog.ps1
+++ b/VenafiPS/Public/Read-VenafiLog.ps1
@@ -197,13 +197,13 @@ function Read-VenafiLog {
 
     begin {
 
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         if ( $PSBoundParameters.Keys -contains 'Skip' -or $PSBoundParameters.Keys -contains 'IncludeTotalCount' ) {
             Write-Warning '-Skip and -IncludeTotalCount not implemented yet'
         }
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
             $queryParams = @{
                 Filter            = $Filter
                 Order             = $Order
@@ -274,7 +274,7 @@ function Read-VenafiLog {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
             Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty activityLogEntries
         }
         else {

--- a/VenafiPS/Public/Read-VenafiLog.ps1
+++ b/VenafiPS/Public/Read-VenafiLog.ps1
@@ -46,8 +46,10 @@ For each item in the array, you can provide a field name by itself; this will de
 You can also provide a hashtable with the field name as the key and either asc or desc as the value.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path (for TPP)

--- a/VenafiPS/Public/Read-VenafiLog.ps1
+++ b/VenafiPS/Public/Read-VenafiLog.ps1
@@ -47,6 +47,7 @@ You can also provide a hashtable with the field name as the key and either asc o
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path (for TPP)

--- a/VenafiPS/Public/Read-VenafiLog.ps1
+++ b/VenafiPS/Public/Read-VenafiLog.ps1
@@ -192,12 +192,12 @@ function Read-VenafiLog {
         [psobject[]] $Order,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
 
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         if ( $PSBoundParameters.Keys -contains 'Skip' -or $PSBoundParameters.Keys -contains 'IncludeTotalCount' ) {
             Write-Warning '-Skip and -IncludeTotalCount not implemented yet'

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -14,6 +14,7 @@ Provide this switch to remove associations prior to certificate removal
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -13,8 +13,10 @@ Path to the certificate to remove
 Provide this switch to remove associations prior to certificate removal
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppCertificate.ps1
+++ b/VenafiPS/Public/Remove-TppCertificate.ps1
@@ -65,11 +65,11 @@ function Remove-TppCertificate {
         [switch] $KeepAssociatedApps,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
@@ -102,11 +102,11 @@ function Remove-TppCertificateAssociation {
         [switch] $All,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
@@ -23,8 +23,10 @@ Otherwise retain the Device DN and its children.
 Remove all associated application objects
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 InputObject, Path

--- a/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
+++ b/VenafiPS/Public/Remove-TppCertificateAssociation.ps1
@@ -24,6 +24,7 @@ Remove all associated application objects
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 InputObject, Path

--- a/VenafiPS/Public/Remove-TppClient.ps1
+++ b/VenafiPS/Public/Remove-TppClient.ps1
@@ -11,6 +11,7 @@ Unique id for one or more clients
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ClientId

--- a/VenafiPS/Public/Remove-TppClient.ps1
+++ b/VenafiPS/Public/Remove-TppClient.ps1
@@ -10,8 +10,10 @@ Provide an array of client IDs to remove a large list at once.
 Unique id for one or more clients
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ClientId

--- a/VenafiPS/Public/Remove-TppClient.ps1
+++ b/VenafiPS/Public/Remove-TppClient.ps1
@@ -45,11 +45,11 @@ function Remove-TppClient {
         [switch] $RemoveAssociatedDevices,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
@@ -9,8 +9,10 @@ Delete a code sign certificate environment and related objects such as keys and 
 Path of the environment to delete
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
@@ -51,11 +51,11 @@ function Remove-TppCodeSignEnvironment {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignEnvironment.ps1
@@ -10,6 +10,7 @@ Path of the environment to delete
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignProject.ps1
@@ -51,11 +51,11 @@ function Remove-TppCodeSignProject {
         [String] $Path,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignProject.ps1
@@ -9,8 +9,10 @@ Delete a code sign project.  You must be a code sign admin or owner of the proje
 Path of the project to delete
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppCodeSignProject.ps1
+++ b/VenafiPS/Public/Remove-TppCodeSignProject.ps1
@@ -10,6 +10,7 @@ Path of the project to delete
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Remove-TppPermission.ps1
+++ b/VenafiPS/Public/Remove-TppPermission.ps1
@@ -13,8 +13,10 @@ Full path to an object.  You can also pipe in a TppObject
 Prefixed Universal Id of the user or group to have their permissions removed
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path, Guid, IdentityId

--- a/VenafiPS/Public/Remove-TppPermission.ps1
+++ b/VenafiPS/Public/Remove-TppPermission.ps1
@@ -14,6 +14,7 @@ Prefixed Universal Id of the user or group to have their permissions removed
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path, Guid, IdentityId

--- a/VenafiPS/Public/Remove-TppPermission.ps1
+++ b/VenafiPS/Public/Remove-TppPermission.ps1
@@ -72,11 +72,11 @@ function Remove-TppPermission {
         [string[]] $IdentityId,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-VenafiTeam.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeam.ps1
@@ -38,11 +38,11 @@ function Remove-VenafiTeam {
         [string] $ID,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-VenafiTeam.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeam.ps1
@@ -9,8 +9,10 @@ Remove a team from either VaaS or TPP
 Team ID.  For VaaS, this is the team guid.  For TPP, this is the local ID.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Remove-VenafiTeam.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeam.ps1
@@ -42,7 +42,7 @@ function Remove-VenafiTeam {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -52,7 +52,7 @@ function Remove-VenafiTeam {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             $params.UriLeaf = "teams/$ID"
         }

--- a/VenafiPS/Public/Remove-VenafiTeam.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeam.ps1
@@ -10,6 +10,7 @@ Team ID.  For VaaS, this is the team guid.  For TPP, this is the local ID.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Remove-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamMember.ps1
@@ -56,11 +56,11 @@ function Remove-VenafiTeamMember {
         [string[]] $Member,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamMember.ps1
@@ -16,8 +16,10 @@ For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
 For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Remove-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamMember.ps1
@@ -17,6 +17,7 @@ For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIde
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Remove-VenafiTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamMember.ps1
@@ -60,7 +60,7 @@ function Remove-VenafiTeamMember {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -69,7 +69,7 @@ function Remove-VenafiTeamMember {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             $params.Method = 'Delete'
             $params.UriLeaf = "teams/$ID/members"

--- a/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
@@ -60,7 +60,7 @@ function Remove-VenafiTeamOwner {
     )
 
     begin {
-        Test-VenafiSession -VenafiSession $VenafiSession
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
         $params = @{
             VenafiSession = $VenafiSession
@@ -69,7 +69,7 @@ function Remove-VenafiTeamOwner {
 
     process {
 
-        if ( $VenafiSession.Platform -eq 'VaaS' ) {
+        if ( $platform -eq 'VaaS' ) {
 
             # get team details and ensure at least 1 owner will remain
             $thisTeam = Get-VenafiTeam -ID $ID -VenafiSession $VenafiSession

--- a/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
@@ -56,11 +56,11 @@ function Remove-VenafiTeamOwner {
         [string[]] $Owner,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate()
+        Test-VenafiSession -VenafiSession $VenafiSession
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
@@ -16,8 +16,10 @@ For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
 For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeamOwner.ps1
@@ -17,6 +17,7 @@ For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIde
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 ID

--- a/VenafiPS/Public/Rename-TppObject.ps1
+++ b/VenafiPS/Public/Rename-TppObject.ps1
@@ -57,10 +57,10 @@ function Rename-TppObject {
         [String] $NewPath,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
-    $VenafiSession.Validate('TPP')
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     $params = @{
         VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Rename-TppObject.ps1
+++ b/VenafiPS/Public/Rename-TppObject.ps1
@@ -12,8 +12,10 @@ Full path to an existing object
 New path, including name
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Rename-TppObject.ps1
+++ b/VenafiPS/Public/Rename-TppObject.ps1
@@ -13,6 +13,7 @@ New path, including name
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Revoke-TppCertificate.ps1
+++ b/VenafiPS/Public/Revoke-TppCertificate.ps1
@@ -103,11 +103,11 @@ function Revoke-TppCertificate {
         [switch] $Force,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Revoke-TppCertificate.ps1
+++ b/VenafiPS/Public/Revoke-TppCertificate.ps1
@@ -37,6 +37,7 @@ Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 TppObject or Path

--- a/VenafiPS/Public/Revoke-TppCertificate.ps1
+++ b/VenafiPS/Public/Revoke-TppCertificate.ps1
@@ -36,8 +36,10 @@ Wait for the requested revocation to be complete
 Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 TppObject or Path

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -76,7 +76,7 @@ function Revoke-TppToken {
         [switch] $Force,
 
         [Parameter(ParameterSetName = 'Session')]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -19,8 +19,10 @@ Token object obtained from New-TppToken
 Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 TppToken

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -20,6 +20,7 @@ Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 TppToken

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -26,8 +26,10 @@ If unsure of the class name, add the value through the TPP UI and go to Support-
 Lock the value on the policy.  Only applicable to setting policies.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -104,11 +104,11 @@ function Set-TppAttribute {
         [switch] $Lock,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -27,6 +27,7 @@ Lock the value on the policy.  Only applicable to setting policies.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
@@ -53,11 +53,11 @@ function Set-TppCodeSignProjectStatus {
         [TppCodeSignProjectStatus] $Status,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP', 'token')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'token'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
@@ -13,6 +13,7 @@ New project status, must have the appropriate perms.  Status can be Disabled, En
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiPS/Public/Set-TppCodeSignProjectStatus.ps1
@@ -12,8 +12,10 @@ Path of the project to update
 New project status, must have the appropriate perms.  Status can be Disabled, Enabled, Draft, or Pending.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppCredential.ps1
+++ b/VenafiPS/Public/Set-TppCredential.ps1
@@ -14,8 +14,10 @@ The full path to the credential object
 Hashtable containing the keys/values to be updated
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppCredential.ps1
+++ b/VenafiPS/Public/Set-TppCredential.ps1
@@ -60,11 +60,11 @@ function Set-TppCredential {
         [hashtable] $Value,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Set-TppCredential.ps1
+++ b/VenafiPS/Public/Set-TppCredential.ps1
@@ -15,6 +15,7 @@ Hashtable containing the keys/values to be updated
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path

--- a/VenafiPS/Public/Set-TppPermission.ps1
+++ b/VenafiPS/Public/Set-TppPermission.ps1
@@ -101,11 +101,11 @@ function Set-TppPermission {
         [switch] $Force,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Set-TppPermission.ps1
+++ b/VenafiPS/Public/Set-TppPermission.ps1
@@ -22,6 +22,7 @@ Overwrite an existing permission if one exists
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path, Guid, IdentityId

--- a/VenafiPS/Public/Set-TppPermission.ps1
+++ b/VenafiPS/Public/Set-TppPermission.ps1
@@ -21,8 +21,10 @@ TppPermission object.  You can create a new object or get existing object from G
 Overwrite an existing permission if one exists
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path, Guid, IdentityId

--- a/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
+++ b/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
@@ -24,8 +24,10 @@ Specifies the time before which the ticket should be processed.
 ScheduledStop must be specified when the "Approved Between" status is set
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 TicketGuid

--- a/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
+++ b/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
@@ -25,6 +25,7 @@ ScheduledStop must be specified when the "Approved Between" status is set
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 TicketGuid

--- a/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
+++ b/VenafiPS/Public/Set-TppWorkflowTicketStatus.ps1
@@ -73,7 +73,7 @@ function Set-TppWorkflowTicketStatus {
         [DateTime] $ScheduledStop,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
@@ -96,7 +96,7 @@ function Set-TppWorkflowTicketStatus {
             }
         }
 
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
     }
 
     process {

--- a/VenafiPS/Public/Test-TppIdentity.ps1
+++ b/VenafiPS/Public/Test-TppIdentity.ps1
@@ -13,6 +13,7 @@ Only return boolean instead of ID and Exists list.  Helpful when validating just
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Identity

--- a/VenafiPS/Public/Test-TppIdentity.ps1
+++ b/VenafiPS/Public/Test-TppIdentity.ps1
@@ -12,8 +12,10 @@ The id that represents the user or group.
 Only return boolean instead of ID and Exists list.  Helpful when validating just 1 identity.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Identity

--- a/VenafiPS/Public/Test-TppIdentity.ps1
+++ b/VenafiPS/Public/Test-TppIdentity.ps1
@@ -60,11 +60,11 @@ function Test-TppIdentity {
         [Switch] $ExistOnly,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Test-TppObject.ps1
+++ b/VenafiPS/Public/Test-TppObject.ps1
@@ -15,8 +15,10 @@ Guid which represents a unqiue object.  Provide either this or Path.
 Only return boolean instead of Object and Exists list.  Helpful when validating just 1 object.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 Path or Guid.

--- a/VenafiPS/Public/Test-TppObject.ps1
+++ b/VenafiPS/Public/Test-TppObject.ps1
@@ -71,11 +71,11 @@ function Test-TppObject {
         [Switch] $ExistOnly,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {
-        $VenafiSession.Validate('TPP')
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
         $params = @{
             VenafiSession = $VenafiSession

--- a/VenafiPS/Public/Test-TppObject.ps1
+++ b/VenafiPS/Public/Test-TppObject.ps1
@@ -16,6 +16,7 @@ Only return boolean instead of Object and Exists list.  Helpful when validating 
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 Path or Guid.

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -23,6 +23,7 @@ Token object obtained from New-TppToken
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .PARAMETER GrantDetail
 Provides detailed info about the token object from the TPP server response as an output.  Supported on TPP 20.4 and later.

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -22,10 +22,8 @@ See New-VenafiSession -VaultMetaData
 Token object obtained from New-TppToken
 
 .PARAMETER VenafiSession
-Authentication for the function.
+VenafiSession object to validate.
 The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
 
 .PARAMETER GrantDetail
 Provides detailed info about the token object from the TPP server response as an output.  Supported on TPP 20.4 and later.

--- a/VenafiPS/Public/Test-TppToken.ps1
+++ b/VenafiPS/Public/Test-TppToken.ps1
@@ -22,8 +22,10 @@ See New-VenafiSession -VaultMetaData
 Token object obtained from New-TppToken
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .PARAMETER GrantDetail
 Provides detailed info about the token object from the TPP server response as an output.  Supported on TPP 20.4 and later.

--- a/VenafiPS/Public/Write-TppLog.ps1
+++ b/VenafiPS/Public/Write-TppLog.ps1
@@ -43,6 +43,7 @@ Integer data to write to log.  See link for event ID messages for more info.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+A TPP token or VaaS key can also provided.
 
 .INPUTS
 none

--- a/VenafiPS/Public/Write-TppLog.ps1
+++ b/VenafiPS/Public/Write-TppLog.ps1
@@ -124,14 +124,14 @@ function Write-TppLog {
         [int] $Value2,
 
         [Parameter()]
-        [VenafiSession] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     if ( $PSCmdlet.ParameterSetName -eq 'DefaultGroup' ) {
         throw 'Writing to built-in event groups is no longer supported by Venafi.  You can write to custom event groups.  -EventGroup will be deprecated in a future release.'
     }
 
-    $VenafiSession.Validate('TPP')
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
     # the event id is the group id coupled with the event id
     $fullEventId = "$CustomEventGroup$EventId"

--- a/VenafiPS/Public/Write-TppLog.ps1
+++ b/VenafiPS/Public/Write-TppLog.ps1
@@ -42,8 +42,10 @@ Integer data to write to log.  See link for event ID messages for more info.
 Integer data to write to log.  See link for event ID messages for more info.
 
 .PARAMETER VenafiSession
-Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
 A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
 
 .INPUTS
 none

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -29,7 +29,7 @@ foreach ( $folder in $folders) {
 $script:CloudUrl = 'https://api.venafi.cloud'
 $script:ModuleVersion = '((NEW_VERSION))'
 
-$Script:VenafiSession = New-Object 'VenafiSession'
+$Script:VenafiSession = $null
 Export-ModuleMember -Variable VenafiSession
 
 $aliases = @{


### PR DESCRIPTION
- Allow either a vaas key or tpp token to be provided as authentication to any function that supports that platform.  This better enables devops scenarios so 1 call can be made for a function as opposed to executing New-VenafiSession first.  Create `Test-VenafiSession` to add support for these new ways to authenticate as VenafiSession.Validate isn't used.
- Add option to export from VaaS in JKS format