### PR TITLE
Supercharge `New-TppPolicy` and `New-TppObject`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:latest
+FROM mcr.microsoft.com/powershell:lts-alpine-3.14
 
 RUN pwsh -Command 'Set-PSRepository PSGallery -InstallationPolicy Trusted; Install-Module VenafiPS -ErrorAction Stop'
 

--- a/VenafiPS/Public/Add-TppAdaptableHash.ps1
+++ b/VenafiPS/Public/Add-TppAdaptableHash.ps1
@@ -6,7 +6,7 @@ function Add-TppAdaptableHash {
     .DESCRIPTION
     TPP stores a base64 encoded hash of the file contents of an adaptable script in the Secret Store. This is referenced by
     the Attribute 'PowerShell Script Hash Vault Id' on the DN of the adaptable script. This script retrieves the hash (if
-    present) from the Secret Store and compares it to the hash of the file in one of the scripts directories. It then adds 
+    present) from the Secret Store and compares it to the hash of the file in one of the scripts directories. It then adds
     a new or updated hash if required. When updating an existing hash, it removes the old one from the Secret Store.
 
     .PARAMETER Path
@@ -18,13 +18,13 @@ function Add-TppAdaptableHash {
     The name of the Secret Encryption Key (SEK) to used when encrypting this item. Default is "Software:Default"
 
     .PARAMETER FilePath
-    Required. The full path to the adaptable script file. This should normally be in a 
+    Required. The full path to the adaptable script file. This should normally be in a
     '<drive>:\Program Files\Venafi\Scripts\<subdir>' directory for TPP to recognize the script.
 
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TPP token or VaaS key can also provided.
+    A TPP token can also provided.
     If providing a TPP token, an environment variable named TPP_SERVER must also be set.
 
     .INPUTS
@@ -37,7 +37,7 @@ function Add-TppAdaptableHash {
     Add-TppAdaptableHash -Path $Path -FilePath 'C:\Program Files\Venafi\Scripts\AdaptableApp\AppDriver.ps1'
 
     Update the hash on an adaptable app object.
-    
+
     Note: For an adaptable app or an onboard discovery, 'Path' must always be a policy folder as this is where
     the hash is saved.
 

--- a/VenafiPS/Public/Get-VaasIssuingTemplate.ps1
+++ b/VenafiPS/Public/Get-VaasIssuingTemplate.ps1
@@ -68,8 +68,9 @@
 
     process {
 
+        $params.UriLeaf = 'certificateissuingtemplates'
         if ( $PSBoundParameters.ContainsKey('ID') ) {
-            $params.UriLeaf = "certificateissuingtemplates/$ID"
+            $params.UriLeaf += "/$ID"
         }
 
         $response = Invoke-VenafiRestMethod @params

--- a/VenafiPS/Public/Get-VenafiIdentity.ps1
+++ b/VenafiPS/Public/Get-VenafiIdentity.ps1
@@ -1,128 +1,128 @@
-<#
-.SYNOPSIS
-Get user and group details
-
-.DESCRIPTION
-Returns user/group information for VaaS and TPP.
-For VaaS, this returns user information.
-For TPP, this returns individual identity, group identity, or distribution groups from a local or non-local provider such as Active Directory.
-
-.PARAMETER ID
-For TPP this is the guid or prefixed universal id.  To search, use Find-TppIdentity.
-For VaaS this can either be the user id (guid) or username which is the email address.
-
-.PARAMETER IncludeAssociated
-Include all associated identity groups and folders.  TPP only.
-
-.PARAMETER IncludeMembers
-Include all individual members if the ID is a group.  TPP only.
-
-.PARAMETER Me
-Returns the identity of the authenticated/current user
-
-.PARAMETER All
-Return a complete list of local users.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-ID
-
-.OUTPUTS
-PSCustomObject
-For TPP:
-    Name
-    ID
-    Path
-    FullName
-    Associated (if -IncludeAssociated provided)
-    Members (if -IncludeMembers provided)
-For VaaS:
-    username
-    id
-    companyId
-    firstname
-    lastname
-    emailAddress
-    userType
-    userAccountType
-    userStatus
-    systemRoles
-    productRoles
-    localLoginDisabled
-    hasPassword
-    firstLoginDate
-    creationDate
-    ownedTeams
-    memberedTeams
-
-.EXAMPLE
-Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7'
-
-Get TPP identity details from an id
-
-.EXAMPLE
-Get-VenafiIdentity -ID 9e9db8d6-234a-409c-8299-e3b81ce2f916
-
-Get VaaS identity details from an id
-
-.EXAMPLE
-Get-VenafiIdentity -ID me@x.com
-
-Get VaaS identity details from a username
-
-.EXAMPLE
-Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7' -IncludeMembers
-
-Get TPP identity details.  If the identity is a group it will also return the members
-
-.EXAMPLE
-Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7' -IncludeAssociated
-
-Get TPP identity details from an id and include associated groups/folders
-
-.EXAMPLE
-Get-VenafiIdentity -Me
-
-Get identity details for authenticated/current user, TPP or VaaS
-
-.EXAMPLE
-Get-VenafiIdentity -All
-
-Get all users (VaaS) or all users/groups (TPP)
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppIdentity/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Get-TppIdentity.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Identity-Self.php
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-GetAssociatedEntries.php
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-GetMembers.php
-
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getAll
-
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getById
-
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getByUsername
-#>
 function Get-VenafiIdentity {
+    <#
+    .SYNOPSIS
+    Get user and group details
+
+    .DESCRIPTION
+    Returns user/group information for VaaS and TPP.
+    For VaaS, this returns user information.
+    For TPP, this returns individual identity, group identity, or distribution groups from a local or non-local provider such as Active Directory.
+
+    .PARAMETER ID
+    For TPP this is the guid or prefixed universal id.  To search, use Find-TppIdentity.
+    For VaaS this can either be the user id (guid) or username which is the email address.
+
+    .PARAMETER IncludeAssociated
+    Include all associated identity groups and folders.  TPP only.
+
+    .PARAMETER IncludeMembers
+    Include all individual members if the ID is a group.  TPP only.
+
+    .PARAMETER Me
+    Returns the identity of the authenticated/current user
+
+    .PARAMETER All
+    Return a complete list of local users.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    ID
+
+    .OUTPUTS
+    PSCustomObject
+    For TPP:
+        Name
+        ID
+        Path
+        FullName
+        Associated (if -IncludeAssociated provided)
+        Members (if -IncludeMembers provided)
+    For VaaS:
+        username
+        userId
+        companyId
+        firstname
+        lastname
+        emailAddress
+        userType
+        userAccountType
+        userStatus
+        systemRoles
+        productRoles
+        localLoginDisabled
+        hasPassword
+        firstLoginDate
+        creationDate
+        ownedTeams
+        memberedTeams
+
+    .EXAMPLE
+    Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7'
+
+    Get TPP identity details from an id
+
+    .EXAMPLE
+    Get-VenafiIdentity -ID 9e9db8d6-234a-409c-8299-e3b81ce2f916
+
+    Get VaaS identity details from an id
+
+    .EXAMPLE
+    Get-VenafiIdentity -ID me@x.com
+
+    Get VaaS identity details from a username
+
+    .EXAMPLE
+    Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7' -IncludeMembers
+
+    Get TPP identity details.  If the identity is a group it will also return the members
+
+    .EXAMPLE
+    Get-VenafiIdentity -ID 'AD+myprov:asdfgadsf9g87df98g7d9f8g7' -IncludeAssociated
+
+    Get TPP identity details from an id and include associated groups/folders
+
+    .EXAMPLE
+    Get-VenafiIdentity -Me
+
+    Get identity details for authenticated/current user, TPP or VaaS
+
+    .EXAMPLE
+    Get-VenafiIdentity -All
+
+    Get all users (VaaS) or all users/groups (TPP)
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Get-TppIdentity/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Get-TppIdentity.ps1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Identity-Self.php
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-GetAssociatedEntries.php
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-GetMembers.php
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getAll
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getById
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?urls.primaryName=account-service#/Users/users_getByUsername
+    #>
 
     [CmdletBinding(DefaultParameterSetName = 'Id')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = "Parameter is used")]
@@ -178,24 +178,26 @@ function Get-VenafiIdentity {
                     try {
                         $guid = [guid] $ID
                         $params.UriLeaf = 'users/{0}' -f $guid.ToString()
-                        Invoke-VenafiRestMethod @params
+                        $response = Invoke-VenafiRestMethod @params
                     } catch {
                         $params.UriLeaf = 'users/username/{0}' -f $ID
-                        Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty users
+                        $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty users
                     }
 
                 }
 
                 'Me' {
                     $params.UriLeaf = 'useraccounts'
-                    Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty user
+                    $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty user
                 }
 
                 'All' {
                     $params.UriLeaf = 'users'
-                    Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty users
+                    $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty users
                 }
             }
+
+            $response | Select-Object @{'n' = 'userId'; 'e' = { $_.id } }, * -ExcludeProperty id
         } else {
 
             Switch ($PsCmdlet.ParameterSetName)	{

--- a/VenafiPS/Public/Get-VenafiTeam.ps1
+++ b/VenafiPS/Public/Get-VenafiTeam.ps1
@@ -108,9 +108,9 @@
             $response = Invoke-VenafiRestMethod @params
 
             if ( $response.PSObject.Properties.Name -contains 'teams' ) {
-                $response | Select-Object -ExpandProperty teams
+                $response | Select-Object -ExpandProperty teams | Select-Object @{'n' = 'teamId'; 'e' = { $_.id } }, * -ExcludeProperty id
             } else {
-                $response
+                $response | Select-Object @{'n' = 'teamId'; 'e' = { $_.id } }, * -ExcludeProperty id
             }
         } else {
             if ( $PSCmdlet.ParameterSetName -eq 'All' ) {

--- a/VenafiPS/Public/New-TppObject.ps1
+++ b/VenafiPS/Public/New-TppObject.ps1
@@ -158,7 +158,7 @@ function New-TppObject {
                     # with these classes we know the parent is a policy so we can create them
                     if ( $Class -in 'Policy', 'Device' ) {
                         if ( -not $Force ) {
-                            throw 'Part of -Path does not exist.  Use -Force to create the policy folders.'
+                            throw "Part of the path $newPath does not exist.  Use -Force to create the missing policy folders."
                         } else {
 
                             $pathSplit = $newPath.Split('\')
@@ -166,7 +166,7 @@ function New-TppObject {
                             # create the parent policy folders
                             # don't try and create \ved or \ved\policy levels
                             for ($i = 3; $i -lt ($pathSplit.Count - 1); $i++) {
-                                if ( -not (Find-TppObject -Path ($pathSplit[0..($i - 1)] -join '\') -Pattern $i)) {
+                                if ( -not (Find-TppObject -Path ($pathSplit[0..($i - 1)] -join '\') -Pattern $pathSplit[$i])) {
                                     Write-Verbose ('Creating missing policy folder {0}' -f ($pathSplit[0..$i] -join '\'))
                                     New-TppPolicy -Path ($pathSplit[0..$i] -join '\') -VenafiSession $VenafiSession
                                 }
@@ -175,19 +175,16 @@ function New-TppObject {
                             $retryCreate = $true
                         }
                     } else {
-                        throw 'Part of -Path does not exist.'
+                        throw "Part of path $newPath does not exist."
                     }
                 }
 
                 'ObjectAlreadyExists' {
-                    Write-Verbose "$newPath already existed"
-                    if ( $PassThru ) {
-                        $returnObject = Get-TppObject -Path $newPath -VenafiSession $VenafiSession
-                    }
+                    throw "$newPath already exists"
                 }
 
                 Default {
-                    throw ('Unknown result code from config/create: {0}' -f $response.Result)
+                    throw ('Error creating object: {0}, {1}' -f $response.Result, $_)
                 }
             }
 

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -19,12 +19,22 @@ function New-TppPolicy {
     If setting a custom field, you can use either the name or guid as the key.
     To clear a value overwriting policy, set the value to $null.
 
+    .PARAMETER PolicyAttribute
+    Set policy attributes at policy creation time.
+    Use with -Class.
+
     .PARAMETER Class
-    Set -Attribute as policy attributes.
+    Use with -PolicyAttribute to set policy attributes at policy creation time.
     If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
+
+    .PARAMETER Lock
+    Use with -PolicyAttribute and -Class to lock the policy attribute
 
     .PARAMETER Description
     Policy description
+
+    .PARAMETER Force
+    Force the creation of missing parent policy folders when the Class is either Policy or Device.
 
     .PARAMETER PassThru
     Return a TppObject representing the newly created policy.
@@ -92,6 +102,10 @@ function New-TppPolicy {
         [Parameter(ParameterSetName = 'NameWithPolicyAttribute', Mandatory)]
         [string] $Class,
 
+        [Parameter(ParameterSetName = 'PathWithPolicyAttribute')]
+        [Parameter(ParameterSetName = 'NameWithPolicyAttribute')]
+        [switch] $Lock,
+
         [Parameter()]
         [switch] $Force,
 
@@ -137,7 +151,7 @@ function New-TppPolicy {
                 $response = New-TppObject @params
 
                 if ( $PSBoundParameters.ContainsKey('Class') ) {
-                    $response | Set-TppAttribute -Attribute $PolicyAttribute -Class $Class -VenafiSession $VenafiSession
+                    $response | Set-TppAttribute -Attribute $PolicyAttribute -Class $Class -Lock:$Lock -VenafiSession $VenafiSession
                 }
 
                 if ( $PassThru ) {

--- a/VenafiPS/Public/New-TppPolicy.ps1
+++ b/VenafiPS/Public/New-TppPolicy.ps1
@@ -1,73 +1,99 @@
-<#
-.SYNOPSIS
-Add a new policy folder
-
-.DESCRIPTION
-Add a new policy folder
-
-.PARAMETER Path
-DN path to the new policy
-
-.PARAMETER Description
-Policy description
-
-.PARAMETER PassThru
-Return a TppObject representing the newly created policy.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-Path
-
-.OUTPUTS
-TppObject, if PassThru provided
-
-.EXAMPLE
-$newPolicy = New-TppPolicy -Path '\VED\Policy\Existing Policy Folder\New Policy Folder' -PassThru
-Create policy returning the policy object created
-
-.EXAMPLE
-New-TppPolicy -Path '\VED\Policy\Existing Policy Folder\New Policy Folder' -Description 'this is awesome'
-Create policy with description
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/New-TppPolicy/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppPolicy.ps1
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/New-TppObject/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppObject.ps1
-
-#>
 function New-TppPolicy {
+    <#
+    .SYNOPSIS
+    Add a new policy folder
+
+    .DESCRIPTION
+    Add a new policy folder(s).  Add attributes or policy attributes at the same time.
+
+    .PARAMETER Path
+    Full path to the new policy folder.
+    If the root path is excluded, \ved\policy will be prepended.
+    If used with -Name, this will be the root path and subfolders will be created.
+
+    .PARAMETER Name
+    One of more policy folders to create under -Path.
+
+    .PARAMETER Attribute
+    Hashtable with names and values to be set.
+    If setting a custom field, you can use either the name or guid as the key.
+    To clear a value overwriting policy, set the value to $null.
+
+    .PARAMETER Class
+    Set -Attribute as policy attributes.
+    If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
+
+    .PARAMETER Description
+    Policy description
+
+    .PARAMETER PassThru
+    Return a TppObject representing the newly created policy.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    Path
+
+    .OUTPUTS
+    TppObject, if PassThru provided
+
+    .EXAMPLE
+    $newPolicy = New-TppPolicy -Path '\VED\Policy\Existing Policy Folder\New Policy Folder' -PassThru
+    Create policy returning the policy object created
+
+    .EXAMPLE
+    New-TppPolicy -Path '\VED\Policy\Existing Policy Folder\New Policy Folder' -Description 'this is awesome'
+    Create policy with description
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/New-TppPolicy/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppPolicy.ps1
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/New-TppObject/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/New-TppObject.ps1
+
+    #>
 
     [CmdletBinding(SupportsShouldProcess)]
 
     param (
-        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Path', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Name', ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'PathWithPolicyAttribute', Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'NameWithPolicyAttribute', Mandatory, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [ValidateScript( {
-                if ( $_ | Test-TppDnPath ) {
-                    $true
-                }
-                else {
-                    throw "'$_' is not a valid DN path"
-                }
-            })]
-        [Alias('PolicyDN')]
         [string] $Path,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [Parameter(ParameterSetName = 'NameWithPolicyAttribute', Mandatory)]
+        [string[]] $Name,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String] $Description,
+
+        [Parameter()]
+        [hashtable] $Attribute,
+
+        [Parameter(ParameterSetName = 'PathWithPolicyAttribute', Mandatory)]
+        [Parameter(ParameterSetName = 'NameWithPolicyAttribute', Mandatory)]
+        [hashtable] $PolicyAttribute,
+
+        [Parameter(ParameterSetName = 'PathWithPolicyAttribute', Mandatory)]
+        [Parameter(ParameterSetName = 'NameWithPolicyAttribute', Mandatory)]
+        [string] $Class,
+
+        [Parameter()]
+        [switch] $Force,
 
         [Parameter()]
         [switch] $PassThru,
@@ -79,29 +105,53 @@ function New-TppPolicy {
     begin {
 
         $params = @{
-            Path       = ''
-            Class      = 'Policy'
-            PassThru   = $true
+            Class         = 'Policy'
+            PassThru      = $true
             VenafiSession = $VenafiSession
+            Force         = $Force
         }
 
-        if ( $PSBoundParameters.ContainsKey('Description') ) {
-            $params.Add('Attribute', @{'Description' = $Description })
-        }
+        if ( $PSBoundParameters.ContainsKey('Description') -or $PSBoundParameters.ContainsKey('Attribute') ) {
+            $params.Attribute = @{}
 
+            if ( $PSBoundParameters.ContainsKey('Description') ) {
+                $params.Attribute += @{'Description' = $Description }
+            }
+
+            if ( $PSBoundParameters.ContainsKey('Attribute') ) {
+                $params.Attribute += $Attribute
+            }
+        }
     }
 
     process {
-        $params.Path = $Path
 
-        if ( $PSCmdlet.ShouldProcess($Path, 'Create Policy') ) {
+        $newPath = $Path | ConvertTo-TppFullPath
 
-            Write-Verbose ($params | Out-String)
-            $response = New-TppObject @params
+        if ( $PSCmdlet.ParameterSetName -in 'Path', 'PathWithPolicyAttribute' ) {
 
-            if ( $PassThru ) {
-                $response
+            $params.Path = $newPath
+
+            if ( $PSCmdlet.ShouldProcess($newPath, 'Create Policy') ) {
+
+                $response = New-TppObject @params
+
+                if ( $PSBoundParameters.ContainsKey('Class') ) {
+                    $response | Set-TppAttribute -Attribute $PolicyAttribute -Class $Class -VenafiSession $VenafiSession
+                }
+
+                if ( $PassThru ) {
+                    $response
+                }
+            }
+        } else {
+            foreach ($thisName in $Name) {
+                $PSBoundParameters['Path'] = Join-Path -Path $newPath -ChildPath $thisName
+                $null = $PSBoundParameters.Remove('Name')
+
+                New-TppPolicy @PSBoundParameters
             }
         }
+
     }
 }

--- a/VenafiPS/Public/New-VaasApplication.ps1
+++ b/VenafiPS/Public/New-VaasApplication.ps1
@@ -10,8 +10,7 @@ function New-VaasApplication {
     Application name
 
     .PARAMETER Owner
-    List of user and/or team IDs to be owners.
-    Use Get-VenafiIdentity or Get-VenafiTeam to retrieve the ID.
+    List of user and/or team IDs or names to be owners
 
     .PARAMETER Description
     Application description
@@ -43,7 +42,7 @@ function New-VaasApplication {
     PSCustomObject, if PassThru provided
 
     .EXAMPLE
-    New-VaasApplication -Name 'MyNewApp' -Owner '4ba1e64f-12ad-4a34-a0e2-bc4481a56f7d'
+    New-VaasApplication -Name 'MyNewApp' -Owner '4ba1e64f-12ad-4a34-a0e2-bc4481a56f7d','greg@venafi.com'
 
     Create a new application
 
@@ -76,7 +75,7 @@ function New-VaasApplication {
         [string] $Name,
 
         [Parameter(Mandatory)]
-        [guid[]] $Owner,
+        [string[]] $Owner,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -115,15 +114,16 @@ function New-VaasApplication {
 
         # determine if user or team and build the payload
         $ownerHash = foreach ($thisOwner in $Owner) {
+
             $team = Get-VenafiTeam -ID $thisOwner -VenafiSession $VenafiSession -ErrorAction SilentlyContinue
             if ( $team ) {
-                @{ 'ownerId' = $thisOwner; 'ownerType' = 'TEAM' }
+                @{ 'ownerId' = $team.teamId; 'ownerType' = 'TEAM' }
             } else {
                 $user = Get-VenafiIdentity -ID $thisOwner -VenafiSession $VenafiSession -ErrorAction SilentlyContinue
                 if ( $user ) {
-                    @{ 'ownerId' = $thisOwner; 'ownerType' = 'USER' }
+                    @{ 'ownerId' = $user.userId; 'ownerType' = 'USER' }
                 } else {
-                    Write-Error "Owner $thisOwner not found for application $Name"
+                    Write-Error "Owner $thisOwner not found"
                     Continue
                 }
             }

--- a/VenafiPS/Public/Remove-TppEngineFolder.ps1
+++ b/VenafiPS/Public/Remove-TppEngineFolder.ps1
@@ -48,8 +48,8 @@ function Remove-TppEngineFolder
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
 
     param (
-        [Parameter(Mandatory,ParameterSetName = 'AllEngines')]
-        [Parameter(Mandatory,ParameterSetName = 'Matrix')]
+        [Parameter(Mandatory,ParameterSetName = 'AllEngines', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName = 'Matrix', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
             if ( $_ | Test-TppDnPath ) { $true }
@@ -58,8 +58,8 @@ function Remove-TppEngineFolder
         [Alias('FolderDN', 'Folder')]
         [String[]] $FolderPath,
 
-        [Parameter(Mandatory,ParameterSetName = 'AllFolders')]
-        [Parameter(Mandatory,ParameterSetName = 'Matrix')]
+        [Parameter(Mandatory,ParameterSetName = 'AllFolders', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName = 'Matrix', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
             if ( $_ | Test-TppDnPath ) { $true }
@@ -157,9 +157,9 @@ function Remove-TppEngineFolder
             }
             else {  # ParameterSetName='Matrix'
                 if ($FolderList.Count -gt 1) { $shouldProcessAction += "Remove $($FolderList.Count) folders" }
-                else { $shouldProcessAction += "Remove $($FolderList.Path)" }
+                else { $shouldProcessAction = "Remove $($FolderList.Path)" }
                 if ($EngineList.Count -gt 1) { $shouldProcessTarget = "$($EngineList.Count) processing engines" }
-                else { $shouldProcessTarget += "$($EngineList.Name)" }
+                else { $shouldProcessTarget = "$($EngineList.Name)" }
             }
             if ($PSCmdlet.ShouldProcess($shouldProcessTarget, $shouldProcessAction)) {
                 foreach ($engine in $EngineList) {

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -15,18 +15,15 @@ function Set-TppAttribute {
     If setting a custom field, you can use either the name or guid as the key.
     To clear a value overwriting policy, set the value to $null.
 
-    .PARAMETER BypassValidation
-    Bypass data validation.  Only applicable to custom fields.
-
-    .PARAMETER Policy
-    Set policies (aka policy attributes) instead of object attributes
-
     .PARAMETER Class
     Required when setting policy attributes.  Provide the class name to set the value for.
     If unsure of the class name, add the value through the TPP UI and go to Support->Policy Attributes to find it.
 
     .PARAMETER Lock
     Lock the value on the policy.  Only applicable to setting policies.
+
+    .PARAMETER BypassValidation
+    Bypass data validation.  Only applicable to custom fields.
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -93,7 +90,7 @@ function Set-TppAttribute {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Being flagged incorrectly')]
 
     param (
-        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
@@ -108,15 +105,15 @@ function Set-TppAttribute {
         [Parameter(Mandatory)]
         [hashtable] $Attribute,
 
-        [Parameter()]
-        [switch] $BypassValidation,
-
         [Parameter(Mandatory, ParameterSetName = 'Policy')]
         [Alias('ClassName', 'PolicyClass')]
         [string] $Class,
 
         [Parameter(ParameterSetName = 'Policy')]
         [switch] $Lock,
+
+        [Parameter()]
+        [switch] $BypassValidation,
 
         [Parameter()]
         [psobject] $VenafiSession = $script:VenafiSession


### PR DESCRIPTION
- `New-TppObject`
  - Add `-Force` option to create missing parent policy folders
  - Return object if already exists and -PassThru provided
  - Root path \ved\policy will be automatically prepended if not provided for -Path
- Supercharge `New-TppPolicy`
  - Add `-Name` to provide a list of policy folders to create
  - Add `-Attribute` and `-PolicyAttribute` to set both kinds of attributes at policy creation time
  - Add `-Force` to create missing parent policy folders
- Update `New-VaasApplication` to allow -Owner to be a name in addition to guid
- Fix `Get-VaasIssuingTemplate -All` not executing under certain circumstances
