### PR TITLE
History search and Move object fix

### DIFF
--- a/VenafiPS/Public/Find-TppHistoricalCertificate.ps1
+++ b/VenafiPS/Public/Find-TppHistoricalCertificate.ps1
@@ -1,0 +1,128 @@
+
+<#
+.SYNOPSIS
+Find historical certificates in TPP
+
+.DESCRIPTION
+Certificates in the secret store matching the key/value provided will be found and their details returned with their associated 'current' certificate.
+As this function may return details on many certificates, optional parallel processing has been implemented.
+Be sure to use PowerShell Core, v7 or greater, to take advantage.
+
+.PARAMETER Path
+Starting path to associated current certificates to limit the search
+
+.PARAMETER Attribute
+Name and value to search.
+See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Secretstore-lookupbyassociation.php for more details.
+Note, ValidFrom will perform a greater than or equal comparison and ValidTo will perform a less than or equal comparison.
+Currently, one 1 name/value pair can be used.
+
+.PARAMETER VenafiSession
+Authentication for the function.
+The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+A TPP token or VaaS key can also provided.
+If providing a TPP token, an environment variable named TppServer must also be set.
+
+.INPUTS
+None
+
+.OUTPUTS
+PSCustomObject with the following properties:
+    Name
+    TypeName
+    Path
+    History
+
+.EXAMPLE
+Get-TppHistoricalCertificate -Attribute @{'ValidTo' = (Get-Date)}
+Find historical certificates that are still active
+
+.EXAMPLE
+Get-TppHistoricalCertificate -Attribute @{'ValidTo' = (Get-Date)} -Path '\ved\policy\certs'
+Find historical certificates that are still active and the current certificate starts with a specific path
+
+#>
+
+function Find-TppHistoricalCertificate {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                }
+                else {
+                    throw "'$_' is not a valid DN path"
+                }
+            }
+        )]
+        [string] $Path = '\VED\Policy',
+
+        [Parameter(Mandatory)]
+        [hashtable] $Attribute,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [psobject] $VenafiSession = $script:VenafiSession
+    )
+
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP' -AuthType 'Token'
+
+    $activeVaultId = Find-TppVaultId -Attribute $Attribute -VenafiSession $VenafiSession
+    if ( -not $activeVaultId ) {
+        return
+    }
+
+    Write-Warning ('Found {0} matching vault items' -f $activeVaultId.Count)
+
+    $owners = if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $activeVaultId | ForEach-Object {
+            Invoke-VenafiRestMethod -UriLeaf "secretstore/ownerlookup" -Body @{'Namespace' = 'config'; 'VaultID' = $_ } -Method Post -VenafiSession $VenafiSession
+        }
+    }
+    else {
+        $activeVaultId | ForEach-Object -ThrottleLimit 100 -Parallel {
+            Import-Module VenafiPS
+            New-VenafiSession -Server ($using:VenafiSession).Server -AccessToken ($using:VenafiSession).Token.AccessToken
+            Invoke-VenafiRestMethod -UriLeaf "secretstore/ownerlookup" -Body @{'Namespace' = 'config'; 'VaultID' = $_ } -Method Post
+        }
+    }
+
+    # limit current certs to the path provided
+    $certs = $owners.owners.where{ $_ -like "$Path*" } | Select-Object -Unique
+
+    Write-Warning ('Getting details on {0} current certificates' -f $certs.Count)
+
+    $sbGeneric = {
+
+        $thisDetailedCert = Get-VenafiCertificate -Path $_ -IncludePreviousVersions -VenafiSession $VenafiSession -ErrorAction SilentlyContinue
+        if ( -not $thisDetailedCert -or $thisDetailedCert.TypeName -notlike '*certificate*' ) { return }
+
+        $history = $thisDetailedCert.PreviousVersions | Where-Object { $_.VaultId -in $activeVaultId } | Select-Object -ExpandProperty CertificateDetails
+        if ( $history ) {
+            $thisDetailedCert | Select-Object Name, TypeName, Path,
+            @{
+                'n' = 'History'
+                'e' = { $history }
+            }
+        }
+    }
+
+    # needed for ps7
+    $sbGenericString = $sbGeneric.ToString()
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $certs | ForEach-Object -Process $sbGeneric
+    }
+    else {
+        $certs | ForEach-Object -ThrottleLimit 100 -Parallel {
+            Import-Module VenafiPS
+            $VenafiSession = New-VenafiSession -Server ($using:VenafiSession).Server -AccessToken ($using:VenafiSession).Token.AccessToken -PassThru
+            $activeVaultId = $using:activeVaultId
+
+            Invoke-Expression $using:sbGenericString
+        }
+    }
+}

