### PR TITLE
Find/Get certificate updates

### DIFF
--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -141,6 +141,10 @@ function Find-VenafiCertificate {
     For each item in the array, you can provide a field name by itself; this will default to ascending.
     You can also provide a hashtable with the field name as the key and either asc or desc as the value.
 
+    .PARAMETER IncludeVaasOwner
+    Retrieve detailed user/team owner info, only for VaaS.
+    This will cause additional api calls to be made and take longer.
+
     .PARAMETER CountOnly
     Return the count of certificates found from the query as opposed to the certificates themselves
 
@@ -224,7 +228,7 @@ function Find-VenafiCertificate {
     Find VaaS certificates matching multiple values.  In this case, find all certificates expiring in the next 30 days.
 
     .EXAMPLE
-    Find-VenafiCertificate -IncludeOwner
+    Find-VenafiCertificate -IncludeVaasOwner
 
     When finding VaaS certificates, include user/team owner information.
     This will make additional api calls and will increase the response time.
@@ -414,7 +418,7 @@ function Find-VenafiCertificate {
         [psobject[]] $Order,
 
         [Parameter(ParameterSetName = 'VaaS')]
-        [Switch] $IncludeOwner,
+        [Switch] $IncludeVaasOwner,
 
         [Parameter(ParameterSetName = 'TPP')]
         [Switch] $CountOnly,
@@ -641,7 +645,7 @@ function Find-VenafiCertificate {
                 @{
                     'n' = 'owner'
                     'e' = {
-                        if ( $IncludeOwner ) {
+                        if ( $IncludeVaasOwner ) {
 
                             # this scriptblock requires ?ownershipTree=true be part of the url
                             foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -223,6 +223,12 @@ function Find-VenafiCertificate {
 
     Find VaaS certificates matching multiple values.  In this case, find all certificates expiring in the next 30 days.
 
+    .EXAMPLE
+    Find-VenafiCertificate -IncludeOwner
+
+    When finding VaaS certificates, include user/team owner information.
+    This will make additional api calls and will increase the response time.
+
     .LINK
     http://VenafiPS.readthedocs.io/en/latest/functions/Find-VenafiCertificate/
 
@@ -407,6 +413,9 @@ function Find-VenafiCertificate {
         [parameter(ParameterSetName = 'VaaS')]
         [psobject[]] $Order,
 
+        [Parameter(ParameterSetName = 'VaaS')]
+        [Switch] $IncludeOwner,
+
         [Parameter(ParameterSetName = 'TPP')]
         [Switch] $CountOnly,
 
@@ -452,11 +461,14 @@ function Find-VenafiCertificate {
                 VenafiSession = $VenafiSession
                 Method        = 'Post'
                 UriRoot       = 'outagedetection/v1'
-                UriLeaf       = 'certificatesearch'
+                UriLeaf       = 'certificatesearch?ownershipTree=true'
                 Body          = $body
                 # ensure we get json back otherwise we might get csv
                 Header        = @{'Accept' = 'application/json' }
             }
+
+            $appOwners = [System.Collections.Generic.List[object]]::new()
+
         } else {
 
             $params = @{
@@ -619,7 +631,73 @@ function Find-VenafiCertificate {
                     'e' = {
                         $_.Id
                     }
-                }, * -ExcludeProperty Id
+                },
+                @{
+                    'n' = 'application'
+                    'e' = {
+                        $_.applicationIds | Get-VaasApplication -VenafiSession $VenafiSession | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
+                    }
+                },
+                @{
+                    'n' = 'owner'
+                    'e' = {
+                        if ( $IncludeOwner ) {
+
+                            # this scriptblock requires ?ownershipTree=true be part of the url
+                            foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {
+                                $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                                if ( -not $thisOwnerDetail ) {
+                                    $thisOwnerDetail = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession | Select-Object firstName, lastName, emailAddress,
+                                    @{
+                                        'n' = 'status'
+                                        'e' = { $_.userStatus }
+                                    },
+                                    @{
+                                        'n' = 'role'
+                                        'e' = { $_.systemRoles }
+                                    },
+                                    @{
+                                        'n' = 'type'
+                                        'e' = { 'USER' }
+                                    },
+                                    @{
+                                        'n' = 'userId'
+                                        'e' = { $_.id }
+                                    }
+
+                                    $appOwners.Add($thisOwnerDetail)
+
+                                }
+                                $thisOwnerDetail
+                            }
+
+                            foreach ($thisOwner in $_.ownership.owningContainers.owningTeams) {
+                                $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                                if ( -not $thisOwnerDetail ) {
+                                    $thisOwnerDetail = Get-VenafiTeam -ID $thisOwner -VenafiSession $VenafiSession | Select-Object name, role, members,
+                                    @{
+                                        'n' = 'type'
+                                        'e' = { 'TEAM' }
+                                    },
+                                    @{
+                                        'n' = 'teamId'
+                                        'e' = { $_.id }
+                                    }
+
+                                    $appOwners.Add($thisOwnerDetail)
+                                }
+                                $thisOwnerDetail
+                            }
+                        } else {
+                            $_.ownership.owningContainers | Select-Object owningUsers, owningTeams
+                        }
+                    }
+                },
+                @{
+                    'n' = 'instance'
+                    'e' = { $_.instances }
+                },
+                * -ExcludeProperty Id, applicationIds, instances, totalInstanceCount, ownership
 
                 $body.paging.pageNumber += 1
 

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -161,7 +161,7 @@
                 $params.UriRoot = 'outagedetection/v1'
                 $params.UriLeaf = "certificates"
 
-                if ( $PSCmdlet.ParameterSetName -eq 'Id' ) {
+                if ( $PSBoundParameters.ContainsKey('CertificateId') ) {
                     $params.UriLeaf += "/$CertificateId"
                 }
 
@@ -190,51 +190,55 @@
                 @{
                     'n' = 'owner'
                     'e' = {
+                        if ( $IncludeVaasOwner ) {
 
-                        # this scriptblock requires ?ownershipTree=true be part of the url
-                        foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {
-                            $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
-                            if ( -not $thisOwnerDetail ) {
-                                $thisOwnerDetail = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession | Select-Object firstName, lastName, emailAddress,
-                                @{
-                                    'n' = 'status'
-                                    'e' = { $_.userStatus }
-                                },
-                                @{
-                                    'n' = 'role'
-                                    'e' = { $_.systemRoles }
-                                },
-                                @{
-                                    'n' = 'type'
-                                    'e' = { 'USER' }
-                                },
-                                @{
-                                    'n' = 'userId'
-                                    'e' = { $_.id }
+                            # this scriptblock requires ?ownershipTree=true be part of the url
+                            foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {
+                                $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                                if ( -not $thisOwnerDetail ) {
+                                    $thisOwnerDetail = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession | Select-Object firstName, lastName, emailAddress,
+                                    @{
+                                        'n' = 'status'
+                                        'e' = { $_.userStatus }
+                                    },
+                                    @{
+                                        'n' = 'role'
+                                        'e' = { $_.systemRoles }
+                                    },
+                                    @{
+                                        'n' = 'type'
+                                        'e' = { 'USER' }
+                                    },
+                                    @{
+                                        'n' = 'userId'
+                                        'e' = { $_.id }
+                                    }
+
+                                    $appOwners.Add($thisOwnerDetail)
+
                                 }
-
-                                $appOwners.Add($thisOwnerDetail)
-
+                                $thisOwnerDetail
                             }
-                            $thisOwnerDetail
-                        }
 
-                        foreach ($thisOwner in $_.ownership.owningContainers.owningTeams) {
-                            $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
-                            if ( -not $thisOwnerDetail ) {
-                                $thisOwnerDetail = Get-VenafiTeam -ID $thisOwner -VenafiSession $VenafiSession | Select-Object name, role, members,
-                                @{
-                                    'n' = 'type'
-                                    'e' = { 'TEAM' }
-                                },
-                                @{
-                                    'n' = 'teamId'
-                                    'e' = { $_.id }
+                            foreach ($thisOwner in $_.ownership.owningContainers.owningTeams) {
+                                $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                                if ( -not $thisOwnerDetail ) {
+                                    $thisOwnerDetail = Get-VenafiTeam -ID $thisOwner -VenafiSession $VenafiSession | Select-Object name, role, members,
+                                    @{
+                                        'n' = 'type'
+                                        'e' = { 'TEAM' }
+                                    },
+                                    @{
+                                        'n' = 'teamId'
+                                        'e' = { $_.id }
+                                    }
+
+                                    $appOwners.Add($thisOwnerDetail)
                                 }
-
-                                $appOwners.Add($thisOwnerDetail)
+                                $thisOwnerDetail
                             }
-                            $thisOwnerDetail
+                        } else {
+                            $_.ownership.owningContainers | Select-Object owningUsers, owningTeams
                         }
                     }
                 },


### PR DESCRIPTION
- Add VaaS application details to `Find-VenafiCertificate` and `Get-VenafiCertificate`.  Removed `applicationIds` property and replaced with `application`.
- Add `-IncludeVaasOwner` to `Find-VenafiCertificate` and `Get-VenafiCertificate` to retrieve user and team owner details.  Removed `ownership` property (which was never populated) and add `owner`.
- Add `-All` to `Get-VenafiCertificate` in keeping with our standard to retrieve all objects from a function.  The default, with no parameters, will no longer retrieve all, but prompt for an id to get.
- Fix `Get-VenafiCertificate` returning TppObject instead of detailed certificate info when retrieving all on TPP
- Add support for previous versions when retrieving all on TPP
- Add alias `Guid` to `Get-VenafiCertificate` to keep from calling `ConvertTo-TppGuid` when a TppObject is piped in