### PR TITLE
Add Import-VaasCertificate, Import-TppCertificate pipeline/parallel

### DIFF
--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData', 'certificate')
     )
 
     begin {

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -1,82 +1,84 @@
-<#
-.SYNOPSIS
-Get certificate data
-
-.DESCRIPTION
-Get certificate data from either Venafi as a Service or TPP.
-
-.PARAMETER CertificateId
-Certificate identifier.  For Venafi as a Service, this is the unique guid.  For TPP, use the full path.
-
-.PARAMETER Format
-Certificate format.  For Venafi as a Service, you can provide either PEM or DER.  For TPP, Base64, Base64 (PKCS#8), DER, JKS, PKCS #7, or PKCS #12.
-
-.PARAMETER OutPath
-Folder path to save the certificate to.  The name of the file will be determined automatically.  TPP Only...for now.
-
-.PARAMETER IncludeChain
-Include the certificate chain with the exported certificate.  Not supported with DER format.  TPP Only.
-
-.PARAMETER FriendlyName
-Label or alias to use.  Permitted with Base64 and PKCS #12 formats.  Required when Format is JKS.  TPP Only.
-
-.PARAMETER IncludePrivateKey
-DEPRECATED. Provide a value for -PrivateKeyPassword.
-
-.PARAMETER PrivateKeyPassword
-Password required to include the private key.  Not supported with DER or PKCS #7 formats.  TPP Only.
-You must adhere to the following rules:
-- Password is at least 12 characters.
-- Comprised of at least three of the following:
-    - Uppercase alphabetic letters
-    - Lowercase alphabetic letters
-    - Numeric characters
-    - Special characters
-
-.PARAMETER KeystorePassword
-Password required to retrieve the certificate in JKS format.  TPP Only.
-You must adhere to the following rules:
-- Password is at least 12 characters.
-- Comprised of at least three of the following:
-    - Uppercase alphabetic letters
-    - Lowercase alphabetic letters
-    - Numeric characters
-    - Special characters
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-CertificateId/Path from TppObject
-
-.OUTPUTS
-Vaas, System.String.  TPP, PSCustomObject.
-
-.EXAMPLE
-$certId | Export-VenafiCertificate -Format PEM
-Get certificate data from Venafi as a Service
-
-.EXAMPLE
-$cert | Export-VenafiCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
-Get certificate data and save to a file, TPP
-
-.EXAMPLE
-$cert | Export-VenafiCertificate -Format 'PKCS #7' -IncludeChain
-Get one or more certificates with the certificate chain included, TPP
-
-.EXAMPLE
-$cert | Export-VenafiCertificate -Format 'PKCS #12' -PrivateKeyPassword $cred.password
-Get one or more certificates with private key included, TPP
-
-.EXAMPLE
-$cert | Export-VenafiCertificate -FriendlyName 'MyFriendlyName' -KeystorePassword $cred.password
-Get certificates in JKS format, TPP
-
-#>
 function Export-VenafiCertificate {
+    <#
+    .SYNOPSIS
+    Get certificate data
+
+    .DESCRIPTION
+    Get certificate data from either Venafi as a Service or TPP.
+
+    .PARAMETER CertificateId
+    Certificate identifier.  For Venafi as a Service, this is the unique guid.  For TPP, use the full path.
+
+    .PARAMETER Format
+    Certificate format.
+    For Venafi as a Service, you can provide either PEM, DER, or JKS.
+    For TPP, Base64, Base64 (PKCS#8), DER, JKS, PKCS #7, or PKCS #12.
+
+    .PARAMETER OutPath
+    Folder path to save the certificate to.  The name of the file will be determined automatically.  TPP Only...for now.
+
+    .PARAMETER IncludeChain
+    Include the certificate chain with the exported certificate.  Not supported with DER format.  TPP Only.
+
+    .PARAMETER FriendlyName
+    Label or alias to use.  Permitted with Base64 and PKCS #12 formats.  Required when Format is JKS.  TPP Only.
+
+    .PARAMETER IncludePrivateKey
+    DEPRECATED. Provide a value for -PrivateKeyPassword.
+
+    .PARAMETER PrivateKeyPassword
+    Password required to include the private key.  Not supported with DER or PKCS #7 formats.  TPP Only.
+    You must adhere to the following rules:
+    - Password is at least 12 characters.
+    - Comprised of at least three of the following:
+        - Uppercase alphabetic letters
+        - Lowercase alphabetic letters
+        - Numeric characters
+        - Special characters
+
+    .PARAMETER KeystorePassword
+    Password required to retrieve the certificate in JKS format.  TPP Only.
+    You must adhere to the following rules:
+    - Password is at least 12 characters.
+    - Comprised of at least three of the following:
+        - Uppercase alphabetic letters
+        - Lowercase alphabetic letters
+        - Numeric characters
+        - Special characters
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    CertificateId / Path from TppObject
+
+    .OUTPUTS
+    Vaas, System.String.  TPP, PSCustomObject.
+
+    .EXAMPLE
+    $certId | Export-VenafiCertificate -Format PEM
+    Get certificate data from Venafi as a Service
+
+    .EXAMPLE
+    $cert | Export-VenafiCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
+    Get certificate data and save to a file, TPP
+
+    .EXAMPLE
+    $cert | Export-VenafiCertificate -Format 'PKCS #7' -IncludeChain
+    Get one or more certificates with the certificate chain included, TPP
+
+    .EXAMPLE
+    $cert | Export-VenafiCertificate -Format 'PKCS #12' -PrivateKeyPassword $cred.password
+    Get one or more certificates with private key included, TPP
+
+    .EXAMPLE
+    $cert | Export-VenafiCertificate -FriendlyName 'MyFriendlyName' -KeystorePassword $cred.password
+    Get certificates in JKS format, TPP
+
+    #>
 
     [CmdletBinding(DefaultParameterSetName = 'Vaas')]
     [Alias('Get-TppCertificate')]
@@ -96,8 +98,7 @@ function Export-VenafiCertificate {
         [ValidateScript( {
                 if (Test-Path $_ -PathType Container) {
                     $true
-                }
-                else {
+                } else {
                     Throw "Output path '$_' does not exist"
                 }
             })]
@@ -141,8 +142,7 @@ function Export-VenafiCertificate {
             if ( $Format -notin 'PEM', 'DER', 'JKS') {
                 throw "Venafi as a Service does not support the format $Format"
             }
-        }
-        else {
+        } else {
 
             if ($PrivateKeyPassword) {
 
@@ -197,9 +197,11 @@ function Export-VenafiCertificate {
             $params.Method = 'Get'
             $params.FullResponse = $true
             $response = Invoke-VenafiRestMethod @params
-            $response.Content
-        }
-        else {
+            [pscustomobject] @{
+                'CertificateData' = $response.Content -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
+            }
+
+        } else {
             $params.Method = 'Post'
             $params.UriLeaf = 'certificates/retrieve'
 
@@ -216,8 +218,7 @@ function Export-VenafiCertificate {
                     [IO.File]::WriteAllBytes($outFile, $bytes)
                     Write-Verbose ('Saved {0} with format {1}' -f $outFile, $response.Format)
                 }
-            }
-            else {
+            } else {
                 $response
             }
         }

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -81,7 +81,7 @@ function Export-VenafiCertificate {
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Vaas')]
-    [Alias('Get-TppCertificate')]
+    [Alias('Get-TppCertificate', 'Export-TppCertificate', 'Export-VaasCertificate')]
 
     param (
 

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -223,7 +223,7 @@ https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=outagede
 function Find-VenafiCertificate {
 
     [CmdletBinding(DefaultParameterSetName = 'NoParams', SupportsPaging)]
-    [Alias('Find-TppCertificate')]
+    [Alias('Find-TppCertificate', 'Find-VaasCertificate')]
 
     param (
 

--- a/VenafiPS/Public/Get-TppAttribute.ps1
+++ b/VenafiPS/Public/Get-TppAttribute.ps1
@@ -6,17 +6,12 @@ function Get-TppAttribute {
     .DESCRIPTION
     Retrieves object attributes as well as policies (aka policy attributes).
     You can either retrieve all attributes or individual ones.
-    By default, the attributes returned are not the effective policy, but that can be requested with the
-    Effective switch.
+    By default, the attributes returned are not the effective policy, but that can be requested with the -Effective switch.
     Policy folders can have attributes as well as policies which apply to the resultant objects.
     For more info on policies and how they are different than attributes, see https://docs.venafi.com/Docs/current/TopNav/Content/Policies/c_policies_tpp.php.
 
     .PARAMETER Path
     Path to the object to retrieve configuration attributes.  Just providing DN will return all attributes.
-
-    .PARAMETER Guid
-    To be deprecated; use -Path instead.
-    Object Guid.  Just providing Guid will return all attributes.
 
     .PARAMETER Attribute
     Only retrieve the value/values for this attribute
@@ -24,11 +19,11 @@ function Get-TppAttribute {
     .PARAMETER Effective
     Get the objects attribute value, once policies have been applied.
     This is not applicable to policies, only objects.
+    The output will contain the path where the policy was applied from.
 
     .PARAMETER All
-    Get all effective object attribute values.
-    This will perform 3 steps, get the object type, enumerate the attributes for the object type, and get all the effective values.
-    The output will contain the path where the policy was applied from.
+    Get all object attribute values.
+    This will perform 3 steps, get the object type, enumerate the attributes for the object type, and get all the values.
     Note, expect this to take longer than usual given the number of api calls.
 
     .PARAMETER PolicyClass
@@ -60,38 +55,77 @@ function Get-TppAttribute {
     .EXAMPLE
     Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -New
 
-    Name                                   : test.gdb.com
-    Path                                   : \ved\policy\certificates\test.gdb.com
-    TypeName                               : X509 Server Certificate
-    Guid                                   : b7a7221b-e038-41d9-9d49-d7f45c1ca128
-    Certificate Vault Id                   : @{Value=442493; CustomFieldName=; PolicyPath=}
-    Consumers                              : @{Value=System.Object[]; CustomFieldName=; PolicyPath=}
-    Created By                             : @{Value=WebAdmin; CustomFieldName=; PolicyPath=}
+    Name                          : test.gdb.com
+    Path                          : \VED\Policy\Certificates\test.gdb.com
+    TypeName                      : X509 Server Certificate
+    Guid                          : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    ServiceNow Assignment Group   : @{Value=Venafi Management; CustomFieldGuid={7f214dec-9878-495f-a96c-57291f0d42da}}
+    ServiceNow CI                 : @{Value=9cc047ed1bad81100774ebd1b24bcbd0;
+                                    CustomFieldGuid={a26df613-595b-46ef-b5df-79f6eace72d9}}
+    Certificate Vault Id          : @{Value=442493; CustomFieldGuid=}
+    Consumers                     : @{Value=System.Object[]; CustomFieldGuid=}
+    Created By                    : @{Value=WebAdmin; CustomFieldGuid=}
+    CSR Vault Id                  : @{Value=442492; CustomFieldGuid=}
 
-    Retrieve all values for an object, excluding values assigned by policy
+    Retrieve values directly set on an object, excluding values assigned by policy
 
     .EXAMPLE
     Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -Attribute 'Driver Name' -New
 
     Name        : test.gdb.com
-    Path        : \ved\policy\certificates\test.gdb.com
+    Path        : \VED\Policy\Certificates\test.gdb.com
     TypeName    : X509 Server Certificate
     Guid        : b7a7221b-e038-41d9-9d49-d7f45c1ca128
-    Driver Name : @{Value=appx509certificate; CustomFieldName=; PolicyPath=}
+    Driver Name : @{Value=appx509certificate; CustomFieldGuid=}
 
     Retrieve the value for a specific attribute
 
     .EXAMPLE
-    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -AttributeName 'State' -Effective -New
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -Attribute 'ServiceNow Assignment Group' -New
 
-    Name     : test.gdb.com
-    Path     : \ved\policy\certificates\test.gdb.com
-    TypeName : X509 Server Certificate
-    Guid     : b7a7221b-e038-41d9-9d49-d7f45c1ca128
-    State    : @{Value=UT; CustomFieldName=; PolicyPath=\VED\Policy\Certificates}
+    Name                        : test.gdb.com
+    Path                        : \VED\Policy\Certificates\test.gdb.com
+    TypeName                    : X509 Server Certificate
+    Guid                        : b7a7221b-e038-41d9-9d49-d7f45c1ca199
+    ServiceNow Assignment Group : @{Value=Venafi Management; CustomFieldGuid={7f214dec-9878-495f-a96c-57291f0d42da}}
 
-    Retrieve the effective (policy applied) value for a specific attribute.
-    This not only returns the value, but also the path where the policy is applied.
+    Retrieve the value for a custom field.
+    You can specify either the guid or custom field label name.
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -Attribute 'Organization','State' -Effective -New
+
+    Name         : test.gdb.com
+    Path         : \VED\Policy\Certificates\test.gdb.com
+    TypeName     : X509 Server Certificate
+    Guid         : b7a7221b-e038-41d9-9d49-d7f45c1ca128
+    Organization : @{Value=Venafi, Inc.; CustomFieldGuid=; Overridden=False; Locked=True;
+                PolicyPath=\VED\Policy\Certificates}
+    State        : @{Value=UT; CustomFieldGuid=; Overridden=False; Locked=False; PolicyPath=\VED\Policy\Certificates}
+
+    Retrieve the effective (policy applied) value for a specific attribute(s).
+    This not only returns the value, but also the path where the policy is applied and if locked or overridden.
+
+    .EXAMPLE
+    Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -Effective -All -New
+
+    Name                                               : test.gdb.com
+    Path                                               : \VED\Policy\certificates\test.gdb.com
+    TypeName                                           : X509 Server Certificate
+    ServiceNow Assignment Group                        : @{Value=Venafi Management;
+                                                        CustomFieldGuid={7f214dec-9878-495f-a96c-57291f0d42da};
+                                                        Overridden=False; Locked=False; PolicyPath=}
+    ServiceNow CI                                      : @{Value=9cc047ed1bad81100774ebd1b24bcbd0;
+                                                        CustomFieldGuid={a26df613-595b-46ef-b5df-79f6eace72d9};
+                                                        Overridden=False; Locked=False; PolicyPath=}
+    ACME Account DN                                    :
+    Adaptable CA:Binary Data Vault ID                  :
+    Adaptable CA:Early Password Vault ID               :
+    Adaptable CA:Early Pkcs7 Vault ID                  :
+    Adaptable CA:Early Private Key Vault ID            :
+
+    Retrieve the effective (policy applied) value for all attributes.
+    This not only returns the value, but also the path where the policy is applied and if locked or overridden.
 
     .EXAMPLE
     Get-TppAttribute -Path '\VED\Policy\certificates\test.gdb.com' -All -New
@@ -106,33 +140,33 @@ function Get-TppAttribute {
     Created By           : @{Value=WebAdmin; CustomFieldName=; PolicyPath=}
     State                : @{Value=UT; CustomFieldName=; PolicyPath=\VED\Policy\Certificates}
 
-    Retrieve all effective values for an object
+    Retrieve values for all attributes applicable to this object
 
     .EXAMPLE
-    Get-TppAttribute -Path '\VED\Policy\certificates' -PolicyClass 'X509 Certificate' -AttributeName 'State' -New
+    Get-TppAttribute -Path '\VED\Policy\certificates' -PolicyClass 'X509 Certificate' -Attribute 'State' -New
 
     Name            : certificates
-    Path            : \ved\policy\certificates
+    Path            : \VED\Policy\certificates
     TypeName        : Policy
     Guid            : a91fc152-a9fb-4b49-a7ca-7014b14d73eb
-    PolicyClassName : x509 certificate
-    State           : UT
+    PolicyClassName : X509 Certificate
+    State           : @{Value=UT; Locked=False}
 
     Retrieve specific policy attribute values for the specified policy folder and class
 
     .EXAMPLE
     Get-TppAttribute -Path '\VED\Policy\certificates' -PolicyClass 'X509 Certificate' -All -New
 
-    Name            : certificates
-    Path            : \ved\policy\certificates
-    TypeName        : Policy
-    Guid            : a91fc152-a9fb-4b49-a7ca-7014b14d73eb
-    PolicyClassName : x509 certificate
-    City            : Salt Lake City
-    Country         : US
-    Management Type : Enrollment
-    Organization    : Venafi, Inc.
-    State           : UT
+    Name                                               : certificates
+    Path                                               : \VED\Policy\certificates
+    TypeName                                           : Policy
+    PolicyClassName                                    : X509 Certificate
+    ServiceNow Assignment Group                        :
+    Certificate Authority                              :
+    Certificate Download: PBES2 Algorithm              :
+    Certificate Process Validator                      :
+    Certificate Vault Id                               :
+    City                                               : @{Value=Salt Lake City; Locked=False}
 
     Retrieve all policy attribute values for the specified policy folder and class
 
@@ -155,11 +189,12 @@ function Get-TppAttribute {
     [CmdletBinding(DefaultParameterSetName = 'ByPath')]
     param (
 
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'ByPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory, ParameterSetName = 'AllEffectivePath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory, ParameterSetName = 'PolicyPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AllByPath', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Effective', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AllEffective', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Policy', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicy', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
@@ -171,33 +206,35 @@ function Get-TppAttribute {
         [Alias('DN')]
         [String] $Path,
 
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByPath')]
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
         [Parameter(ParameterSetName = 'ByPath')]
-        [Parameter(Mandatory, ParameterSetName = 'PolicyPath')]
+        [Parameter(Mandatory, ParameterSetName = 'Policy')]
         [ValidateNotNullOrEmpty()]
         [String[]] $Attribute,
 
-        [Parameter(Mandatory, ParameterSetName = 'EffectiveByPath')]
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
+        [Parameter(Mandatory, ParameterSetName = 'AllEffective')]
         [Alias('EffectivePolicy')]
         [Switch] $Effective,
 
-        [Parameter(Mandatory, ParameterSetName = 'AllEffectivePath')]
-        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath')]
+        [Parameter(Mandatory, ParameterSetName = 'AllByPath')]
+        [Parameter(Mandatory, ParameterSetName = 'AllEffective')]
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicy')]
         [switch] $All,
 
-        [Parameter(ParameterSetName = 'PolicyPath')]
-        [Parameter(ParameterSetName = 'AllPolicyPath')]
+        [Parameter(ParameterSetName = 'Policy')]
+        [Parameter(ParameterSetName = 'AllPolicy')]
         [switch] $Policy,
 
-        [Parameter(Mandatory, ParameterSetName = 'PolicyPath')]
-        [Parameter(Mandatory, ParameterSetName = 'AllPolicyPath')]
+        [Parameter(Mandatory, ParameterSetName = 'Policy')]
+        [Parameter(Mandatory, ParameterSetName = 'AllPolicy')]
         [ValidateNotNullOrEmpty()]
         [Alias('ClassName')]
         [string] $PolicyClass,
 
-        [Parameter(ParameterSetName = 'EffectiveByPath')]
+        [Parameter(ParameterSetName = 'Effective')]
         [Parameter(ParameterSetName = 'ByPath')]
-        [Parameter(ParameterSetName = 'PolicyPath')]
+        [Parameter(ParameterSetName = 'Policy')]
         [switch] $AsValue,
 
         [Parameter()]
@@ -208,6 +245,8 @@ function Get-TppAttribute {
     )
 
     begin {
+
+        Write-Debug $PSCmdlet.ParameterSetName
 
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'TPP'
 
@@ -226,25 +265,34 @@ function Get-TppAttribute {
             Body          = @{}
         }
 
-        if ( $PolicyClass ) {
-            $params.uriLeaf = 'config/ReadPolicy'
-        } else {
-            if ( $PSBoundParameters.ContainsKey('Attribute') ) {
-                if ( $Effective ) {
-                    $params.uriLeaf = 'config/ReadEffectivePolicy'
-                } else {
+        $isEffective = $false
+        switch ( $PSCmdlet.ParameterSetName ) {
+            { $_ -in 'Policy', 'AllPolicy' } {
+                $params.uriLeaf = 'config/ReadPolicy'
+                break
+            }
+
+            { $_ -in 'Effective', 'AllEffective' } {
+                $params.uriLeaf = 'config/ReadEffectivePolicy'
+                $isEffective = $true
+                break
+            }
+
+            'AllByPath' {
+                # use config/read instead of config/readall as we will get list of attributes for this class first
+                # and then get all the values for them
+                $params.uriLeaf = 'config/read'
+                break
+            }
+
+            Default {
+                if ( $PSBoundParameters.ContainsKey('Attribute') ) {
                     $params.uriLeaf = 'config/read'
-                }
-            } else {
-                if ( $All ) {
-                    $params.uriLeaf = 'config/ReadEffectivePolicy'
                 } else {
                     $params.uriLeaf = 'config/readall'
                 }
             }
         }
-
-        $isEffective = ($params.UriLeaf -eq 'config/ReadEffectivePolicy')
     }
 
     process {
@@ -283,14 +331,25 @@ function Get-TppAttribute {
 
                 $response = Invoke-VenafiRestMethod @params
 
-                if ( $response ) {
-                    [PSCustomObject] @{
-                        Name       = $thisAttribute
-                        Value      = $response.Values
-                        PolicyPath = $response.PolicyDN
-                        Locked     = $response.Locked
-                        Overridden = $response.Overridden
+                if ( $response.Error ) {
+                    if ( $response.Result -eq 601) {
+                        Write-Error "'$thisAttribute' is not a valid attribute for $Path"
+                        continue
+                    } elseif ( $response.Result -eq 102) {
+                        # attribute is valid, but value not set
+                        # we're ok with this one
+                    } else {
+                        Write-Error $response.Error
+                        continue
                     }
+                }
+
+                [PSCustomObject] @{
+                    Name       = $thisAttribute
+                    Value      = $response.Values
+                    PolicyPath = $response.PolicyDN
+                    Locked     = $response.Locked
+                    Overridden = $response.Overridden
                 }
             }
         } else {
@@ -335,9 +394,22 @@ function Get-TppAttribute {
 
                 foreach ($thisConfigValue in $configValues) {
 
-                    $valueOut = $null
+                    # attribute name will be overridden to use the label if a custom field
+                    $newAttributeName = $thisConfigValue.Name
 
-                    if ( -not $thisConfigValue.Value ) { continue }
+                    $customField = $VenafiSession.CustomField | Where-Object { $_.Guid -eq $thisConfigValue.Name -or $_.Label -eq $thisConfigValue.Name }
+
+                    # add this attribute as the custom field label instead of guid
+                    if ( $customField ) {
+                        $newAttributeName = $customField.Label
+                    }
+
+                    if ( -not $thisConfigValue.Value ) {
+                        Add-Member -InputObject $return -NotePropertyMembers @{ $newAttributeName = $null } -Force
+                        continue
+                    }
+
+                    $valueOut = $null
 
                     switch ($thisConfigValue.Value.GetType().Name) {
                         'Object[]' {
@@ -360,22 +432,12 @@ function Get-TppAttribute {
                         }
                     }
 
-                    # attribute name will be overridden to use the label if a custom field
-                    $newAttributeName = $thisConfigValue.Name
-
                     if ( $PolicyClass ) {
                         $newProp = [pscustomobject] @{
                             Value  = $valueOut
                             Locked = $thisConfigValue.Locked
                         }
                     } else {
-
-                        $customField = $VenafiSession.CustomField | Where-Object { $_.Guid -eq $thisConfigValue.Name -or $_.Label -eq $thisConfigValue.Name }
-
-                        # add this attribute as the custom field label instead of guid
-                        if ( $customField ) {
-                            $newAttributeName = $customField.Label
-                        }
 
                         $newProp = [pscustomobject] @{
                             'Value'           = $valueOut

--- a/VenafiPS/Public/Get-TppIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-TppIdentityAttribute.ps1
@@ -10,6 +10,7 @@ The id that represents the user or group.  Use Find-TppIdentity to get the id.
 
 .PARAMETER Attribute
 Retrieve identity attribute values for the users and groups.
+Common user attributes include Group Membership, Name, Internet Email Address, Given Name, and Surname.
 
 .PARAMETER VenafiSession
 Authentication for the function.
@@ -56,7 +57,6 @@ function Get-TppIdentityAttribute {
         [string[]] $ID,
 
         [Parameter()]
-        [ValidateSet('Group Membership', 'Name', 'Internet Email Address', 'Given Name', 'Surname')]
         [string[]] $Attribute,
 
         [Parameter()]

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -67,7 +67,7 @@ function Import-TppCertificate {
 
     .EXAMPLE
     Import-TppCertificate -PolicyPath mycerts -CertificatePath (gci c:\certs).FullName
-    Import multiple certificates in parallel on PS v7.  \ved\policy will be appended to the policy path.
+    Import multiple certificates in parallel on PS v6+.  \ved\policy will be appended to the policy path.
 
     .INPUTS
     CertificatePath

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -25,15 +25,24 @@ function Import-VaasCertificate {
 
     .EXAMPLE
     Import-VaasCertificate -CertificatePath c:\www.VenafiPS.com.cer
+
     Import a certificate
 
     .EXAMPLE
     Import-VaasCertificate -CertificatePath c:\www.VenafiPS.com.cer -Application 'a2f83b26-c712-4f46-be41-2e1fb901f20c'
+
     Import a certificate and assign an application
 
     .EXAMPLE
     Import-VaasCertificate -CertificatePath (gci c:\certs).FullName
+
     Import multiple certificates
+
+    .EXAMPLE
+    Export-VenafiCertificate -CertificateId '\ved\policy\my.cert.com' -Format Base64 | Import-VaasCertificate -VenafiSession $vaas_key
+
+    Export from TPP and import into VaaS.
+    As $VenafiSession can only point to one platform at a time, in this case TPP, the session needs to be overridden for the import.
 
     .INPUTS
     CertificatePath, CertificateData

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -45,6 +45,12 @@ function Import-VaasCertificate {
     Export from TPP and import into VaaS.
     As $VenafiSession can only point to one platform at a time, in this case TPP, the session needs to be overridden for the import.
 
+    .EXAMPLE
+    Find-TppCertificate -Path '\ved\policy\certs' -Recursive | Export-VenafiCertificate -Format Base64 | Import-VaasCertificate -VenafiSession $vaas_key
+
+    Bulk export from TPP and import into VaaS.
+    As $VenafiSession can only point to one platform at a time, in this case TPP, the session needs to be overridden for the import.
+
     .INPUTS
     CertificatePath, CertificateData
 

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -4,7 +4,8 @@ function Import-VaasCertificate {
     Import one or more certificates
 
     .DESCRIPTION
-    Import one or more certificates
+    Import one or more certificates.
+    The blocklist will be overridden.
 
     .PARAMETER CertificatePath
     Path to a certificate file.  Provide either this or CertificateData.
@@ -93,7 +94,9 @@ function Import-VaasCertificate {
             Method        = 'Post'
             UriRoot       = 'outagedetection/v1'
             UriLeaf       = 'certificates'
-            Body          = @{}
+            Body          = @{
+                'overrideBlocklist' = 'true'
+            }
         }
 
         $allCerts = [System.Collections.Generic.List[object]]::new()

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -1,0 +1,133 @@
+function Import-VaasCertificate {
+    <#
+    .SYNOPSIS
+    Import one or more certificates
+
+    .DESCRIPTION
+    Import one or more certificates
+
+    .PARAMETER CertificatePath
+    Path to a certificate file.  Provide either this or CertificateData.
+
+    .PARAMETER CertificateData
+    Contents of a certificate to import.  Provide either this or CertificatePath.
+
+    .PARAMETER Application
+    Application to assign to this certificate
+
+    .PARAMETER PassThru
+    Return imported certificate details
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A VaaS key can also provided.
+
+    .EXAMPLE
+    Import-VaasCertificate -CertificatePath c:\www.VenafiPS.com.cer
+    Import a certificate
+
+    .EXAMPLE
+    Import-VaasCertificate -CertificatePath c:\www.VenafiPS.com.cer -Application 'a2f83b26-c712-4f46-be41-2e1fb901f20c'
+    Import a certificate and assign an application
+
+    .EXAMPLE
+    Import-VaasCertificate -CertificatePath (gci c:\certs).FullName
+    Import multiple certificates
+
+    .INPUTS
+    CertificatePath, CertificateData
+
+    .OUTPUTS
+    PSCustomObject, if PassThru provided
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=outagedetection-service#/Certificates/certificateimports_create
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'ByFile')]
+
+    param (
+
+        [Parameter(Mandatory, ParameterSetName = 'ByFile', ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-Path ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid path"
+                }
+            })]
+        [Alias('FullName')]
+        [String[]] $CertificatePath,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByData', ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [String[]] $CertificateData,
+
+        [Parameter()]
+        [String[]] $Application,
+
+        [Parameter()]
+        [switch] $PassThru,
+
+        [Parameter()]
+        [psobject] $VenafiSession = $script:VenafiSession
+    )
+
+    begin {
+
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
+
+        $params = @{
+            VenafiSession = $VenafiSession
+            Method        = 'Post'
+            UriRoot       = 'outagedetection/v1'
+            UriLeaf       = 'certificates'
+            Body          = @{}
+        }
+
+        $allCerts = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+
+        if ( $PSCmdlet.ParameterSetName -like 'ByFile*' ) {
+            foreach ($thisCertPath in $CertificatePath) {
+                if ($PSVersionTable.PSVersion.Major -lt 6) {
+                    $cert = Get-Content $thisCertPath -Encoding Byte
+                } else {
+                    $cert = Get-Content $thisCertPath -AsByteStream
+                }
+                $allCerts.Add(
+                    @{
+                        'certificate'    = [System.Convert]::ToBase64String($cert)
+                        'applicationIds' = $Application
+                    }
+                )
+            }
+        } else {
+            foreach ($thisCertData in $CertificateData) {
+                $allCerts.Add(
+                    @{
+                        'certificate'    = $thisCertData
+                        'applicationIds' = $Application
+                    }
+                )
+            }
+        }
+
+    }
+
+    end {
+        $params.Body.certificates = $allCerts
+
+        $response = Invoke-VenafiRestMethod @params
+
+        Write-Verbose $response.statistics
+
+        if ( $PassThru ) {
+            $response.certificateInformations
+        }
+    }
+}

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -73,10 +73,6 @@ function New-VenafiSession {
     To clear the metadata, reauthenticate with this function with a credential and without providing -VaultMetadata.
     To use this parameter, the SecretManagement vault must support it.
 
-    .PARAMETER NoCF
-    Bypass pulling in custom field definitions which assists in guid to name translation.
-    Useful when a large amount of data is contained in the definition, eg. long list of allowed values.
-
     .PARAMETER PassThru
     Optionally, send the session object to the pipeline instead of script scope.
 

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -272,9 +272,6 @@ function New-VenafiSession {
         [string] $VaultVaasKeyName,
 
         [Parameter()]
-        [switch] $NoCF,
-
-        [Parameter()]
         [switch] $PassThru
     )
 
@@ -511,7 +508,7 @@ function New-VenafiSession {
 
     # will fail if user is on an older version.  this isn't required so bypass on failure
     # only applicable to tpp
-    if ( $PSCmdlet.ParameterSetName -notin 'Vaas', 'VaultVaasKey' -and -not $NoCF ) {
+    if ( $PSCmdlet.ParameterSetName -notin 'Vaas', 'VaultVaasKey' ) {
         $newSession.Version = (Get-TppVersion -VenafiSession $newSession -ErrorAction SilentlyContinue)
         $certFields = 'X509 Certificate', 'Device', 'Application Base' | Get-TppCustomField -VenafiSession $newSession -ErrorAction SilentlyContinue
         # make sure we remove duplicates
@@ -523,5 +520,4 @@ function New-VenafiSession {
     } else {
         $Script:VenafiSession = $newSession
     }
-    # }
 }

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -303,10 +303,10 @@ function New-VenafiSession {
 
     Write-Verbose ('Parameter set: {0}' -f $PSCmdlet.ParameterSetName)
 
-    if ( $PSCmdlet.ParameterSetName -like 'Vault*') {
+    if ( $PSBoundParameters.Keys -like 'Vault*') {
         # ensure the appropriate setup has been performed
         if ( -not (Get-Module -Name Microsoft.PowerShell.SecretManagement -ListAvailable)) {
-            throw 'The module Microsoft.PowerShell.SecretManagement is required as well as a vault named ''VenafiPS''.  See the github readme for guidance, https://github.com/Venafi/VenafiPS#tokenkey-secret-storage.'
+            throw 'Vault functionality requires the module Microsoft.PowerShell.SecretManagement as well as a vault named ''VenafiPS''.  See the github readme for guidance, https://github.com/Venafi/VenafiPS#tokenkey-secret-storage.'
         }
 
         $vault = Get-SecretVault -Name 'VenafiPS' -ErrorAction SilentlyContinue

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -101,7 +101,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Test-TppObject', 'Test-TppToken', 'Write-TppLog', 'Get-VenafiTeam',
                'Remove-VenafiTeam', 'Add-VenafiTeamMember', 'Add-VenafiTeamOwner',
                'Remove-VenafiTeamMember', 'Remove-VenafiTeamOwner', 'New-VenafiTeam',
-               'Search-TppHistory', 'Get-VaasIssuingTemplate', 'New-VaasApplication'
+               'Search-TppHistory', 'Get-VaasIssuingTemplate', 'New-VaasApplication','Import-VaasCertificate'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -112,7 +112,7 @@ VariablesToExport = 'VenafiSession'
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = 'fto', 'itcr', 'Find-TppCertificate', 'Get-TppIdentity', 'Read-TppLog',
                'Invoke-TppRestMethod', 'Get-TppCertificate',
-               'Get-TppCertificateDetail'
+               'Get-TppCertificateDetail', 'Find-VaasCertificate', 'Export-TppCertificate', 'Export-VaasCertificate'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()


### PR DESCRIPTION
- Add `Import-VaasCertificate`.  Export from TPP right into VaaS (and vice versa).
- Fix SecretManagement module existence check not always being triggered, #123
- `Import-TppCertificate` updates
  - Add pipelining from either certificate path or data.  You can provide FileInfo objects or just an array of paths.
  - If using PS v6+, import will now use parallel processing.  Control the number of certificates imported at once with the new parameter `-ThrottleLimit`.
  - Add prepending '\ved\policy' to `-PolicyPath` if not provided
 - Add 'certificate' field to `Write-VerboseWithSecret` to hide certificate data being passed to VaaS
 - Allow any attribute names for `Get-TppIdentityAttribute -Attribute`, #125 
 - `Get-TppAttribute` updates
   - `-Attribute` can now accept custom field labels/names to retrieve the value, #74 
   - Return Locked and Overridden values where applicable
   - Notify user when attribute name provided to `-Attribute` is not valid