--- a/VenafiPS/Public/Find-TppObject.ps1
+++ b/VenafiPS/Public/Find-TppObject.ps1
@@ -116,7 +116,8 @@ function Find-TppObject {
         [Parameter(Mandatory, ParameterSetName = 'FindByPattern')]
         [Parameter(ParameterSetName = 'FindByClass')]
         [Parameter(Mandatory, ParameterSetName = 'FindByAttribute')]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNull()]
+        [AllowEmptyString()]
         [String] $Pattern,
 
         [Parameter(Mandatory, ParameterSetName = 'FindByClass')]

--- a/VenafiPS/Public/Get-VaasOrgUnit.ps1
+++ b/VenafiPS/Public/Get-VaasOrgUnit.ps1
@@ -42,6 +42,9 @@ function Get-VaasOrgUnit {
     )
 
     begin {
+
+        Write-Warning 'Get-VaasOrgUnit will be deprecated in a future release'
+
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
 
         $params = @{

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -92,23 +92,22 @@ function Move-TppObject {
 
     process {
 
-        if ( $PSCmdlet.ShouldProcess($SourcePath, "Move to $TargetPath") ) {
-
-            $params = @{
-                VenafiSession = $VenafiSession
-                Method        = 'Post'
-                UriLeaf       = 'config/RenameObject'
-                Body          = @{
-                    ObjectDN    = $SourcePath
-                    NewObjectDN = $TargetPath
-                }
+        $params = @{
+            VenafiSession = $VenafiSession
+            Method        = 'Post'
+            UriLeaf       = 'config/RenameObject'
+            Body          = @{
+                ObjectDN    = $SourcePath
+                NewObjectDN = $TargetPath
             }
+        }
 
-            # if target is a policy, append the object name from source
-            if ( $targetIsPolicy ) {
-                $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath (Split-Path -Path $SourcePath -Leaf)
-            }
+        # if target is a policy, append the object name from source
+        if ( $targetIsPolicy ) {
+            $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath (Split-Path -Path $SourcePath -Leaf)
+        }
 
+        if ( $PSCmdlet.ShouldProcess($SourcePath, ('Move to {0}' -f $params.Body.NewObjectDN)) ) {
             $response = Invoke-VenafiRestMethod @params
 
             if ( $response.Result -ne [TppConfigResult]::Success ) {

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -10,7 +10,7 @@ A rename can be done at the same time as the move by providing a full target pat
 Full path to an existing object in TPP
 
 .PARAMETER TargetPath
-New path.  This can either be an existing policy and the existing object name will be kept or a full path including the object name.
+New path.  This can either be an existing policy and the existing object name will be kept or a full path including a new object name.
 
 .PARAMETER VenafiSession
 Authentication for the function.
@@ -26,7 +26,7 @@ n/a
 
 .EXAMPLE
 Move-TppObject -SourceDN '\VED\Policy\My Folder\mycert.company.com' -TargetDN '\VED\Policy\New Folder\mycert.company.com'
-Moves mycert.company.com to a new Policy folder
+Move object to a new Policy folder
 
 .EXAMPLE
 Find-VenafiCertificate -Path '\ved\policy\certs' | Move-TppObject -TargetDN '\VED\Policy\New Folder'

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -3,13 +3,14 @@
 Move an object of any type
 
 .DESCRIPTION
-Move an object of any type
+Move an object of any type from one policy to another.
+A rename can be done at the same time as the move by providing a full target path including the new object name.
 
 .PARAMETER SourcePath
-Full path to an object in TPP
+Full path to an existing object in TPP
 
 .PARAMETER TargetPath
-New path
+New path.  This can either be an existing policy and the existing object name will be kept or a full path including the object name.
 
 .PARAMETER VenafiSession
 Authentication for the function.
@@ -26,6 +27,10 @@ n/a
 .EXAMPLE
 Move-TppObject -SourceDN '\VED\Policy\My Folder\mycert.company.com' -TargetDN '\VED\Policy\New Folder\mycert.company.com'
 Moves mycert.company.com to a new Policy folder
+
+.EXAMPLE
+Find-VenafiCertificate -Path '\ved\policy\certs' | Move-TppObject -TargetDN '\VED\Policy\New Folder'
+Move all objects found in 1 folder to another
 
 .LINK
 http://VenafiPS.readthedocs.io/en/latest/functions/Move-TppObject/
@@ -77,6 +82,12 @@ function Move-TppObject {
 
     begin {
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
+
+        # determine if target is a policy or other object
+        # if policy, we'll need to append the object name when moving
+        # if not policy, the item won't exist so handle the error
+        $targetObject = Get-TppObject -Path $TargetPath -VenafiSession $VenafiSession -ErrorAction SilentlyContinue
+        $targetIsPolicy = ($targetObject.TypeName -eq 'Policy')
     }
 
     process {
@@ -91,6 +102,11 @@ function Move-TppObject {
                     ObjectDN    = $SourcePath
                     NewObjectDN = $TargetPath
                 }
+            }
+
+            # if target is a policy, append the object name from source
+            if ( $targetIsPolicy ) {
+                $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath (Split-Path -Path $SourcePath -Leaf)
             }
 
             $response = Invoke-VenafiRestMethod @params

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -91,6 +91,10 @@ New-VenafiSession -Server venafitpp.mycompany.com -ClientId MyApp -Scope @{'cert
 Create token-based session using Windows Integrated authentication with a certain scope and privilege restriction
 
 .EXAMPLE
+New-VenafiSession -Server venafitpp.mycompany.com -Credential $cred -ClientId MyApp -Scope @{'certificate'='manage'}
+Create token-based session
+
+.EXAMPLE
 New-VenafiSession -Server venafitpp.mycompany.com -Certificate $myCert -ClientId MyApp -Scope @{'certificate'='manage'}
 Create token-based session using a client certificate
 

--- a/VenafiPS/Public/Search-TppHistory.ps1
+++ b/VenafiPS/Public/Search-TppHistory.ps1
@@ -9,7 +9,8 @@ As this function may return details on many items, optional parallel processing 
 Be sure to use PowerShell Core, v7 or greater, to take advantage.
 
 .PARAMETER Path
-Starting path to associated current items to limit the search
+Starting path to associated current items to limit the search.
+The default is \VED\Policy.
 
 .PARAMETER Attribute
 Name and value to search.

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -100,7 +100,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Set-TppWorkflowTicketStatus', 'Test-ModuleHash', 'Test-TppIdentity',
                'Test-TppObject', 'Test-TppToken', 'Write-TppLog', 'Get-VenafiTeam',
                'Remove-VenafiTeam', 'Add-VenafiTeamMember', 'Add-VenafiTeamOwner',
-               'Remove-VenafiTeamMember', 'Remove-VenafiTeamOwner', 'New-VenafiTeam'
+               'Remove-VenafiTeamMember', 'Remove-VenafiTeamOwner', 'New-VenafiTeam', 'Find-TppHistoricalCertificate'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -100,7 +100,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Set-TppWorkflowTicketStatus', 'Test-ModuleHash', 'Test-TppIdentity',
                'Test-TppObject', 'Test-TppToken', 'Write-TppLog', 'Get-VenafiTeam',
                'Remove-VenafiTeam', 'Add-VenafiTeamMember', 'Add-VenafiTeamOwner',
-               'Remove-VenafiTeamMember', 'Remove-VenafiTeamOwner', 'New-VenafiTeam', 'Find-TppHistoricalCertificate'
+               'Remove-VenafiTeamMember', 'Remove-VenafiTeamOwner', 'New-VenafiTeam', 'Search-TppHistory'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
- Add `Search-TppHistory` to find historical items by attribute value and their associated current item
- Fix `Move-TppObject` not appending object name when moving multiple objects to a new folder and passed via pipeline
- Update `Find-TppObject` to allow passing of empty string for `-Pattern` to find objects which don't have a value set