### PR TITLE
Team and identity enhancements/fixes

### DIFF
--- a/VenafiPS/Classes/TppObject.ps1
+++ b/VenafiPS/Classes/TppObject.ps1
@@ -14,7 +14,8 @@ class TppObject {
         $this.Path = $Path.Replace('\\', '\')
         $this.TypeName = $TypeName
         $this.Guid = $Guid
-        $this.Name = Split-Path -Path $this.Path -Leaf
+        # issue 129
+        $this.Name = $this.Path.Split('\')[-1]
         $this.ParentPath = $this.Path.Replace(('\{0}' -f $this.Name), '')
         $this | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.Path } -Force
     }

--- a/VenafiPS/Private/ConvertTo-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Private/ConvertTo-TppCodeSignEnvironment.ps1
@@ -35,7 +35,7 @@ function ConvertTo-TppCodeSignEnvironment {
         $InputObject | Select-Object  -Property `
         @{
             n = 'Name'
-            e = { ($_.DN).Path.Split('\')[-1] }
+            e = { ($_.DN).Split('\')[-1] }
         },
         @{
             n = 'Path'

--- a/VenafiPS/Private/ConvertTo-TppCodeSignEnvironment.ps1
+++ b/VenafiPS/Private/ConvertTo-TppCodeSignEnvironment.ps1
@@ -1,24 +1,24 @@
-<#
-.SYNOPSIS
-Convert code sign certificate environment to something powershell friendly
-
-.DESCRIPTION
-Convert code sign certificate environment to something powershell friendly
-
-.PARAMETER InputObject
-Code sign certificate environment object
-
-.INPUTS
-InputObject
-
-.OUTPUTS
-PSCustomObject
-
-.EXAMPLE
-$envObj | ConvertTo-TppCodeSignEnvironment
-
-#>
 function ConvertTo-TppCodeSignEnvironment {
+    <#
+    .SYNOPSIS
+    Convert code sign certificate environment to something powershell friendly
+
+    .DESCRIPTION
+    Convert code sign certificate environment to something powershell friendly
+
+    .PARAMETER InputObject
+    Code sign certificate environment object
+
+    .INPUTS
+    InputObject
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    $envObj | ConvertTo-TppCodeSignEnvironment
+
+    #>
 
     [CmdletBinding()]
 
@@ -35,7 +35,7 @@ function ConvertTo-TppCodeSignEnvironment {
         $InputObject | Select-Object  -Property `
         @{
             n = 'Name'
-            e = { Split-Path $_.DN -Leaf }
+            e = { ($_.DN).Path.Split('\')[-1] }
         },
         @{
             n = 'Path'

--- a/VenafiPS/Private/ConvertTo-TppCodeSignProject.ps1
+++ b/VenafiPS/Private/ConvertTo-TppCodeSignProject.ps1
@@ -35,7 +35,7 @@ function ConvertTo-TppCodeSignProject {
         $InputObject | Select-Object -Property `
         @{
             n = 'Name'
-            e = { ($_.DN).Path.Split('\')[-1] }
+            e = { ($_.DN).Split('\')[-1] }
         },
         @{
             n = 'Path'

--- a/VenafiPS/Private/ConvertTo-TppCodeSignProject.ps1
+++ b/VenafiPS/Private/ConvertTo-TppCodeSignProject.ps1
@@ -1,24 +1,24 @@
-<#
-.SYNOPSIS
-Convert code sign project to something powershell friendly
-
-.DESCRIPTION
-Convert code sign project to something powershell friendly
-
-.PARAMETER InputObject
-Code sign project object
-
-.INPUTS
-InputObject
-
-.OUTPUTS
-PSCustomObject
-
-.EXAMPLE
-$envObj | ConvertTo-TppCodeSignProject
-
-#>
 function ConvertTo-TppCodeSignProject {
+    <#
+    .SYNOPSIS
+    Convert code sign project to something powershell friendly
+
+    .DESCRIPTION
+    Convert code sign project to something powershell friendly
+
+    .PARAMETER InputObject
+    Code sign project object
+
+    .INPUTS
+    InputObject
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    $envObj | ConvertTo-TppCodeSignProject
+
+    #>
 
     [CmdletBinding()]
 
@@ -35,7 +35,7 @@ function ConvertTo-TppCodeSignProject {
         $InputObject | Select-Object -Property `
         @{
             n = 'Name'
-            e = { Split-Path $_.DN -Leaf }
+            e = { ($_.DN).Path.Split('\')[-1] }
         },
         @{
             n = 'Path'

--- a/VenafiPS/Private/Test-TppDnPath.ps1
+++ b/VenafiPS/Private/Test-TppDnPath.ps1
@@ -4,18 +4,17 @@ function Test-TppDnPath {
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
-        [string[]] $Path,
+        [string] $Path,
 
         [Parameter()]
-        [switch] $AllowRoot
+        [bool] $AllowRoot = $true
     )
 
     process {
         if ( $AllowRoot ) {
-            $_ -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)*$'
-        }
-        else {
-            $_ -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)+$'
+            $Path -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)*$'
+        } else {
+            $Path -imatch '^[\\|\\\\]+ved([\\|\\\\]+.+)+$'
         }
     }
 }

--- a/VenafiPS/Private/Test-TppIdentityFormat.ps1
+++ b/VenafiPS/Private/Test-TppIdentityFormat.ps1
@@ -1,23 +1,82 @@
 function Test-TppIdentityFormat {
 
+    <#
+    .SYNOPSIS
+        Validate identity formats
+    .DESCRIPTION
+        Validate the format for identities prefixed name, prefixed universal, and local.
+        As these formats are often interchangeable with api calls, you can validate multiple formats at once.
+        By default, prefixed name and prefixed universal will be validated.
+    .PARAMETER Identity
+        The identity string to be validated
+    .PARAMETER Format
+        Format to validate, Name, Universal, and/or Local.
+    .EXAMPLE
+        Test-TppIdentityFormat -ID "AD+BigSur:cypher"
+
+        Test the identity against all formats.  This would succeed for Name, but fail on Universal
+    .EXAMPLE
+        Test-TppIdentityFormat -ID "AD+BigSur:cypher" -Format Name
+
+        Test the identity against a specific format.
+    #>
+
     [CmdletBinding()]
     [OutputType([System.Boolean])]
 
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [string] $Identity,
+        [string] $ID,
 
         [Parameter()]
-        [ValidateSet('Name', 'Universal')]
-        [string] $Type = 'Universal'
+        [ValidateSet('Name', 'Universal', 'Local')]
+        [string[]] $Format = @('Name', 'Universal')
     )
 
+    begin {
+
+        # https://docs.microsoft.com/en-US/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#domain-names
+        $prefixRegex = '(?im)^(local|(AD|LDAP)\+[a-z0-9\-]{1,15}):'
+        $localPrefixRegex = '(?im)^local:'
+        $nameRegex = '.+$'
+        $universalRegex = '\{?([0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12})\}?$'
+
+        $success = $false
+    }
     process {
 
-        if ( $Type -eq 'Universal' ) {
-            $Identity -match '^(AD|LDAP)+.+:\w{32}$' -or $Identity -match '^local:\{?\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\}?$'
-        } else {
-            #TODO
+        foreach ($thisType in $Format) {
+            switch ($thisType) {
+
+                'Name' {
+                    $thisMatch = $ID -match ($prefixRegex + $nameRegex)
+                    if ( $thisMatch ) {
+                        Write-Verbose "$ID is a valid name identity"
+                    }
+                }
+
+                'Universal' {
+                    $thisMatch = $ID -match ($prefixRegex + $universalRegex)
+                    if ( $thisMatch ) {
+                        Write-Verbose "$ID is a valid universal identity"
+                    }
+                }
+
+                'Local' {
+                    $thisMatch = $ID -match ($localPrefixRegex + $nameRegex) -or $ID -match ($localPrefixRegex + $universalRegex)
+                    if ( $thisMatch ) {
+                        Write-Verbose "$ID is a valid local identity"
+                    }
+                }
+            }
+
+            if ( $thisMatch ) {
+                $success = $true
+            }
         }
+    }
+
+    end {
+        $success
     }
 }

--- a/VenafiPS/Public/Find-TppObject.ps1
+++ b/VenafiPS/Public/Find-TppObject.ps1
@@ -103,7 +103,7 @@ function Find-TppObject {
         [Parameter(ParameterSetName = 'FindByPattern', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
-                if ( $_ | Test-TppDnPath -AllowRoot ) {
+                if ( $_ | Test-TppDnPath ) {
                     $true
                 }
                 else {

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -230,7 +230,7 @@ function Find-VenafiCertificate {
         [Parameter(ParameterSetName = 'TPP', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
-                if ( $_ | Test-TppDnPath -AllowRoot ) {
+                if ( $_ | Test-TppDnPath ) {
                     $true
                 }
                 else {

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -1,67 +1,69 @@
-﻿<#
-.SYNOPSIS
-Get Team info
+﻿function Get-VenafiTeam {
+    <#
+    .SYNOPSIS
+    Get Team info
 
-.DESCRIPTION
-Get info for a VaaS or TPP team including members and owners.
-For VaaS, you can retrieve info on all teams as well.
+    .DESCRIPTION
+    Get info for a VaaS or TPP team including members and owners.
+    For VaaS, you can retrieve info on all teams as well.
 
-.PARAMETER ID
-Team ID, required for TPP.
-For VaaS, this is the team guid.
-For TPP, this is the local prefixed universal ID.  You can find the group ID with Find-TppIdentity.
+    .PARAMETER ID
+    Team ID, required for TPP.
+    For VaaS, this is the team guid.
+    For TPP, this is the local prefixed universal ID.  You can find the group ID with Find-TppIdentity.
 
-.PARAMETER All
-Provide this switch to get all teams
+    .PARAMETER All
+    Provide this switch to get all teams
 
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
 
-.INPUTS
-ID
+    .INPUTS
+    ID
 
-.OUTPUTS
-PSCustomObject
+    .OUTPUTS
+    PSCustomObject
 
-.EXAMPLE
-Get-VenafiTeam -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    .EXAMPLE
+    Get-VenafiTeam -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
-Get info for a VaaS team
+    Get info for a VaaS team
 
-.EXAMPLE
-Get-VenafiTeam -ID 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}'
+    .EXAMPLE
+    Get-VenafiTeam -ID 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}'
 
-Get info for a TPP team
+    Get info for a TPP team
 
-.EXAMPLE
-Find-TppIdentity -Name MyTeamName | Get-VenafiTeam
+    .EXAMPLE
+    Find-TppIdentity -Name MyTeamName | Get-VenafiTeam
 
-Search for a team and then get details
+    Search for a team and then get details
 
-.EXAMPLE
-Get-VenafiTeam -All
+    .EXAMPLE
+    Get-VenafiTeam -All
 
-Get info for all teams
+    Get info for all teams
 
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Teams/get_2
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Teams/get_2
 
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Teams/get_1
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Teams/get_1
 
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Teams-prefix-universal.php
-#>
-function Get-VenafiTeam {
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Teams-prefix-universal.php
+    #>
 
     [CmdletBinding()]
+    [Alias('Get-TppTeam', 'Get-VaasTeam')]
+
     param (
 
-        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName)]
-        [Alias('PrefixedUniversal', 'Guid')]
+        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        [Alias('PrefixedUniversal', 'Guid', 'PrefixedName')]
         [string] $ID,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
@@ -85,53 +87,59 @@ function Get-VenafiTeam {
 
         if ( $platform -eq 'VaaS' ) {
 
-            if ( $Id ) {
-                $params.UriLeaf = "teams/$ID"
-            }
-            else {
+            if ( $PSCmdlet.ParameterSetName -eq 'All' ) {
                 $params.UriLeaf = 'teams'
+            } else {
+                if ( [guid]::TryParse($ID, $([ref][guid]::Empty)) ) {
+                    $guid = [guid] $ID
+                    $params.UriLeaf = 'teams/{0}' -f $guid.ToString()
+                } else {
+                    Write-Error "'$ID' is not the proper format for a Team.  Format should be a guid."
+                    return
+                }
             }
 
             $response = Invoke-VenafiRestMethod @params
 
             if ( $response.PSObject.Properties.Name -contains 'teams' ) {
                 $response | Select-Object -ExpandProperty teams
-            }
-            else {
+            } else {
                 $response
             }
-        }
-        else {
+        } else {
             if ( $PSCmdlet.ParameterSetName -eq 'All' ) {
 
                 # no built-in api for this, get group objects and then get details
-                Find-TppObject -Path '\VED\Identity' -Class 'Group' -VenafiSession $VenafiSession | Where-Object {$_.Name -ne 'Everyone'} | Get-VenafiTeam -VenafiSession $VenafiSession
-            }
-            else {
+                Find-TppObject -Path '\VED\Identity' -Class 'Group' -VenafiSession $VenafiSession | Where-Object { $_.Name -ne 'Everyone' } | Get-VenafiTeam -VenafiSession $VenafiSession
+            } else {
 
-                # check if just a guid or prefixed universal id
-                if ( Test-TppIdentityFormat -Identity $ID ) {
-                    $guid = [guid]($ID.Replace('local:', ''))
+                # not only does -match set $matches, but -notmatch does as well
+                if ( $ID -notmatch '(?im)^(local:)?\{?([0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12})\}?$' ) {
+                    Write-Error "'$ID' is not the proper format for a Team.  Format should either be a guid or local:{guid}."
+                    return
                 }
-                else {
-                    try {
-                        $guid = [guid] $ID
+
+                $params.UriLeaf = ('Teams/local/{{{0}}}' -f $matches[2])
+
+                try {
+
+                    $response = Invoke-VenafiRestMethod @params
+
+                    $out = [pscustomobject] ($response.ID | ConvertTo-TppIdentity)
+                    $out | Add-Member @{
+                        Members = $response.Members | ConvertTo-TppIdentity
+                        Owners  = $response.Owners | ConvertTo-TppIdentity
                     }
-                    catch {
-                        Write-Error "$ID is not a valid team id"
-                        Continue
+                    $out
+                } catch {
+
+                    # handle known errors where the local group is not actually a team
+                    if ( $_.ErrorDetails.Message -like '*Failed to read the team identity;*' ) {
+                        Write-Error "$ID looks to be a local group and not a Team.  The server responded with $_"
+                    } else {
+                        Write-Error "$ID : $_"
                     }
                 }
-                $params.UriLeaf = ('Teams/local/{{{0}}}' -f $guid.ToString())
-
-                $response = Invoke-VenafiRestMethod @params
-
-                $out = [pscustomobject] ($response.ID | ConvertTo-TppIdentity)
-                $out | Add-Member @{
-                    Members = $response.Members | ConvertTo-TppIdentity
-                    Owners  = $response.Owners | ConvertTo-TppIdentity
-                }
-                $out
             }
         }
     }

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -62,7 +62,7 @@
 
     param (
 
-        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName)]
         [Alias('PrefixedUniversal', 'Guid', 'PrefixedName')]
         [string] $ID,
 

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -105,7 +105,7 @@ function Move-TppObject {
         # if target is a policy, append the object name from source
         if ( $targetIsPolicy ) {
             # get object name, issue 129
-            $childPath = $SourcePath.Path.Split('\')[-1]
+            $childPath = $SourcePath.Split('\')[-1]
             $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath $childPath
         }
 

--- a/VenafiPS/Public/Move-TppObject.ps1
+++ b/VenafiPS/Public/Move-TppObject.ps1
@@ -104,7 +104,9 @@ function Move-TppObject {
 
         # if target is a policy, append the object name from source
         if ( $targetIsPolicy ) {
-            $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath (Split-Path -Path $SourcePath -Leaf)
+            # get object name, issue 129
+            $childPath = $SourcePath.Path.Split('\')[-1]
+            $params.Body.NewObjectDN = Join-Path -Path $TargetPath -ChildPath $childPath
         }
 
         if ( $PSCmdlet.ShouldProcess($SourcePath, ('Move to {0}' -f $params.Body.NewObjectDN)) ) {

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -1,108 +1,108 @@
-<#
-.SYNOPSIS
-Create a new CAPI application
-
-.DESCRIPTION
-Create a new CAPI application
-
-.PARAMETER Path
-Full path, including name, to the application to be created.  The application must be created under a device.
-Alternatively, provide the path to the device and provide ApplicationName.
-
-.PARAMETER ApplicationName
-1 or more application names to create.  Path property must be a path to a device.
-
-.PARAMETER CertificatePath
-Path to the certificate to associate to the new application
-
-.PARAMETER CredentialPath
-Path to the associated credential which has rights to access the connected device
-
-.PARAMETER FriendlyName
-The Friendly Name that helps to uniquely identify the certificate after it has been installed in the Windows CAPI store
-
-.PARAMETER Descripion
-Application description
-
-.PARAMETER WinRmPort
-WinRM port to connect to application on
-
-.PARAMETER Disable
-Set processing to disabled.  It is enabled by default.
-
-.PARAMETER WebSiteName
-The unique name of the IIS web site
-
-.PARAMETER BindingIp
-The IP address to bind the certificate to the IIS web site. If not specified, the Internet Information Services (IIS) Manager console shows 'All Unassigned'.
-
-.PARAMETER BindingPort
-The TCP port 1 to 65535 to bind the certificate to the IIS web site
-
-.PARAMETER BindingHostName
-The hostname to bind the certificate to the IIS web site. Specifying this value will make it so the certificate is only accessible to clients using Server Name Indication (SNI)
-
-.PARAMETER CreateBinding
-Specify that Trust Protection Platform should create an IIS web site binding if the one specified doesn’t already exist.
-
-.PARAMETER PushCertificate
-Push the certificate to the application.  CertificatePath must be provided.
-
-.PARAMETER SkipExistenceCheck
-By default, the paths for the new application, certifcate, and credential will be validated for existence.
-Specify this switch to bypass this check.
-
-.PARAMETER PassThru
-Return a TppObject representing the newly created capi app.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-Path
-
-.OUTPUTS
-TppObject, if PassThru provided
-
-.EXAMPLE
-New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path
-Create a new application
-
-.EXAMPLE
-New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -WebSiteName 'mysite' -BindingIp '1.2.3.4'
-Create a new application and update IIS
-
-.EXAMPLE
-New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -WebSiteName 'mysite' -BindingIp '1.2.3.4' -PushCertificate
-Create a new application, update IIS, and push the certificate to the new app
-
-.EXAMPLE
-New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -PassThru
-Create a new application and return a TppObject for the newly created app
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/New-TppCapiApplication/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppCapiApplication.ps1
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppObject.ps1
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Find-TppCertificate/
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppObject/
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-create.php
-
-#>
 function New-TppCapiApplication {
+    <#
+    .SYNOPSIS
+    Create a new CAPI application
+
+    .DESCRIPTION
+    Create a new CAPI application
+
+    .PARAMETER Path
+    Full path, including name, to the application to be created.  The application must be created under a device.
+    Alternatively, provide the path to the device and provide ApplicationName.
+
+    .PARAMETER ApplicationName
+    1 or more application names to create.  Path property must be a path to a device.
+
+    .PARAMETER CertificatePath
+    Path to the certificate to associate to the new application
+
+    .PARAMETER CredentialPath
+    Path to the associated credential which has rights to access the connected device
+
+    .PARAMETER FriendlyName
+    The Friendly Name that helps to uniquely identify the certificate after it has been installed in the Windows CAPI store
+
+    .PARAMETER Descripion
+    Application description
+
+    .PARAMETER WinRmPort
+    WinRM port to connect to application on
+
+    .PARAMETER Disable
+    Set processing to disabled.  It is enabled by default.
+
+    .PARAMETER WebSiteName
+    The unique name of the IIS web site
+
+    .PARAMETER BindingIp
+    The IP address to bind the certificate to the IIS web site. If not specified, the Internet Information Services (IIS) Manager console shows 'All Unassigned'.
+
+    .PARAMETER BindingPort
+    The TCP port 1 to 65535 to bind the certificate to the IIS web site
+
+    .PARAMETER BindingHostName
+    The hostname to bind the certificate to the IIS web site. Specifying this value will make it so the certificate is only accessible to clients using Server Name Indication (SNI)
+
+    .PARAMETER CreateBinding
+    Specify that Trust Protection Platform should create an IIS web site binding if the one specified doesn’t already exist.
+
+    .PARAMETER PushCertificate
+    Push the certificate to the application.  CertificatePath must be provided.
+
+    .PARAMETER SkipExistenceCheck
+    By default, the paths for the new application, certifcate, and credential will be validated for existence.
+    Specify this switch to bypass this check.
+
+    .PARAMETER PassThru
+    Return a TppObject representing the newly created capi app.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    Path
+
+    .OUTPUTS
+    TppObject, if PassThru provided
+
+    .EXAMPLE
+    New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path
+    Create a new application
+
+    .EXAMPLE
+    New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -WebSiteName 'mysite' -BindingIp '1.2.3.4'
+    Create a new application and update IIS
+
+    .EXAMPLE
+    New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -WebSiteName 'mysite' -BindingIp '1.2.3.4' -PushCertificate
+    Create a new application, update IIS, and push the certificate to the new app
+
+    .EXAMPLE
+    New-TppCapiApplication -Path '\ved\policy\mydevice\capi' -CertificatePath $cert.Path -CredentialPath $cred.Path -PassThru
+    Create a new application and return a TppObject for the newly created app
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/New-TppCapiApplication/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppCapiApplication.ps1
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppObject.ps1
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Find-TppCertificate/
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppObject/
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-create.php
+
+    #>
 
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'NonIis')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '')]
@@ -113,8 +113,7 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -129,8 +128,7 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -142,8 +140,7 @@ function New-TppCapiApplication {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -210,7 +207,8 @@ function New-TppCapiApplication {
         if ( -not $PSBoundParameters.ContainsKey('SkipExistenceCheck') ) {
 
             if ( $PSBoundParameters.ContainsKey('CertificatePath') ) {
-                $certName = (Split-Path -Path $CertificatePath -Leaf)
+                # issue 129
+                $certName = $CertificatePath.Path.Split('\')[-1]
                 $certPath = $CertificatePath -replace ('\\+{0}' -f $certName), ''
 
                 $certObject = Find-TppCertificate -Path $certPath -VenafiSession $VenafiSession
@@ -290,9 +288,9 @@ function New-TppCapiApplication {
             # ensure the parent path exists and is of type device
             if ( $PSBoundParameters.ContainsKey('ApplicationName') ) {
                 $devicePath = $Path
-            }
-            else {
-                $devicePath = $Path -replace ('\\+{0}' -f (Split-Path $Path -Leaf)), ''
+            } else {
+                $deviceName = $Path.Path.Split('\')[-1]
+                $devicePath = $Path -replace ('\\+{0}' -f $deviceName), ''
             }
 
             $device = Get-TppObject -Path $devicePath -VenafiSession $VenafiSession
@@ -301,8 +299,7 @@ function New-TppCapiApplication {
                 if ( $device.TypeName -ne 'Device' ) {
                     throw ('A device object could not be found at ''{0}''' -f $devicePath)
                 }
-            }
-            else {
+            } else {
                 throw ('No object was found at the parent path ''{0}''' -f $devicePath)
             }
         }
@@ -311,8 +308,7 @@ function New-TppCapiApplication {
             $appPaths = $ApplicationName | ForEach-Object {
                 $Path + "\$_"
             }
-        }
-        else {
+        } else {
             $appPaths = @($Path)
         }
 

--- a/VenafiPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiPS/Public/New-TppCapiApplication.ps1
@@ -208,7 +208,7 @@ function New-TppCapiApplication {
 
             if ( $PSBoundParameters.ContainsKey('CertificatePath') ) {
                 # issue 129
-                $certName = $CertificatePath.Path.Split('\')[-1]
+                $certName = $CertificatePath.Split('\')[-1]
                 $certPath = $CertificatePath -replace ('\\+{0}' -f $certName), ''
 
                 $certObject = Find-TppCertificate -Path $certPath -VenafiSession $VenafiSession
@@ -289,7 +289,7 @@ function New-TppCapiApplication {
             if ( $PSBoundParameters.ContainsKey('ApplicationName') ) {
                 $devicePath = $Path
             } else {
-                $deviceName = $Path.Path.Split('\')[-1]
+                $deviceName = $Path.Split('\')[-1]
                 $devicePath = $Path -replace ('\\+{0}' -f $deviceName), ''
             }
 

--- a/VenafiPS/Public/Remove-VenafiTeam.ps1
+++ b/VenafiPS/Public/Remove-VenafiTeam.ps1
@@ -61,7 +61,7 @@ function Remove-VenafiTeam {
         }
         else {
             # check if just a guid or prefixed universal id
-            if ( Test-TppIdentityFormat -Identity $ID ) {
+            if ( Test-TppIdentityFormat -ID $ID -Format 'Local' ) {
                 $guid = [guid]($ID.Replace('local:', ''))
             }
             else {

--- a/VenafiPS/Public/Test-TppIdentity.ps1
+++ b/VenafiPS/Public/Test-TppIdentity.ps1
@@ -1,51 +1,52 @@
-<#
-.SYNOPSIS
-Test if an identity exists
-
-.DESCRIPTION
-Provided with a prefixed universal id, find out if an identity exists.
-
-.PARAMETER Identity
-The id that represents the user or group.
-
-.PARAMETER ExistOnly
-Only return boolean instead of ID and Exists list.  Helpful when validating just 1 identity.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-Identity
-
-.OUTPUTS
-PSCustomObject will be returned with properties 'ID', a System.String, and 'Exists', a System.Boolean.
-
-.EXAMPLE
-'local:78uhjny657890okjhhh', 'AD+mydomain.com:azsxdcfvgbhnjmlk09877654321' | Test-TppIdentity
-
-Test multiple identities
-
-.EXAMPLE
-Test-TppIdentity -Identity 'AD+mydomain.com:azsxdcfvgbhnjmlk09877654321' -ExistOnly
-
-Retrieve existence for only one identity, returns boolean
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Test-TppIdentity/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Test-TppIdentity.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php
-
-#>
 function Test-TppIdentity {
+    <#
+    .SYNOPSIS
+    Test if an identity exists
+
+    .DESCRIPTION
+    Provided with a prefixed universal id, find out if an identity exists.
+
+    .PARAMETER Identity
+    The id that represents the user or group.
+
+    .PARAMETER ExistOnly
+    Only return boolean instead of ID and Exists list.  Helpful when validating just 1 identity.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    Identity
+
+    .OUTPUTS
+    PSCustomObject will be returned with properties 'ID', a System.String, and 'Exists', a System.Boolean.
+
+    .EXAMPLE
+    'local:78uhjny657890okjhhh', 'AD+mydomain.com:azsxdcfvgbhnjmlk09877654321' | Test-TppIdentity
+
+    Test multiple identities
+
+    .EXAMPLE
+    Test-TppIdentity -Identity 'AD+mydomain.com:azsxdcfvgbhnjmlk09877654321' -ExistOnly
+
+    Retrieve existence for only one identity, returns boolean
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Test-TppIdentity/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Test-TppIdentity.ps1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php
+
+    #>
 
     [CmdletBinding()]
+
     param (
 
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
@@ -56,7 +57,7 @@ function Test-TppIdentity {
                     throw "'$_' is not a valid Prefixed Universal Id format.  See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-IdentityInformation.php."
                 }
             })]
-        [Alias('PrefixedUniversal', 'Contact', 'IdentityId')]
+        [Alias('PrefixedUniversal', 'Contact', 'IdentityId', 'FullName')]
         [string[]] $ID,
 
         [Parameter()]
@@ -71,21 +72,24 @@ function Test-TppIdentity {
 
         $params = @{
             VenafiSession = $VenafiSession
-            Method     = 'Post'
-            UriLeaf    = 'Identity/Validate'
-            Body       = @{
-                'ID' = @{
-                    'PrefixedUniversal' = ''
-                }
-            }
+            Method        = 'Post'
+            UriLeaf       = 'Identity/Validate'
         }
     }
 
     process {
 
-        foreach ( $thisId in $ID ) {
+        foreach ( $thisID in $ID ) {
 
-            $params.Body.Id.PrefixedUniversal = $thisId
+            $params.Body = @{
+                'ID' = @{}
+            }
+
+            if ( Test-TppIdentityFormat -ID $thisID -Format 'Universal' ) {
+                $params.Body.ID.PrefixedUniversal = $thisId
+            } else {
+                $params.Body.ID.PrefixedName = $thisId
+            }
 
             $response = Invoke-VenafiRestMethod @params
 


### PR DESCRIPTION
- Add validation and error handling in `Get-VenafiTeam` for invalid IDs, #126 
- Add messaging and error handling in `Get-VenafiTeam` for local groups, #127 
- Add support for PrefixedName identity format in `Test-TppIdentity` and `Get-VenafiIdentity`, #128 
- Fix Split-Path failing in TppObject class, and other functions where applicable, when PowerShell reserved characters are used in the object name, #129 