### PR TITLE
Invoke-VenafiRestMethod -FullResponse not failing

### DIFF
--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -238,17 +238,22 @@ function Invoke-VenafiRestMethod {
 
             409 {
                 # 409 = item already exists.  some functions use this for a 'force' option, eg. Set-TppPermission
-                # treat this as non error/exception
-                $response = [pscustomobject] @{
-                    StatusCode = $statusCode
-                    Error      =
-                    try {
-                        $originalError.ErrorDetails.Message | ConvertFrom-Json
-                    } catch {
-                        $originalError.ErrorDetails.Message
+                # treat this as non error/exception if FullResponse provided
+                if ( $FullResponse ) {
+                    $response = [pscustomobject] @{
+                        StatusCode = $statusCode
+                        Error      =
+                        try {
+                            $originalError.ErrorDetails.Message | ConvertFrom-Json
+                        } catch {
+                            $originalError.ErrorDetails.Message
+                        }
                     }
+                } else {
+                    throw $originalError
                 }
             }
+
             Default {
                 throw $originalError
             }


### PR DESCRIPTION
Fixes #152
Core issue was with the way Invoke-VenafiRestMethod was handling errors when -FullResponse was used.  The error was being consumed instead of thrown.