### PR TITLE
multiple issue fixes, client delete 5k max, user matching rules for new vaas team

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,6 +17,7 @@ assignees: ''
 Operating System:
 VenafiPS version:
 PowerShell version:
+TPP version (if applicable):
 ```
 
 # Steps to reproduce

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -1,96 +1,157 @@
-<#
-.SYNOPSIS
-Get object attributes as well as policies (policy attributes)
-
-.DESCRIPTION
-Retrieves object attributes as well as policies (aka policy attributes).
-You can either retrieve all attributes or individual ones.
-By default, the attributes returned are not the effective policy, but that can be requested with the
-Effective switch.
-Policy folders can have attributes as well as policies which apply to the resultant objects.
-For more info on policies and how they are different than attributes, see https://docs.venafi.com/Docs/current/TopNav/Content/Policies/c_policies_tpp.php.
-
-.PARAMETER Path
-Path to the object to retrieve configuration attributes.  Just providing DN will return all attributes.
-
-.PARAMETER Guid
-To be deprecated; use -Path instead.
-Object Guid.  Just providing Guid will return all attributes.
-
-.PARAMETER Attribute
-Only retrieve the value/values for this attribute
-
-.PARAMETER Effective
-Get the objects attribute value, once policies have been applied.
-This is not applicable to policies, only objects.
-
-.PARAMETER All
-Get all effective object attribute values.
-This will perform 3 steps, get the object type, enumerate the attributes for the object type, and get all the effective values.
-The output will contain the path where the policy was applied from.
-Note, expect this to take longer than usual given the number of api calls.
-
-.PARAMETER Policy
-Get policies (aka policy attributes) instead of object attributes
-
-.PARAMETER ClassName
-Required when getting policy attributes.  Provide the class name to retrieve the value for.
-If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
-
-.INPUTS
-Path
-
-.OUTPUTS
-PSCustomObject with properties:
-- Name
-- Value
-- PolicyPath (only applicable with -All)
-- IsCustomField (not applicable to policies)
-- CustomName (not applicable to policies)
-
-.EXAMPLE
-Get-TppAttribute -Path '\VED\Policy\My Folder\myapp.company.com'
-Retrieve all values for an object, excluding values assigned by policy
-
-.EXAMPLE
-Get-TppAttribute -Path '\VED\Policy\My Folder\myapp.company.com' -AttributeName 'driver name'
-Retrieve the value for a specific attribute
-
-.EXAMPLE
-Get-TppAttribute -Path '\VED\Policy\My Folder\myapp.company.com' -AttributeName 'Contact' -Effective
-Retrieve the effective value for a specific attribute
-
-.EXAMPLE
-Get-TppAttribute -Path '\VED\Policy\My Folder\myapp.company.com' -All
-Retrieve all effective values for an object
-
-.EXAMPLE
-Get-TppAttribute -Path '\VED\Policy\My Folder' -Policy -Class 'X509 Certificate' -AttributeName 'Contact'
-Retrieve the policy attribute value for the specified policy folder
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppAttribute/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Get-TppAttribute.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-read.php
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-readall.php
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-readeffectivepolicy.php
-
-#>
 function Get-TppAttribute {
+    <#
+    .SYNOPSIS
+    Get object attributes as well as policies (policy attributes)
+
+    .DESCRIPTION
+    Retrieves object attributes as well as policies (aka policy attributes).
+    You can either retrieve all attributes or individual ones.
+    By default, the attributes returned are not the effective policy, but that can be requested with the
+    Effective switch.
+    Policy folders can have attributes as well as policies which apply to the resultant objects.
+    For more info on policies and how they are different than attributes, see https://docs.venafi.com/Docs/current/TopNav/Content/Policies/c_policies_tpp.php.
+
+    .PARAMETER Path
+    Path to the object to retrieve configuration attributes.  Just providing DN will return all attributes.
+
+    .PARAMETER Guid
+    To be deprecated; use -Path instead.
+    Object Guid.  Just providing Guid will return all attributes.
+
+    .PARAMETER Attribute
+    Only retrieve the value/values for this attribute
+
+    .PARAMETER Effective
+    Get the objects attribute value, once policies have been applied.
+    This is not applicable to policies, only objects.
+
+    .PARAMETER All
+    Get all effective object attribute values.
+    This will perform 3 steps, get the object type, enumerate the attributes for the object type, and get all the effective values.
+    The output will contain the path where the policy was applied from.
+    Note, expect this to take longer than usual given the number of api calls.
+
+    .PARAMETER PolicyClass
+    Get policies (aka policy attributes) instead of object attributes.
+    Provide the class name to retrieve the value for.
+    If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
+
+    .PARAMETER New
+    New output format which returns 1 object with multiple properties instead of an object per property
+
+    .PARAMETER Policy
+    Deprecated.  To retrieve policy attributes, just provide -PolicyClass.
+
+    .PARAMETER AsValue
+    Deprecated.  No longer required with -New format.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TppServer must also be set.
+
+    .INPUTS
+    Path
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -New
+
+    Name                                   : test.gdb.com
+    Path                                   : \ved\policy\certificates\test.gdb.com
+    TypeName                               : X509 Server Certificate
+    Guid                                   : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    Certificate Vault Id                   : @{Value=442493; CustomFieldName=; PolicyPath=}
+    Consumers                              : @{Value=System.Object[]; CustomFieldName=; PolicyPath=}
+    Created By                             : @{Value=WebAdmin; CustomFieldName=; PolicyPath=}
+
+    Retrieve all values for an object, excluding values assigned by policy
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -Attribute 'Driver Name' -New
+
+    Name        : test.gdb.com
+    Path        : \ved\policy\certificates\test.gdb.com
+    TypeName    : X509 Server Certificate
+    Guid        : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    Driver Name : @{Value=appx509certificate; CustomFieldName=; PolicyPath=}
+
+    Retrieve the value for a specific attribute
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -AttributeName 'State' -Effective -New
+
+    Name     : test.gdb.com
+    Path     : \ved\policy\certificates\test.gdb.com
+    TypeName : X509 Server Certificate
+    Guid     : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    State    : @{Value=UT; CustomFieldName=; PolicyPath=\VED\Policy\Certificates}
+
+    Retrieve the effective (policy applied) value for a specific attribute.
+    This not only returns the value, but also the path where the policy is applied.
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -All -New
+
+    Name                 : test.gdb.com
+    Path                 : \ved\policy\certificates\test.gdb.com
+    TypeName             : X509 Server Certificate
+    Guid                 : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    Certificate Vault Id : @{Value=442493; CustomFieldName=; PolicyPath=}
+    City                 : @{Value=Salt Lake City; CustomFieldName=; PolicyPath=\VED\Policy\Certificates}
+    Consumers            : @{Value=System.Object[]; CustomFieldName=; PolicyPath=}
+    Created By           : @{Value=WebAdmin; CustomFieldName=; PolicyPath=}
+    State                : @{Value=UT; CustomFieldName=; PolicyPath=\VED\Policy\Certificates}
+
+    Retrieve all effective values for an object
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates' -PolicyClass 'X509 Certificate' -AttributeName 'State' -New
+
+    Name            : certificates
+    Path            : \ved\policy\certificates
+    TypeName        : Policy
+    Guid            : a91fc152-a9fb-4b49-a7ca-7014b14d73eb
+    PolicyClassName : x509 certificate
+    State           : UT
+
+    Retrieve specific policy attribute values for the specified policy folder and class
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates' -PolicyClass 'X509 Certificate' -All -New
+
+    Name            : certificates
+    Path            : \ved\policy\certificates
+    TypeName        : Policy
+    Guid            : a91fc152-a9fb-4b49-a7ca-7014b14d73eb
+    PolicyClassName : x509 certificate
+    City            : Salt Lake City
+    Country         : US
+    Management Type : Enrollment
+    Organization    : Venafi, Inc.
+    State           : UT
+
+    Retrieve all policy attribute values for the specified policy folder and class
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppAttribute/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Get-TppAttribute.ps1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-read.php
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-readall.php
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-readeffectivepolicy.php
+
+    #>
     [CmdletBinding(DefaultParameterSetName = 'ByPath')]
     param (
 
@@ -98,47 +159,48 @@ function Get-TppAttribute {
         [Parameter(Mandatory, ParameterSetName = 'ByPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'AllEffectivePath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'PolicyPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
         [Alias('DN')]
         [String] $Path,
 
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByGuid', ValueFromPipeline)]
-        [Parameter(Mandatory, ParameterSetName = 'ByGuid', ValueFromPipeline)]
-        [ValidateNotNullOrEmpty()]
-        [guid] $Guid,
-
         [Parameter(Mandatory, ParameterSetName = 'EffectiveByPath')]
         [Parameter(ParameterSetName = 'ByPath')]
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByGuid')]
-        [Parameter(ParameterSetName = 'ByGuid')]
         [Parameter(Mandatory, ParameterSetName = 'PolicyPath')]
         [ValidateNotNullOrEmpty()]
         [String[]] $Attribute,
 
         [Parameter(Mandatory, ParameterSetName = 'EffectiveByPath')]
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByGuid')]
         [Alias('EffectivePolicy')]
         [Switch] $Effective,
 
         [Parameter(Mandatory, ParameterSetName = 'AllEffectivePath')]
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath')]
         [switch] $All,
 
-        [Parameter(Mandatory, ParameterSetName = 'PolicyPath')]
+        [Parameter(ParameterSetName = 'PolicyPath')]
+        [Parameter(ParameterSetName = 'AllPolicyPath')]
         [switch] $Policy,
 
         [Parameter(Mandatory, ParameterSetName = 'PolicyPath')]
-        [string] $ClassName,
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath')]
+        [Alias('ClassName')]
+        [string] $PolicyClass,
+
+        [Parameter(ParameterSetName = 'EffectiveByPath')]
+        [Parameter(ParameterSetName = 'ByPath')]
+        [Parameter(ParameterSetName = 'PolicyPath')]
+        [switch] $AsValue,
 
         [Parameter()]
-        [switch] $AsValue,
+        [switch] $New,
 
         [Parameter()]
         [psobject] $VenafiSession = $script:VenafiSession
@@ -148,59 +210,54 @@ function Get-TppAttribute {
 
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
-        if ( $Guid ) {
-            Write-Warning '-Guid will be deprecated in a future release.  Please use -Path instead.'
-        }
+        if ( $AsValue ) { Write-Warning '-AsValue wil be deprecated in a future release.  Please use the new format with -New.' }
+        if ( $Policy ) { Write-Warning '-Policy is no longer required; just provide -PolicyClass to find policy attributes.' }
 
-        $baseParams = @{
-            VenafiSession = $VenafiSession
-            Method        = 'Post'
-            Body          = @{
-                ObjectDN = ''
-            }
+        if ( $All -and $PolicyClass ) {
+            Write-Verbose "Getting attributes for class $PolicyClass"
+            $Attribute = Get-TppClassAttribute -ClassName $PolicyClass -VenafiSession $VenafiSession | Select-Object -ExpandProperty Name
         }
-
-        if ( $Policy ) {
-            $uriLeaf = 'config/ReadPolicy'
-        }
-        else {
-            if ( $PSBoundParameters.ContainsKey('Attribute') ) {
-                if ( $Effective ) {
-                    $uriLeaf = 'config/ReadEffectivePolicy'
-                }
-                else {
-                    $uriLeaf = 'config/read'
-                }
-            }
-            else {
-                if ( $All ) {
-                    $uriLeaf = 'config/ReadEffectivePolicy'
-                }
-                else {
-                    $uriLeaf = 'config/readall'
-                }
-            }
-        }
-        $baseParams.UriLeaf = $uriLeaf
     }
 
     process {
 
-        switch -Wildcard ($PSCmdlet.ParameterSetName) {
-            '*Path' {
-                $pathToProcess = $Path
-            }
-
-            '*Guid' {
-                $pathToProcess = $Guid | ConvertTo-TppPath -VenafiSession $VenafiSession
+        $params = @{
+            VenafiSession = $VenafiSession
+            Method        = 'Post'
+            Body          = @{
+                ObjectDN = $Path
             }
         }
 
-        $baseParams.Body['ObjectDN'] = $pathToProcess
+        if ( $PolicyClass ) {
+            $params.uriLeaf = 'config/ReadPolicy'
+        } else {
+            if ( $PSBoundParameters.ContainsKey('Attribute') ) {
+                if ( $Effective ) {
+                    $params.uriLeaf = 'config/ReadEffectivePolicy'
+                } else {
+                    $params.uriLeaf = 'config/read'
+                }
+            } else {
+                if ( $All ) {
+                    $params.uriLeaf = 'config/ReadEffectivePolicy'
+                } else {
+                    $params.uriLeaf = 'config/readall'
+                }
+            }
+        }
+        # $baseParams.UriLeaf = $uriLeaf
 
-        if ( $All ) {
-            $className = Get-TppObject -Path $pathToProcess -VenafiSession $VenafiSession | Select-Object -ExpandProperty TypeName
-            $Attribute = Get-TppClassAttribute -ClassName $className -VenafiSession $VenafiSession | Select-Object -ExpandProperty Name
+        # $baseParams.Body['ObjectDN'] = $Path
+        $thisObject = Get-TppObject -Path $Path -VenafiSession $VenafiSession
+
+        if ( $PolicyClass -and $thisObject.TypeName -ne 'Policy' ) {
+            Write-Error ('You are attempting to retrieve policy attributes, but {0} is not a policy path' -f $Path)
+            continue
+        }
+
+        if ( $All -and -not $PolicyClass ) {
+            $Attribute = Get-TppClassAttribute -ClassName $thisObject.TypeName -VenafiSession $VenafiSession | Select-Object -ExpandProperty Name
         }
 
         if ( $Attribute ) {
@@ -209,16 +266,11 @@ function Get-TppAttribute {
             # api which allows passing a list
             $configValues = foreach ($thisAttribute in $Attribute) {
 
-                $params = $baseParams.Clone()
-                $params.Body += @{
-                    AttributeName = $thisAttribute
-                }
+                $params.Body.AttributeName = $thisAttribute
 
                 # add the class for a policy call
-                if ( $ClassName ) {
-                    $params.Body += @{
-                        'Class' = $ClassName
-                    }
+                if ( $PolicyClass ) {
+                    $params.Body.Class = $PolicyClass
                 }
 
                 $response = Invoke-VenafiRestMethod @params
@@ -231,9 +283,8 @@ function Get-TppAttribute {
                     }
                 }
             }
-        }
-        else {
-            $response = Invoke-VenafiRestMethod @baseParams
+        } else {
+            $response = Invoke-VenafiRestMethod @params
             if ( $response ) {
                 $configValues = $response.NameValues | Select-Object Name,
                 @{
@@ -249,28 +300,89 @@ function Get-TppAttribute {
 
             $configValues = @($configValues)
 
-            if ( $configValues.Count -eq 1 -and $AsValue ) {
-                return $configValues.Value
+            if ( $AsValue ) {
+                if ( $configValues.Count -eq 1 ) {
+                    return $configValues.Value
+                } else {
+                    Write-Warning '-AsValue can only be used for 1 attribute'
+                }
             }
 
-            # convert custom field guids to names
-            foreach ($thisConfigValue in $configValues) {
+            if ( $New ) {
 
-                $customField = $VenafiSession.CustomField | Where-Object { $_.Guid -eq $thisConfigValue.Name }
-                $thisConfigValue | Add-Member @{
-                    'IsCustomField' = [bool]$customField
-                    'CustomName'    = $null
-                }
-                if ( $customField ) {
-                    $thisConfigValue.CustomName = $customField.Label
+                $return = [pscustomobject] @{
+                    Name     = $thisObject.Name
+                    Path     = $Path
+                    TypeName = $thisObject.TypeName
+                    Guid     = $thisObject.Guid
                 }
 
-                $thisConfigValue
+                if ( $PolicyClass ) {
+                    Add-Member -InputObject $return -NotePropertyMembers @{ 'PolicyClassName' = $PolicyClass }
+                }
+                # no customfieldname for policy attribs
+
+                foreach ($thisConfigValue in $configValues) {
+
+                    $valueOut = $null
+
+                    if ( -not $thisConfigValue.Value ) { continue }
+
+                    switch ($thisConfigValue.Value.GetType().Name) {
+                        'Object[]' {
+                            switch ($thisConfigValue.Value.Count) {
+                                0 {
+                                    $valueOut = $null
+                                }
+
+                                1 {
+                                    $valueOut = $thisConfigValue.Value[0]
+                                }
+
+                                Default {
+                                    $valueOut = $thisConfigValue.Value
+                                }
+                            }
+                        }
+                        Default {
+                            $valueOut = $thisConfigValue.Value
+                        }
+                    }
+
+                    if ( $PolicyClass ) {
+                        $newProp = $valueOut
+                    } else {
+
+                        $customField = $VenafiSession.CustomField | Where-Object { $_.Guid -eq $thisConfigValue.Name }
+                        $newProp = [pscustomobject] @{
+                            'Value'           = $valueOut
+                            'CustomFieldName' = $customField.Label
+                            'PolicyPath'      = $thisConfigValue.PolicyPath
+                        }
+                    }
+                    Add-Member -InputObject $return -NotePropertyMembers @{ $thisConfigValue.Name = $newProp } -Force
+
+                }
+
+                $return
+
+            } else {
+
+                # convert custom field guids to names
+                foreach ($thisConfigValue in $configValues) {
+
+                    $customField = $VenafiSession.CustomField | Where-Object { $_.Guid -eq $thisConfigValue.Name }
+
+                    $thisConfigValue | Add-Member @{
+                        'IsCustomField' = [bool] $customField
+                        'CustomName'    = $customField.Label
+                    }
+
+                    $thisConfigValue
+                }
             }
+
+
         }
-    }
-
-    end {
-
     }
 }

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -39,7 +39,7 @@ By default, this function will import and replace the certificate regardless of 
 By using this parameter, this function will import, but use newest. Only import the certificate when no Certificate object exists with a past, present, or current version of the imported certificate.
 If a match is found between the Certificate object and imported certificate, activate the certificate with the most current 'Valid From' date.
 Archive the unused certificate, even if it is the imported certificate, to the History tab.
-See https://github.com/Venafi/VenafiPS/issues/88#issuecomment-600134145 for a flowchart of the reconciliation algorithm.
+See https://docs.venafi.com/Docs/currentSDK/TopNav/Content/CA/c-CA-Import-ReconciliationRules-tpp.php for a flowchart of the reconciliation algorithm.
 
 .PARAMETER PassThru
 Return a TppObject representing the newly imported object.

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -225,8 +225,6 @@ function Invoke-VenafiCertificateAction {
             $params.Body += $AdditionalParameters
         }
 
-        Write-Verbose ($params | ConvertTo-Json)
-
         try {
             if ( $performInvoke ) {
                 Invoke-VenafiRestMethod @params -FullResponse | Out-Null

--- a/VenafiPS/Public/New-TppCertificate.ps1
+++ b/VenafiPS/Public/New-TppCertificate.ps1
@@ -145,9 +145,11 @@ function New-TppCertificate {
 
         [Parameter(Mandatory, ParameterSetName = 'ByName', ValueFromPipeline)]
         [Parameter(Mandatory, ParameterSetName = 'ByNameWithDevice', ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
         [String] $Name,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Subject')]
         [String] $CommonName,
 

--- a/VenafiPS/Public/New-TppCertificate.ps1
+++ b/VenafiPS/Public/New-TppCertificate.ps1
@@ -1,119 +1,119 @@
-<#
-.SYNOPSIS
-Enrolls or provisions a new certificate
-
-.DESCRIPTION
-Enrolls or provisions a new certificate
-
-.PARAMETER Path
-The folder DN path for the new certificate. If the value is missing, use the system default
-
-.PARAMETER Name
-Name of the certifcate.  If not provided, the name will be the same as the subject.
-
-.PARAMETER CommonName
-Subject Common Name.  If Name isn't provided, CommonName will be used.
-
-.PARAMETER Csr
-The PKCS#10 Certificate Signing Request (CSR).
-If this value is provided, any Subject DN fields and the KeyBitSize in the request are ignored.
-
-.PARAMETER CertificateType
-Type of certificate to be created.
-No value provided will default to X.509 Server Certificate.
-
-.PARAMETER CertificateAuthorityDN
-The Distinguished Name (DN) of the Trust Protection Platform Certificate Authority Template object for enrolling the certificate. If the value is missing, use the default CADN
-
-.PARAMETER CertificateAuthorityAttribute
-Name/value pairs providing any CA attributes to store with the Certificate object.
-During enrollment, these values will be submitted to the CA.
-
-.PARAMETER ManagementType
-The level of management that Trust Protection Platform applies to the certificate:
-- Enrollment: Default. Issue a new certificate, renewed certificate, or key generation request to a CA for enrollment. Do not automatically provision the certificate.
-- Provisioning:  Issue a new certificate, renewed certificate, or key generation request to a CA for enrollment. Automatically install or provision the certificate.
-- Monitoring:  Allow Trust Protection Platform to monitor the certificate for expiration and renewal.
-- Unassigned: Certificates are neither enrolled or monitored by Trust Protection Platform.
-
-.PARAMETER SubjectAltName
-A list of Subject Alternate Names.
-The value must be 1 or more hashtables with the SAN type and value.
-Acceptable SAN types are OtherName, Email, DNS, URI, and IPAddress.
-You can provide more than 1 of the same SAN type with multiple hashtables.
-
-.PARAMETER CustomField
-Hashtable of custom field(s) to be updated when creating the certificate.
-This is required when the custom fields are mandatory.
-The key is the name, not guid, of the custom field.
-
-.PARAMETER NoWorkToDo
-Turn off lifecycle processing for this certificate update
-
-.PARAMETER Device
-An array of hashtables for devices to be created.
-Available parameters can be found at https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php.
-If provisioning applications as well, those should be provided with the Application parameter.
-
-.PARAMETER Application
-An array of hashtables for applications to be created.
-Available parameters can be found at https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request-ApplicationsParameter.php.
-In addition to the application parameters, a key/value must be provided for the associated device.
-The key needs to be 'DeviceName' and the value is the ObjectName from the device.
-See the example.
-
-.PARAMETER PassThru
-Return a TppObject representing the newly created certificate.
-If devices and/or applications were created, a 'Device' property will be available as well.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
-
-.INPUTS
-None
-
-.OUTPUTS
-TppObject, if PassThru is provided
-If devices and/or applications were created, a 'Device' property will be available as well.
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template'
-Create certificate by name
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -Csr '-----BEGIN CERTIFICATE REQUEST-----\nMIIDJDCCAgwCAQAw...-----END CERTIFICATE REQUEST-----'
-Create certificate using a CSR
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -CustomField @{''=''}
-Create certificate and update custom fields
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -CommonName 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -PassThru
-Create certificate using common name.  Return the created object.
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -SubjectAltName @{'Email'='me@x.com'},@{'IPAddress'='1.2.3.4'}
-Create certificate including subject alternate names
-
-.EXAMPLE
-New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -Device @{'PolicyDN'=$DevicePath; 'ObjectName'='MyDevice'; 'Host'='1.2.3.4'} -Application @{'DeviceName'='MyDevice'; 'ObjectName'='BasicApp'; 'DriverName'='appbasic'}
-Create a new certificate with associated device and app objects
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/New-TppCertificate/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppCertificate.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php
-
-#>
 function New-TppCertificate {
+    <#
+    .SYNOPSIS
+    Enrolls or provisions a new certificate
+
+    .DESCRIPTION
+    Enrolls or provisions a new certificate
+
+    .PARAMETER Path
+    The folder DN path for the new certificate. If the value is missing, use the system default
+
+    .PARAMETER Name
+    Name of the certifcate.  If not provided, the name will be the same as the subject.
+
+    .PARAMETER CommonName
+    Subject Common Name.  If Name isn't provided, CommonName will be used.
+
+    .PARAMETER Csr
+    The PKCS#10 Certificate Signing Request (CSR).
+    If this value is provided, any Subject DN fields and the KeyBitSize in the request are ignored.
+
+    .PARAMETER CertificateType
+    Type of certificate to be created.
+    No value provided will default to X.509 Server Certificate.
+
+    .PARAMETER CertificateAuthorityDN
+    The Distinguished Name (DN) of the Trust Protection Platform Certificate Authority Template object for enrolling the certificate. If the value is missing, use the default CADN
+
+    .PARAMETER CertificateAuthorityAttribute
+    Name/value pairs providing any CA attributes to store with the Certificate object.
+    During enrollment, these values will be submitted to the CA.
+
+    .PARAMETER ManagementType
+    The level of management that Trust Protection Platform applies to the certificate:
+    - Enrollment: Default. Issue a new certificate, renewed certificate, or key generation request to a CA for enrollment. Do not automatically provision the certificate.
+    - Provisioning:  Issue a new certificate, renewed certificate, or key generation request to a CA for enrollment. Automatically install or provision the certificate.
+    - Monitoring:  Allow Trust Protection Platform to monitor the certificate for expiration and renewal.
+    - Unassigned: Certificates are neither enrolled or monitored by Trust Protection Platform.
+
+    .PARAMETER SubjectAltName
+    A list of Subject Alternate Names.
+    The value must be 1 or more hashtables with the SAN type and value.
+    Acceptable SAN types are OtherName, Email, DNS, URI, and IPAddress.
+    You can provide more than 1 of the same SAN type with multiple hashtables.
+
+    .PARAMETER CustomField
+    Hashtable of custom field(s) to be updated when creating the certificate.
+    This is required when the custom fields are mandatory.
+    The key is the name, not guid, of the custom field.
+
+    .PARAMETER NoWorkToDo
+    Turn off lifecycle processing for this certificate update
+
+    .PARAMETER Device
+    An array of hashtables for devices to be created.
+    Available parameters can be found at https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php.
+    If provisioning applications as well, those should be provided with the Application parameter.
+
+    .PARAMETER Application
+    An array of hashtables for applications to be created.
+    Available parameters can be found at https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request-ApplicationsParameter.php.
+    In addition to the application parameters, a key/value must be provided for the associated device.
+    The key needs to be 'DeviceName' and the value is the ObjectName from the device.
+    See the example.
+
+    .PARAMETER PassThru
+    Return a TppObject representing the newly created certificate.
+    If devices and/or applications were created, a 'Device' property will be available as well.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TppServer must also be set.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    TppObject, if PassThru is provided
+    If devices and/or applications were created, a 'Device' property will be available as well.
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template'
+    Create certificate by name
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -Csr '-----BEGIN CERTIFICATE REQUEST-----\nMIIDJDCCAgwCAQAw...-----END CERTIFICATE REQUEST-----'
+    Create certificate using a CSR
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -CustomField @{''=''}
+    Create certificate and update custom fields
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -CommonName 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -PassThru
+    Create certificate using common name.  Return the created object.
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -SubjectAltName @{'Email'='me@x.com'},@{'IPAddress'='1.2.3.4'}
+    Create certificate including subject alternate names
+
+    .EXAMPLE
+    New-TppCertificate -Path '\ved\policy\folder' -Name 'mycert.com' -Device @{'PolicyDN'=$DevicePath; 'ObjectName'='MyDevice'; 'Host'='1.2.3.4'} -Application @{'DeviceName'='MyDevice'; 'ObjectName'='BasicApp'; 'DriverName'='appbasic'}
+    Create a new certificate with associated device and app objects
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/New-TppCertificate/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppCertificate.ps1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php
+
+    #>
 
     [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess)]
 
@@ -124,8 +124,7 @@ function New-TppCertificate {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -154,8 +153,7 @@ function New-TppCertificate {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -215,8 +213,7 @@ function New-TppCertificate {
                         'Email' {
                             try {
                                 $null = [mailaddress]$thisValue
-                            }
-                            catch {
+                            } catch {
                                 ('''{0}'' is not a valid email' -f $thisValue)
                             }
                         }
@@ -232,8 +229,7 @@ function New-TppCertificate {
                         'IPAddress' {
                             try {
                                 $null = [ipaddress]$thisValue
-                            }
-                            catch {
+                            } catch {
                                 ('''{0}'' is not a valid IP Address' -f $thisValue)
                             }
                         }
@@ -284,7 +280,7 @@ function New-TppCertificate {
         }
 
         if ( $Csr ) {
-            $params.Body.Add('PKCS10', $Csr -replace "`n|`r", "")
+            $params.Body.Add('PKCS10', ($Csr -replace "`n|`r", ""))
         }
 
         if ( $PSBoundParameters.ContainsKey('CertificateAuthorityPath') ) {
@@ -362,15 +358,14 @@ function New-TppCertificate {
                 if ( $PassThru ) {
                     $newCert = Get-TppObject -Path $response.CertificateDN -VenafiSession $VenafiSession
                     if ( $Device ) {
-                        $newCert | Add-Member @{ 'Device' = @{'Path' = $response.Devices.DN} }
+                        $newCert | Add-Member @{ 'Device' = @{'Path' = $response.Devices.DN } }
                         if ( $Application ) {
                             $newCert.Device.Application = $response.Devices.Applications.DN
                         }
                     }
                     $newCert
                 }
-            }
-            catch {
+            } catch {
                 Write-Error $_
                 continue
             }

--- a/VenafiPS/Public/New-VenafiTeam.ps1
+++ b/VenafiPS/Public/New-VenafiTeam.ps1
@@ -1,99 +1,113 @@
-﻿<#
-.SYNOPSIS
-Create a new team
+﻿function New-VenafiTeam {
+    <#
+    .SYNOPSIS
+    Create a new team
 
-.DESCRIPTION
-Create a new VaaS or TPP team
+    .DESCRIPTION
+    Create a new VaaS or TPP team
 
-.PARAMETER Name
-Team name
+    .PARAMETER Name
+    Team name
 
-.PARAMETER Owner
-1 or more owners for the team
-For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
-For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
+    .PARAMETER Owner
+    1 or more owners for the team
+    For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
+    For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
-.PARAMETER Member
-1 or more members for the team
-For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
-For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
+    .PARAMETER Member
+    1 or more members for the team
+    For VaaS, this is the unique guid obtained from Get-VenafiIdentity.
+    For TPP, this is the identity ID property from Find-TppIdentity or Get-VenafiIdentity.
 
-.PARAMETER Role
-Team role, either 'System Admin', 'PKI Admin', 'Resource Owner' or 'Guest'.  VaaS only.
+    .PARAMETER Role
+    Team role, either 'System Admin', 'PKI Admin', 'Resource Owner' or 'Guest'.  VaaS only.
 
-.PARAMETER Policy
-1 or more policy folder paths this team manages.  TPP only.
+    .PARAMETER UserMatchingRule
+    If SSO is enabled, build your team membership rules to organize your users into teams automatically.
+    If more than 1 rule is configured, they must all be met for a user to meet the criteria.
+    Each rule should be of the format @('claim name', 'operator', 'value')
+    where operator can be equals, not_equals, contains, not_contains, starts_with, or ends_with.
 
-.PARAMETER Product
-1 or more product names, 'TLS', 'SSH', and/or 'Code Signing'.  TPP only.
+    .PARAMETER Policy
+    1 or more policy folder paths this team manages.  TPP only.
 
-.PARAMETER Description
-Team description or purpose.  TPP only.
+    .PARAMETER Product
+    1 or more product names, 'TLS', 'SSH', and/or 'Code Signing'.  TPP only.
 
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
+    .PARAMETER Description
+    Team description or purpose.  TPP only.
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin'
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TppServer must also be set.
 
-Create a new VaaS team
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin'
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin' -PassThru
+    Create a new VaaS team
 
-id                : a7d60730-a967-11ec-8832-4d051bf6d0b4
-name              : My New Team
-systemRoles       : {SYSTEM_ADMIN}
-productRoles      :
-role              : SYSTEM_ADMIN
-members           : {443de910-a6cc-11ec-ad22-018e33741844}
-owners            : {0a2adae0-b22b-11ea-91f3-ebd6dea5452e}
-companyId         : 09b24f81-b22b-11ea-91f3-ebd6dea5452e
-userMatchingRules : {}
-modificationDate  : 3/21/2022 6:38:40 PM
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin' -UserMatchingRule @('MyClaim', 'CONTAINS', 'Group')
 
-Create a new VaaS team returning the new team
+    Create a new VaaS team with user matching rule
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS'
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Owner @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4') -Role 'System Admin' -PassThru
 
-Create a new TPP team
+    id                : a7d60730-a967-11ec-8832-4d051bf6d0b4
+    name              : My New Team
+    systemRoles       : {SYSTEM_ADMIN}
+    productRoles      :
+    role              : SYSTEM_ADMIN
+    members           : {443de910-a6cc-11ec-ad22-018e33741844}
+    owners            : {0a2adae0-b22b-11ea-91f3-ebd6dea5452e}
+    companyId         : 09b24f81-b22b-11ea-91f3-ebd6dea5452e
+    userMatchingRules : {}
+    modificationDate  : 3/21/2022 6:38:40 PM
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -Policy '\ved\policy\myfolder'
+    Create a new VaaS team returning the new team
 
-Create a new TPP team and assign it to a policy
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS'
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -Description 'One amazing team'
+    Create a new TPP team
 
-Create a new TPP team with optional description
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -Policy '\ved\policy\myfolder'
 
-.EXAMPLE
-New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -PassThru
+    Create a new TPP team and assign it to a policy
 
-Name     : My New Team
-ID       : local:{a6053090-e309-49d9-98a7-28cbe7896c27}
-Path     : \VED\Identity\My New Team
-FullName : local:My New Team
-IsGroup  : True
-Members  : @{Name=sample-user; ID=local:{6baad36c-7cac-48c8-8e54-000cc22ad88f};
-           Path=\VED\Identity\sample-user; FullName=local:sample-user; IsGroup=False}
-Owners   : @{Name=sample-owner; ID=local:{d1a76bc7-d3a6-431b-9bea-d2d8780ecd86};
-           Path=\VED\Identity\sample-owner; FullName=local:sample-owner; IsGroup=False}
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -Description 'One amazing team'
 
-Create a new TPP team returning the new team
+    Create a new TPP team with optional description
 
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html#/Teams/create_1
+    .EXAMPLE
+    New-VenafiTeam -Name 'My New Team' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Owner 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}' -Product 'TLS' -PassThru
 
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Teams.php
-#>
-function New-VenafiTeam {
+    Name     : My New Team
+    ID       : local:{a6053090-e309-49d9-98a7-28cbe7896c27}
+    Path     : \VED\Identity\My New Team
+    FullName : local:My New Team
+    IsGroup  : True
+    Members  : @{Name=sample-user; ID=local:{6baad36c-7cac-48c8-8e54-000cc22ad88f};
+               Path=\VED\Identity\sample-user; FullName=local:sample-user; IsGroup=False}
+    Owners   : @{Name=sample-owner; ID=local:{d1a76bc7-d3a6-431b-9bea-d2d8780ecd86};
+               Path=\VED\Identity\sample-owner; FullName=local:sample-owner; IsGroup=False}
+
+    Create a new TPP team returning the new team
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html#/Teams/create_1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Teams.php
+
+    .LINK
+    https://docs.venafi.cloud/vcs-platform/creating-new-teams/
+    #>
 
     [CmdletBinding()]
 
@@ -112,12 +126,14 @@ function New-VenafiTeam {
         [ValidateSet('System Admin', 'PKI Admin', 'Resource Owner', 'Guest')]
         [string] $Role,
 
+        [Parameter(ParameterSetName = 'VaaS')]
+        [System.Collections.Generic.List[array]] $UserMatchingRule,
+
         [Parameter(ParameterSetName = 'TPP')]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid policy path"
                 }
             })]
@@ -137,73 +153,93 @@ function New-VenafiTeam {
         [psobject] $VenafiSession = $script:VenafiSession
     )
 
-    $platform = Test-VenafiSession -VenafiSession $VenafiSession -Platform $PSCmdlet.ParameterSetName -PassThru
-
-    $params = @{
-        VenafiSession = $VenafiSession
+    begin {
+        $platform = Test-VenafiSession -VenafiSession $VenafiSession -Platform $PSCmdlet.ParameterSetName -PassThru
     }
 
-    if ( $platform -eq 'VaaS' ) {
+    process {
 
-        $params.Method = 'Post'
-        $params.UriLeaf = "teams"
-        $params.Body = @{
-            'name'              = $Name
-            'role'              = $Role.Replace(' ', '_').ToUpper()
-            'members'           = @($Member)
-            'owners'            = @($Owner)
-            'userMatchingRules' = @()
+        $params = @{
+            VenafiSession = $VenafiSession
         }
 
-        $response = Invoke-VenafiRestMethod @params
-    }
-    else {
+        if ( $platform -eq 'VaaS' ) {
 
-        $members = foreach ($thisMember in $Member) {
-            if ( $thisMember.StartsWith('local') ) {
-                $memberIdentity = Get-VenafiIdentity -ID $thisMember -VenafiSession $VenafiSession
+            $rules = foreach ($rule in $UserMatchingRule) {
+
+                if ( $rule.Count -ne 3 ) {
+                    throw 'Each rule must contain a claim name, operator, and value'
+                }
+
+                if ( $rule[1].ToUpper() -notin 'EQUALS', 'NOT_EQUALS', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'ENDS_WITH') {
+                    throw 'Valid values for operator are EQUALS, NOT_EQUALS, CONTAINS, NOT_CONTAINS, STARTS_WITH, ENDS_WITH'
+                }
+
                 @{
-                    'PrefixedName'      = $memberIdentity.FullName
-                    'PrefixedUniversal' = $memberIdentity.ID
+                    'claimName' = $rule[0]
+                    'operator'  = $rule[1].ToUpper()
+                    'value'     = $rule[2]
                 }
             }
-            else {
-                @{'PrefixedUniversal' = $thisMember }
+
+            $params.Method = 'Post'
+            $params.UriLeaf = "teams"
+            $params.Body = @{
+                'name'              = $Name
+                'role'              = $Role.Replace(' ', '_').ToUpper()
+                'members'           = @($Member)
+                'owners'            = @($Owner)
+                'userMatchingRules' = @($rules)
             }
-        }
-        $owners = foreach ($thisOwner in $Owner) {
-            if ( $thisOwner.StartsWith('local') ) {
-                $ownerIdentity = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession
-                @{
-                    'PrefixedName'      = $ownerIdentity.FullName
-                    'PrefixedUniversal' = $ownerIdentity.ID
+
+            $response = Invoke-VenafiRestMethod @params
+
+        } else {
+
+            $members = foreach ($thisMember in $Member) {
+                if ( $thisMember.StartsWith('local') ) {
+                    $memberIdentity = Get-VenafiIdentity -ID $thisMember -VenafiSession $VenafiSession
+                    @{
+                        'PrefixedName'      = $memberIdentity.FullName
+                        'PrefixedUniversal' = $memberIdentity.ID
+                    }
+                } else {
+                    @{'PrefixedUniversal' = $thisMember }
                 }
             }
-            else {
-                @{'PrefixedUniversal' = $thisOwner }
+            $owners = foreach ($thisOwner in $Owner) {
+                if ( $thisOwner.StartsWith('local') ) {
+                    $ownerIdentity = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession
+                    @{
+                        'PrefixedName'      = $ownerIdentity.FullName
+                        'PrefixedUniversal' = $ownerIdentity.ID
+                    }
+                } else {
+                    @{'PrefixedUniversal' = $thisOwner }
+                }
             }
-        }
-        $params.Method = 'Post'
-        $params.UriLeaf = 'Teams/'
-        $params.Body = @{
-            'Name'     = @{'PrefixedName' = "local:$Name" }
-            'Members'  = @($members)
-            'Owners'   = @($owners)
-            'Products' = @($Product)
+            $params.Method = 'Post'
+            $params.UriLeaf = 'Teams/'
+            $params.Body = @{
+                'Name'     = @{'PrefixedName' = "local:$Name" }
+                'Members'  = @($members)
+                'Owners'   = @($owners)
+                'Products' = @($Product)
+            }
+
+            if ( $Policy ) {
+                $params.Body.Add('Assets', @($Policy))
+            }
+
+            if ( $Description ) {
+                $params.Body.Add('Description', $Description)
+            }
+
+            $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty ID
         }
 
-        if ( $Policy ) {
-            $params.Body.Add('Assets', @($Policy))
+        if ( $PassThru ) {
+            $response | Get-VenafiTeam -VenafiSession $VenafiSession
         }
-
-        if ( $Description ) {
-            $params.Body.Add('Description', $Description)
-        }
-
-        $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty ID
-    }
-
-    if ( $PassThru ) {
-        $response | Get-VenafiTeam -VenafiSession $VenafiSession
     }
 }

--- a/VenafiPS/Public/Remove-TppClient.ps1
+++ b/VenafiPS/Public/Remove-TppClient.ps1
@@ -1,51 +1,60 @@
-<#
-.SYNOPSIS
-Remove registered client agents
-
-.DESCRIPTION
-Remove registered client agents.
-Provide an array of client IDs to remove a large list at once.
-
-.PARAMETER ClientId
-Unique id for one or more clients
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
-
-.INPUTS
-ClientId
-
-.OUTPUTS
-None
-
-.EXAMPLE
-Remove-TppClient -ClientId 1234
-Remove a client
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Remove-TppClient/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Remove-TppClient.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-ClientDelete.php
-
-#>
 function Remove-TppClient {
+    <#
+    .SYNOPSIS
+        Remove registered client agents
+
+    .DESCRIPTION
+        Remove registered client agents.
+        Provide an array of client IDs to remove a large list at once.
+
+    .PARAMETER ClientId
+        Unique id for one or more clients
+
+    .PARAMETER RemoveAssociatedDevice
+        For a registered Agent, delete the associated Device objects, and only certificates that belong to the associated device.
+        Delete any related Discovery information. Preserve unrelated device, certificate, and Discovery information in other locations of the Policy tree and Secret Store.
+
+    .PARAMETER VenafiSession
+        Authentication for the function.
+        The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+        A TPP token or VaaS key can also provided.
+        If providing a TPP token, an environment variable named TppServer must also be set.
+
+    .INPUTS
+        ClientId
+
+    .OUTPUTS
+        None
+
+    .EXAMPLE
+        Remove-TppClient -ClientId 1234, 5678
+        Remove clients
+
+    .EXAMPLE
+        Remove-TppClient -ClientId 1234, 5678 -RemoveAssociatedDevice
+        Remove clients and associated devices
+
+    .LINK
+        http://VenafiPS.readthedocs.io/en/latest/functions/Remove-TppClient/
+
+    .LINK
+        https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Remove-TppClient.ps1
+
+    .LINK
+        https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-ClientDelete.php
+
+    #>
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
 
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [String[]] $ClientId,
+        [String[]] $ClientID,
 
         [Parameter()]
-        [switch] $RemoveAssociatedDevices,
+        [Alias('RemoveAssociatedDevices')]
+        [switch] $RemoveAssociatedDevice,
 
         [Parameter()]
         [psobject] $VenafiSession = $script:VenafiSession
@@ -60,23 +69,26 @@ function Remove-TppClient {
             UriLeaf       = 'Client/Delete'
             Body          = @{}
         }
-
     }
 
     process {
 
-        $clientIds = $ClientId | ForEach-Object {
-            @{ 'ClientId' = $_ }
-        }
+        if ( $PSCmdlet.ShouldProcess('Remove {0} clients' -f $ClientID.Count) ) {
+            # 5000 clients at a time is an api limitation
+            for ($i = 0; $i -lt $ClientID.Count; $i += 5000) {
 
-        $params.Body.Clients = @($clientIds)
-        $params.Body.DeleteAssociatedDevices = $RemoveAssociatedDevices.IsPresent.ToString().ToLower()
+                $clientIds = $ClientID[$i..($i + 4999)] | ForEach-Object {
+                    @{ 'ClientId' = $_ }
+                }
 
-        if ( $PSCmdlet.ShouldProcess($ClientId -join ', ') ) {
-            $response = Invoke-VenafiRestMethod @params
+                $params.Body.Clients = [array] $clientIds
+                $params.Body.DeleteAssociatedDevices = $RemoveAssociatedDevice.IsPresent.ToString().ToLower()
 
-            if ( $response.Errors ) {
-                Write-Error ($response.Errors | ConvertTo-Json)
+                $response = Invoke-VenafiRestMethod @params
+
+                if ( $response.Errors ) {
+                    Write-Error ($response.Errors | ConvertTo-Json)
+                }
             }
         }
     }

--- a/VenafiPS/Public/Search-TppHistory.ps1
+++ b/VenafiPS/Public/Search-TppHistory.ps1
@@ -1,50 +1,53 @@
-
-<#
-.SYNOPSIS
-Search TPP history for items with specific attributes
-
-.DESCRIPTION
-Items in the secret store matching the key/value provided will be found and their details returned with their associated 'current' item.
-As this function may return details on many items, optional parallel processing has been implemented.
-Be sure to use PowerShell Core, v7 or greater, to take advantage.
-
-.PARAMETER Path
-Starting path to associated current items to limit the search.
-The default is \VED\Policy.
-
-.PARAMETER Attribute
-Name and value to search.
-See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Secretstore-lookupbyassociation.php for more details.
-Note, ValidFrom will perform a greater than or equal comparison and ValidTo will perform a less than or equal comparison.
-Currently, one 1 name/value pair can be used.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TppServer must also be set.
-
-.INPUTS
-None
-
-.OUTPUTS
-PSCustomObject with the following properties:
-    Name
-    TypeName
-    Path
-    History
-
-.EXAMPLE
-Search-TppHistory -Attribute @{'ValidTo' = (Get-Date)}
-Find historical items that are still active
-
-.EXAMPLE
-Search-TppHistory -Attribute @{'ValidTo' = (Get-Date)} -Path '\ved\policy\certs'
-Find historical items that are still active and the current item starts with a specific path
-
-#>
-
 function Search-TppHistory {
+
+    <#
+    .SYNOPSIS
+    Search TPP history for items with specific attributes
+
+    .DESCRIPTION
+    Items in the secret store matching the key/value provided will be found and their details returned with their associated 'current' item.
+    As this function may return details on many items, optional parallel processing has been implemented.
+    Be sure to use PowerShell Core, v7 or greater, to take advantage.
+
+    .PARAMETER Path
+    Starting path to associated current items to limit the search.
+    The default is \VED\Policy.
+
+    .PARAMETER Attribute
+    Name and value to search.
+    See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Secretstore-lookupbyassociation.php for more details.
+    Note, ValidFrom will perform a greater than or equal comparison and ValidTo will perform a less than or equal comparison.
+    Currently, one 1 name/value pair can be used.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TppServer must also be set.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    Search-TppHistory -Attribute @{'ValidTo' = (Get-Date)}
+
+    Name     : test.gdb.com
+    TypeName : X509 Server Certificate
+    Path     : \VED\Policy\Certificates\test.gdb.com
+    History  : {@{AIACAIssuerURL=System.Object[]; AIAKeyIdentifier=F2E970BA11A64D616E78592911D7CC; C=US;
+               CDPURI=0::False; EnhancedKeyUsage=Server Authentication(1.3.6.1.5.5.7.3.1).........}}
+
+    Find historical items that are still active
+
+    .EXAMPLE
+    Search-TppHistory -Attribute @{'ValidTo' = (Get-Date)} -Path '\ved\policy\certs'
+
+    Find historical items that are still active and the current item starts with a specific path
+
+    #>
 
     [CmdletBinding()]
 
@@ -53,8 +56,7 @@ function Search-TppHistory {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             }
@@ -83,8 +85,7 @@ function Search-TppHistory {
         $activeVaultId | ForEach-Object {
             Invoke-VenafiRestMethod -UriLeaf "secretstore/ownerlookup" -Body @{'Namespace' = 'config'; 'VaultID' = $_ } -Method Post -VenafiSession $VenafiSession
         }
-    }
-    else {
+    } else {
         $activeVaultId | ForEach-Object -ThrottleLimit 100 -Parallel {
             Import-Module VenafiPS
             New-VenafiSession -Server ($using:VenafiSession).Server -AccessToken ($using:VenafiSession).Token.AccessToken
@@ -118,8 +119,7 @@ function Search-TppHistory {
 
     if ($PSVersionTable.PSVersion.Major -lt 6) {
         $certs | ForEach-Object -Process $sbGeneric
-    }
-    else {
+    } else {
         $certs | ForEach-Object -ThrottleLimit 100 -Parallel {
             Import-Module VenafiPS
             $VenafiSession = New-VenafiSession -Server ($using:VenafiSession).Server -AccessToken ($using:VenafiSession).Token.AccessToken -PassThru


### PR DESCRIPTION
- Add support for api limitation of 5k clients at a time when calling `Remove-TppClient`
- Add support for VaaS user matching rules with `New-VenafiTeam`
- Add new output format for `Get-TppAttribute` using the parameter `-New`.  Attributes will now be provided as object properties as opposed to individual objects for each property, which made it difficult to retrieve the value itself.  This new format is available for all ways of using the function including attribute, effective attribute, and policy retrieval.  This new format will become the default in the future.
- Add `Get-TppAttribute -PolicyClass -All` to retrieve all policy attributes at once
- Add `New-TppCertificate -WorkToDoTimeout` to override the global setting for a CA to issue/renew certificate
- Add setting common name, if not provided, as the object name in `New-TppCertificate`, #110 
- Fix #111, syntax error when using `New-TppCertificate -Csr`
- `-Guid` has been deprecated from `Get-TppAttribute`.