### PR TITLE
Vaas search updates

### DIFF
--- a/VenafiPS/Classes/VenafiSession.ps1
+++ b/VenafiPS/Classes/VenafiSession.ps1
@@ -3,8 +3,8 @@ class VenafiSession {
     [string] $Server
     [PSCustomObject] $Key
     [PSCustomObject] $Token
-    [PSCustomObject] $CustomField
-    [Version] $Version
+    # [PSCustomObject] $CustomField
+    # [Version] $Version
 
     VenafiSession () {
     }

--- a/VenafiPS/Private/New-VaasSearchQuery.ps1
+++ b/VenafiPS/Private/New-VaasSearchQuery.ps1
@@ -66,12 +66,15 @@ function New-VaasSearchQuery {
             'paging'     = @{}
         }
 
+        $firstMax = 18446744073709551615
         # page size limit from vaas is 1000
-        if ($PSBoundParameters.ContainsKey('First') -and $PSCmdlet.PagingParameters.First -le 1000) {
-            $query.paging.Add('pageSize', $PSCmdlet.PagingParameters.First)
-        } else {
-            $query.paging.Add('pageSize', 1000)
+        $query.paging.Add('pageSize', [Math]::Min($PSCmdlet.PagingParameters.First, 1000))
+
+        # notify user if they picked a -First value greater than 1000
+        if ( $PSCmdlet.PagingParameters.First -ne $firstMax -and $PSCmdlet.PagingParameters.First -gt 1000 ) {
+            Write-Warning '-First can not be larger than 1000 and will be updated'
         }
+
         $query.paging.Add('pageNumber', 0)
 
         function New-VaasExpression {

--- a/VenafiPS/Private/New-VaasSearchQuery.ps1
+++ b/VenafiPS/Private/New-VaasSearchQuery.ps1
@@ -95,8 +95,16 @@ function New-VaasSearchQuery {
             $operands = $loopFilter | ForEach-Object {
                 $thisItem = $_
                 if ( $thisItem.count -eq 3 -and -not ($thisItem | ForEach-Object { if ($_.GetType().Name -eq 'Object[]') { 'array' } })) {
+
+                    # vaas fields are case sensitive, get the proper case if we're aware of the field
+                    $newField = $thisItem[0]
+                    $properCaseField = $vaasFields | Where-Object { $_.ToLower() -eq $newField.ToLower() }
+                    if ( $properCaseField ) {
+                        $newField = $properCaseField
+                    }
+
                     $newOperand = @{
-                        'field'    = $thisItem[0]
+                        'field'    = $newField
                         'operator' = $thisItem[1].ToUpper()
                     }
 
@@ -108,7 +116,12 @@ function New-VaasSearchQuery {
                         }
 
                         'String' {
-                            $newOperand.Add('value', $thisItem[2])
+                            $newValue = $thisItem[2]
+                            # these values should be upper case, fix in case not provided that way
+                            if ( $newOperand.field.ToLower() -in $vaasValuesToUpper.ToLower() ) {
+                                $newValue = $thisItem[2].ToUpper()
+                            }
+                            $newOperand.Add('value', $newValue)
                         }
 
                         Default {

--- a/VenafiPS/Public/Find-VaasObject.ps1
+++ b/VenafiPS/Public/Find-VaasObject.ps1
@@ -1,0 +1,190 @@
+function Find-VaasObject {
+    <#
+    .SYNOPSIS
+    Find different objects on VaaS
+
+    .DESCRIPTION
+    Find objects of type ActivityLog, Machine, MachineIdentity, CertificateRequest, CertificateInstance on VaaS.
+    Supports -First for page size and -IncludeTotalCount to retrieve all by paging.
+    The max page size is 1000.
+    To find certificate objects, use Find-VenafiCertificate.
+
+    .PARAMETER Type
+    Type of object to retrieve.  Can be ActivityLog, Machine, MachineIdentity, CertificateRequest, or CertificateInstance.
+
+    .PARAMETER Filter
+    Array or multidimensional array of fields and values to filter on.
+    Each array should be of the format @('operator', @(field, comparison operator, value), @(field2, comparison operator2, value2)).
+    Nested filters are supported.
+    For a complete list of comparison operators, see https://docs.venafi.cloud/api/about-api-search-operators/.
+
+    .PARAMETER Order
+    Array of fields to order on.
+    For each item in the array, you can provide a field name by itself; this will default to ascending.
+    You can also provide a hashtable with the field name as the key and either asc or desc as the value.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A VaaS key can also provided.
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    Find-VaasObject -Type CertificateInstance
+
+    Get first 1000 records
+
+    .EXAMPLE
+    Find-VaasObject -Type CertificateInstance -First 50
+
+    Get first 50 records
+
+    .EXAMPLE
+    Find-VaasObject -Type CertificateInstance -First 500 -IncludeTotalCount
+
+    Get all records paging 500 at a time
+
+    .EXAMPLE
+    Find-VaasObject -Type ActivityLog -Filter @('activityType', 'eq', 'Notifications') -First 10
+
+    Retrieve 10 records matching the field name
+
+    .EXAMPLE
+    Find-VaasObject -Type ActivityLog -Filter @('activityType', 'eq', 'Notifications') -First 10 -Order @{'activityDate'='desc'}
+
+    Retrieve the most recent 10 records matching the field name
+
+    .EXAMPLE
+    Find-VaasObject -Filter @('and', @('activityDate', 'gt', (get-date).AddMonths(-1)), @('or', @('userId', 'eq', 'ab0feb46-8df7-47e7-8da9-f47ab314f26a'), @('userId', 'eq', '933c28de-6352-46f3-bc12-bd96077e8eae')))
+
+    Advanced filtering of results.  This filter will find log entries by 1 of 2 people within the last month.
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Find-VaasObject/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Find-VaasObject.ps1
+    #>
+
+    [CmdletBinding(SupportsPaging)]
+
+    param (
+
+        [Parameter(Mandatory)]
+        [ValidateSet('ActivityLog', 'Machine', 'MachineIdentity', 'CertificateRequest', 'CertificateInstance')]
+        [string] $Type,
+
+        [Parameter()]
+        [System.Collections.ArrayList] $Filter,
+
+        [parameter()]
+        [psobject[]] $Order,
+
+        [Parameter()]
+        [psobject] $VenafiSession = $script:VenafiSession
+    )
+
+    Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
+
+    if ( $PSBoundParameters.ContainsKey('Skip') ) {
+        Write-Warning '-Skip is not currently supported by VaaS'
+    }
+
+    $queryParams = @{
+        Filter            = $Filter
+        Order             = $Order
+        First             = $PSCmdlet.PagingParameters.First
+        Skip              = $PSCmdlet.PagingParameters.Skip
+        IncludeTotalCount = $PSCmdlet.PagingParameters.IncludeTotalCount
+    }
+
+    $body = New-VaasSearchQuery @queryParams
+
+    $params = @{
+        VenafiSession = $VenafiSession
+        Method        = 'Post'
+        Body          = $body
+        Header        = @{'Accept' = 'application/json' }
+    }
+
+    $objectData = @{
+        'Certificate'         = @{
+            'uriroot'  = 'outagedetection/v1'
+            'urileaf'  = 'certificatesearch'
+            'property' = 'certificates'
+        }
+        'CertificateRequest'  = @{
+            'uriroot'  = 'outagedetection/v1'
+            'urileaf'  = 'certificaterequestssearch'
+            'property' = 'certificaterequests'
+            'filter'   = @{
+                Property        = @{'n' = 'certificateRequestId'; 'e' = { $_.Id } }
+                ExcludeProperty = 'id'
+            }
+        }
+        'CertificateInstance' = @{
+            'uriroot'  = 'outagedetection/v1'
+            'urileaf'  = 'certificateinstancesearch'
+            'property' = 'instances'
+            'filter'   = ''
+        }
+        'Machine'             = @{
+            'uriroot'  = 'v1'
+            'urileaf'  = 'machinesearch'
+            'property' = 'machines'
+            'filter'   = @{
+                Property        = @{'n' = 'machineId'; 'e' = { $_.Id } }
+                ExcludeProperty = 'id'
+            }
+        }
+        'MachineIdentity'     = @{
+            'uriroot'  = 'v1'
+            'urileaf'  = 'machineidentitysearch'
+            'property' = 'machineidentities'
+            'filter'   = @{
+                Property        = @{'n' = 'machineIdentityId'; 'e' = { $_.Id } }
+                ExcludeProperty = 'id'
+            }
+        }
+        'ActivityLog'         = @{
+            'uriroot'  = 'v1'
+            'urileaf'  = 'activitylogsearch'
+            'property' = 'activityLogEntries'
+            'filter'   = @{
+                Property        = @{'n' = 'activityLogId'; 'e' = { $_.Id } }
+                ExcludeProperty = 'id'
+            }
+        }
+    }
+
+    $params.UriRoot = $objectData.$Type.uriroot
+    $params.UriLeaf = $objectData.$Type.urileaf
+
+    $params.UriLeaf += '?ownershipTree=true'
+    $allObjects = [System.Collections.Generic.List[object]]::new()
+
+    do {
+
+        $response = Invoke-VenafiRestMethod @params
+
+        if ( -not $response ) {
+            continue
+        }
+
+        $thisObjects = $response | Select-Object -ExpandProperty $objectData.$Type.property
+
+        $thisObjects | ForEach-Object { $allObjects.Add($_) }
+        $params.body.paging.pageNumber += 1
+
+    } until (
+        @($thisObjects).Count -lt $params.Body.paging.pageSize -or @($thisObjects).Count -eq 0 -or (-not $PSCmdlet.PagingParameters.IncludeTotalCount)
+    )
+
+    if ( $objectData.$Type.filter ) {
+        $allObjects | Select-Object -Property $objectData.$Type.filter.Property, * -ExcludeProperty $objectData.$Type.filter.ExcludeProperty
+    } else {
+        $allObjects
+    }
+}

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -464,6 +464,7 @@ function Find-VenafiCertificate {
                 Header        = @{'Accept' = 'application/json' }
             }
 
+            $apps = [System.Collections.Generic.List[object]]::new()
             $appOwners = [System.Collections.Generic.List[object]]::new()
 
         } else {
@@ -632,7 +633,14 @@ function Find-VenafiCertificate {
                 @{
                     'n' = 'application'
                     'e' = {
-                        $_.applicationIds | Get-VaasApplication -VenafiSession $VenafiSession | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
+                        foreach ($thisAppId in $_.applicationIds) {
+                            $thisApp = $apps | Where-Object { $_.applicationId -eq $thisAppId }
+                            if ( -not $thisApp ) {
+                                $thisApp = $thisAppId | Get-VaasApplication -VenafiSession $VenafiSession | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
+                                $apps.Add($thisApp)
+                            }
+                            $thisApp
+                        }
                     }
                 },
                 @{

--- a/VenafiPS/Public/Find-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Find-VenafiCertificate.ps1
@@ -344,6 +344,14 @@ function Find-VenafiCertificate {
         [DateTime] $IssueDate,
 
         [Parameter(ParameterSetName = 'TPP')]
+        [Alias('ValidFromGreater')]
+        [DateTime] $IssueDateAfter,
+
+        [Parameter(ParameterSetName = 'TPP')]
+        [Alias('ValidFromLess')]
+        [DateTime] $IssueDateBefore,
+
+        [Parameter(ParameterSetName = 'TPP')]
         [Alias('ValidTo')]
         [DateTime] $ExpireDate,
 
@@ -570,6 +578,12 @@ function Find-VenafiCertificate {
                 }
                 'Thumbprint' {
                     $params.Body.Add( 'Thumbprint', $Thumbprint )
+                }
+                'IssueDateAfter' {
+                    $params.Body.Add( 'ValidFromGreater', ($IssueDateAfter | ConvertTo-UtcIso8601) )
+                }
+                'IssueDateBefore' {
+                    $params.Body.Add( 'ValidFromLess', ($IssueDateBefore | ConvertTo-UtcIso8601) )
                 }
                 'IssueDate' {
                     $params.Body.Add( 'ValidFrom', ($IssueDate | ConvertTo-UtcIso8601) )

--- a/VenafiPS/Public/Get-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Get-VenafiCertificate.ps1
@@ -84,7 +84,7 @@
         [Parameter(ParameterSetName = 'Id', Mandatory, ValueFromPipelineByPropertyName)]
         [Parameter(ParameterSetName = 'VaasId', Mandatory, ValueFromPipelineByPropertyName)]
         [Parameter(ParameterSetName = 'TppId', Mandatory, ValueFromPipelineByPropertyName)]
-        [Alias('Guid', 'Path')]
+        [Alias('Guid', 'Path', 'id')]
         [string] $CertificateId,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -105,7 +105,6 @@ function Import-VaasCertificate {
             }
         }
 
-
         if ( $PSBoundParameters.ContainsKey('Application') ) {
             $allApps = Get-VaasApplication -All -VenafiSession $VenafiSession
             $appsForImport = foreach ($thisApplication in $Application) {
@@ -134,26 +133,30 @@ function Import-VaasCertificate {
 
         if ( $PSCmdlet.ParameterSetName -like 'ByFile*' ) {
             foreach ($thisCertPath in $CertificatePath) {
+
                 if ($PSVersionTable.PSVersion.Major -lt 6) {
                     $cert = Get-Content $thisCertPath -Encoding Byte
                 } else {
                     $cert = Get-Content $thisCertPath -AsByteStream
                 }
-                $allCerts.Add(
-                    @{
-                        'certificate'    = [System.Convert]::ToBase64String($cert)
-                        'applicationIds' = @($appsForImport)
-                    }
-                )
+
+                $newCert = @{
+                    'certificate' = [System.Convert]::ToBase64String($cert)
+                }
+                if ( $appsForImport ) {
+                    $newCert.applicationIds = @($appsForImport)
+                }
+                $allCerts.Add($newCert)
             }
         } else {
             foreach ($thisCertData in $CertificateData) {
-                $allCerts.Add(
-                    @{
-                        'certificate'    = $thisCertData
-                        'applicationIds' = @($appsForImport)
-                    }
-                )
+                $newCert = @{
+                    'certificate' = $thisCertData -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
+                }
+                if ( $appsForImport ) {
+                    $newCert.applicationIds = @($appsForImport)
+                }
+                $allCerts.Add($newCert)
             }
         }
 

--- a/VenafiPS/Public/Import-VaasCertificate.ps1
+++ b/VenafiPS/Public/Import-VaasCertificate.ps1
@@ -170,7 +170,7 @@ function Import-VaasCertificate {
         Write-Verbose $response.statistics
 
         if ( $PassThru ) {
-            $response.certificateInformations
+            $response.certificateInformations | Get-VenafiCertificate -VenafiSession $VenafiSession
         }
     }
 }

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -504,7 +504,7 @@ function New-VenafiSession {
 
     # will fail if user is on an older version.  this isn't required so bypass on failure
     # only applicable to tpp
-    if ( $PSCmdlet.ParameterSetName -notin 'Vaas', 'VaultVaasKey' ) {
+    if ( $newSession.Platform -eq 'TPP' ) {
         $newSession | Add-Member @{ Version = (Get-TppVersion -VenafiSession $newSession -ErrorAction SilentlyContinue) }
         $certFields = 'X509 Certificate', 'Device', 'Application Base' | Get-TppCustomField -VenafiSession $newSession -ErrorAction SilentlyContinue
         # make sure we remove duplicates

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -510,23 +510,23 @@ function New-VenafiSession {
         # make sure we remove duplicates
         $newSession | Add-Member @{ CustomField = $certFields.Items | Sort-Object -Property Guid -Unique }
     } else {
-        $newSession | Add-Member @{
-            MachineType = (Invoke-VenafiRestMethod -UriLeaf 'machinetypes' -VenafiSession $newSession | Select-Object -ExpandProperty machineTypes | Select-Object @{
-                    'n' = 'machineTypeId'
-                    'e' = {
-                        $_.Id
-                    }
-                }, * -ExcludeProperty id)
-        }
+        # $newSession | Add-Member @{
+        #     MachineType = (Invoke-VenafiRestMethod -UriLeaf 'machinetypes' -VenafiSession $newSession | Select-Object -ExpandProperty machineTypes | Select-Object @{
+        #             'n' = 'machineTypeId'
+        #             'e' = {
+        #                 $_.Id
+        #             }
+        #         }, * -ExcludeProperty id)
+        # }
 
-        $newSession | Add-Member @{
-            ApplicationServerType = (Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf 'applicationservertypes' -VenafiSession $newSession | Select-Object -ExpandProperty applicationServerTypes | Select-Object @{
-                    'n' = 'applicationServerTypeId'
-                    'e' = {
-                        $_.Id
-                    }
-                }, * -ExcludeProperty id)
-        }
+        # $newSession | Add-Member @{
+        #     ApplicationServerType = (Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf 'applicationservertypes' -VenafiSession $newSession | Select-Object -ExpandProperty applicationServerTypes | Select-Object @{
+        #             'n' = 'applicationServerTypeId'
+        #             'e' = {
+        #                 $_.Id
+        #             }
+        #         }, * -ExcludeProperty id)
+        # }
 
         # $newSession | Add-Member @{
         #     ActivityType = (Invoke-VenafiRestMethod -UriLeaf 'activitytypes' -VenafiSession $newSession | Select-Object -ExpandProperty activityTypes | Select-Object @{

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -505,10 +505,37 @@ function New-VenafiSession {
     # will fail if user is on an older version.  this isn't required so bypass on failure
     # only applicable to tpp
     if ( $PSCmdlet.ParameterSetName -notin 'Vaas', 'VaultVaasKey' ) {
-        $newSession.Version = (Get-TppVersion -VenafiSession $newSession -ErrorAction SilentlyContinue)
+        $newSession | Add-Member @{ Version = (Get-TppVersion -VenafiSession $newSession -ErrorAction SilentlyContinue) }
         $certFields = 'X509 Certificate', 'Device', 'Application Base' | Get-TppCustomField -VenafiSession $newSession -ErrorAction SilentlyContinue
         # make sure we remove duplicates
-        $newSession.CustomField = $certFields.Items | Sort-Object -Property Guid -Unique
+        $newSession | Add-Member @{ CustomField = $certFields.Items | Sort-Object -Property Guid -Unique }
+    } else {
+        $newSession | Add-Member @{
+            MachineType = (Invoke-VenafiRestMethod -UriLeaf 'machinetypes' -VenafiSession $newSession | Select-Object -ExpandProperty machineTypes | Select-Object @{
+                    'n' = 'machineTypeId'
+                    'e' = {
+                        $_.Id
+                    }
+                }, * -ExcludeProperty id)
+        }
+
+        $newSession | Add-Member @{
+            ApplicationServerType = (Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf 'applicationservertypes' -VenafiSession $newSession | Select-Object -ExpandProperty applicationServerTypes | Select-Object @{
+                    'n' = 'applicationServerTypeId'
+                    'e' = {
+                        $_.Id
+                    }
+                }, * -ExcludeProperty id)
+        }
+
+        # $newSession | Add-Member @{
+        #     ActivityType = (Invoke-VenafiRestMethod -UriLeaf 'activitytypes' -VenafiSession $newSession | Select-Object -ExpandProperty activityTypes | Select-Object @{
+        #             'n' = 'activityTypeId'
+        #             'e' = {
+        #                 $_.Id
+        #             }
+        #         }, * -ExcludeProperty id)
+        # }
     }
 
     if ( $PassThru ) {

--- a/VenafiPS/Public/Read-VenafiLog.ps1
+++ b/VenafiPS/Public/Read-VenafiLog.ps1
@@ -1,150 +1,150 @@
-<#
-.SYNOPSIS
-Read entries from the VaaS or TPP log
-
-.DESCRIPTION
-Read entries from the VaaS or TPP log.
-Supports -First for paging.
-Limit of 1000 records.
-
-.PARAMETER Path
-TPP.  Path to search for related records
-
-.PARAMETER EventId
-TPP.  Event ID as found in Logging->Event Definitions
-
-.PARAMETER Severity
-TPP.  Filter records by severity
-
-.PARAMETER StartTime
-TPP.  Start time of events
-
-.PARAMETER EndTime
-TPP.  End time of events
-
-.PARAMETER Text1
-TPP.  Filter matching results of Text1
-
-.PARAMETER Text2
-TPP.  Filter matching results of Text2
-
-.PARAMETER Value1
-TPP.  Filter matching results of Value1
-
-.PARAMETER Value2
-TPP.  Filter matching results of Value2
-
-.PARAMETER Filter
-VaaS.  Array or multidimensional array of fields and values to filter on.
-Each array should be of the format @('operator', @(field, comparison operator, value), @(field2, comparison operator2, value2)).
-Nested filters are supported.
-For a complete list of comparison operators, see https://docs.venafi.cloud/api/about-api-search-operators/.
-
-.PARAMETER Order
-VaaS.  Array of fields to order on.
-For each item in the array, you can provide a field name by itself; this will default to ascending.
-You can also provide a hashtable with the field name as the key and either asc or desc as the value.
-
-.PARAMETER VenafiSession
-Authentication for the function.
-The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-A TPP token or VaaS key can also provided.
-If providing a TPP token, an environment variable named TPP_SERVER must also be set.
-
-.INPUTS
-Path (for TPP)
-
-.OUTPUTS
-PSCustomObject
-For TPP:
-    EventId
-    ClientTimestamp
-    Component
-    ComponentId
-    ComponentSubsystem
-    Data
-    Grouping
-    Id
-    Name
-    ServerTimestamp
-    Severity
-    SourceIP
-    Text1
-    Text2
-    Value1
-    Value2
-For VaaS:
-    id
-    companyId
-    userId
-    activityDate
-    authenticationType
-    resourceUrl
-    resourceId
-    messageKey
-    messageKeyKey
-    messageArgs
-    message
-
-.EXAMPLE
-Read-VenafiLog -First 10
-
-Get the most recent 10 log items
-
-.EXAMPLE
-$capiObject | Read-VenafiLog
-
-Find all events for a specific TPP object
-
-.EXAMPLE
-Read-VenafiLog -EventId '00130003'
-
-Find all TPP events with event ID '00130003', Certificate Monitor - Certificate Expiration Notice
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE'))
-
-Filter VaaS log results
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -First 5
-
-Get first 5 VaaS entries of filtered log results
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('activityDate', 'gt', (get-date).AddMonths(-1)), @('or', @('userId', 'eq', 'ab0feb46-8df7-47e7-8da9-f47ab314f26a'), @('userId', 'eq', '933c28de-6352-46f3-bc12-bd96077e8eae')))
-
-Advanced filtering of VaaS results.  This filter will find log entries by 1 of 2 people within the last month.
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order 'activityDate'
-
-Filter VaaS log results and order them
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order @{'activityDate'='desc'}
-
-Filter VaaS log results and order them descending
-
-.EXAMPLE
-Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order @{'activityDate'='desc'}, 'statusCode'
-
-Filter VaaS log results and order them by multiple fields
-
-.LINK
-https://api.venafi.cloud/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/Activity%20Logs/activitylogs_getByExpression
-
-.LINK
-http://VenafiPS.readthedocs.io/en/latest/functions/Read-TppLog/
-
-.LINK
-https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Read-TppLog.ps1
-
-.LINK
-https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Log.php
-
-#>
 function Read-VenafiLog {
+    <#
+    .SYNOPSIS
+    Read entries from the VaaS or TPP log
+
+    .DESCRIPTION
+    Read entries from the VaaS or TPP log.
+    Supports -First for paging.
+    Limit of 1000 records.
+
+    .PARAMETER Path
+    TPP.  Path to search for related records
+
+    .PARAMETER EventId
+    TPP.  Event ID as found in Logging->Event Definitions
+
+    .PARAMETER Severity
+    TPP.  Filter records by severity
+
+    .PARAMETER StartTime
+    TPP.  Start time of events
+
+    .PARAMETER EndTime
+    TPP.  End time of events
+
+    .PARAMETER Text1
+    TPP.  Filter matching results of Text1
+
+    .PARAMETER Text2
+    TPP.  Filter matching results of Text2
+
+    .PARAMETER Value1
+    TPP.  Filter matching results of Value1
+
+    .PARAMETER Value2
+    TPP.  Filter matching results of Value2
+
+    .PARAMETER Filter
+    VaaS.  Array or multidimensional array of fields and values to filter on.
+    Each array should be of the format @('operator', @(field, comparison operator, value), @(field2, comparison operator2, value2)).
+    Nested filters are supported.
+    For a complete list of comparison operators, see https://docs.venafi.cloud/api/about-api-search-operators/.
+
+    .PARAMETER Order
+    VaaS.  Array of fields to order on.
+    For each item in the array, you can provide a field name by itself; this will default to ascending.
+    You can also provide a hashtable with the field name as the key and either asc or desc as the value.
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TPP token or VaaS key can also provided.
+    If providing a TPP token, an environment variable named TPP_SERVER must also be set.
+
+    .INPUTS
+    Path (for TPP)
+
+    .OUTPUTS
+    PSCustomObject
+    For TPP:
+        EventId
+        ClientTimestamp
+        Component
+        ComponentId
+        ComponentSubsystem
+        Data
+        Grouping
+        Id
+        Name
+        ServerTimestamp
+        Severity
+        SourceIP
+        Text1
+        Text2
+        Value1
+        Value2
+    For VaaS:
+        id
+        companyId
+        userId
+        activityDate
+        authenticationType
+        resourceUrl
+        resourceId
+        messageKey
+        messageKeyKey
+        messageArgs
+        message
+
+    .EXAMPLE
+    Read-VenafiLog -First 10
+
+    Get the most recent 10 log items
+
+    .EXAMPLE
+    $capiObject | Read-VenafiLog
+
+    Find all events for a specific TPP object
+
+    .EXAMPLE
+    Read-VenafiLog -EventId '00130003'
+
+    Find all TPP events with event ID '00130003', Certificate Monitor - Certificate Expiration Notice
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE'))
+
+    Filter VaaS log results
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -First 5
+
+    Get first 5 VaaS entries of filtered log results
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('activityDate', 'gt', (get-date).AddMonths(-1)), @('or', @('userId', 'eq', 'ab0feb46-8df7-47e7-8da9-f47ab314f26a'), @('userId', 'eq', '933c28de-6352-46f3-bc12-bd96077e8eae')))
+
+    Advanced filtering of VaaS results.  This filter will find log entries by 1 of 2 people within the last month.
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order 'activityDate'
+
+    Filter VaaS log results and order them
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order @{'activityDate'='desc'}
+
+    Filter VaaS log results and order them descending
+
+    .EXAMPLE
+    Read-VenafiLog -Filter @('and', @('authenticationType', 'eq', 'NONE')) -Order @{'activityDate'='desc'}, 'statusCode'
+
+    Filter VaaS log results and order them by multiple fields
+
+    .LINK
+    https://api.venafi.cloud/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/Activity%20Logs/activitylogs_getByExpression
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Read-TppLog/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Read-TppLog.ps1
+
+    .LINK
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Log.php
+
+    #>
 
     [CmdletBinding(DefaultParameterSetName = 'TPP', SupportsPaging)]
     [Alias('Read-TppLog')]
@@ -155,8 +155,7 @@ function Read-VenafiLog {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -203,30 +202,10 @@ function Read-VenafiLog {
 
         $platform = Test-VenafiSession -VenafiSession $VenafiSession -PassThru
 
-        if ( $PSBoundParameters.Keys -contains 'Skip' -or $PSBoundParameters.Keys -contains 'IncludeTotalCount' ) {
-            Write-Warning '-Skip and -IncludeTotalCount not implemented yet'
-        }
-
-        if ( $platform -eq 'VaaS' ) {
-            $queryParams = @{
-                Filter            = $Filter
-                Order             = $Order
-                First             = $PSCmdlet.PagingParameters.First
-                Skip              = $PSCmdlet.PagingParameters.Skip
-                IncludeTotalCount = $PSCmdlet.PagingParameters.IncludeTotalCount
+        if ( $platform -eq 'TPP' ) {
+            if ( $PSBoundParameters.Keys -contains 'Skip' -or $PSBoundParameters.Keys -contains 'IncludeTotalCount' ) {
+                Write-Warning '-Skip and -IncludeTotalCount not implemented yet'
             }
-
-            $body = New-VaasSearchQuery @queryParams
-
-            $params = @{
-                VenafiSession = $VenafiSession
-                Method        = 'Post'
-                UriRoot       = 'v1'
-                UriLeaf       = 'activitylogsearch'
-                Body          = $body
-            }
-        }
-        else {
 
             $params = @{
                 VenafiSession = $VenafiSession
@@ -279,9 +258,8 @@ function Read-VenafiLog {
     process {
 
         if ( $platform -eq 'VaaS' ) {
-            Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty activityLogEntries
-        }
-        else {
+            Find-VaasObject -Type ActivityLog @PSBoundParameters
+        } else {
 
             if ( $PSBoundParameters.ContainsKey('Path') ) {
                 $params.Body.Component = $Path

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -106,7 +106,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Import-VaasCertificate', 'Get-VaasConnector', 'Remove-VaasConnector',
                'New-VaasConnector', 'Find-TppEngine', 'Get-TppEngineFolder',
                'Remove-TppEngineFolder', 'Add-TppEngineFolder', 'Revoke-TppGrant',
-               'Add-TppAdaptableHash', 'New-VaasCertificate'
+               'Add-TppAdaptableHash', 'New-VaasCertificate', 'Find-VaasObject'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -95,5 +95,9 @@ $vaasFields = @(
     'keyUsage',
     'extendedKeyUsage',
     'ocspNoCheck',
-    'versionType'
+    'versionType',
+    'activityDate',
+    'activityType',
+    'activityName',
+    'criticality'
 )

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -19,8 +19,7 @@ foreach ( $folder in $folders) {
             if ( $folder -eq 'Public' ) {
                 Export-ModuleMember -Function $thisFile.Basename
             }
-        }
-        Catch {
+        } Catch {
             Write-Error ("Failed to import function {0}: {1}" -f $thisFile.fullname, $folder)
         }
     }
@@ -56,5 +55,45 @@ Export-ModuleMember -Alias *
 # Force TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-
-
+# vaas fields to ensure the values are upper case
+$vaasValuesToUpper = 'certificateStatus', 'signatureAlgorithm', 'signatureHashAlgorithm', 'encryptionType', 'versionType', 'certificateSource', 'deploymentStatus'
+# vaas fields proper case
+$vaasFields = @(
+    'certificateId',
+    'applicationIds',
+    'companyId',
+    'managedCertificateId',
+    'fingerprint',
+    'certificateName',
+    'issuerCertificateIds',
+    'certificateStatus',
+    'statusModificationUserId',
+    'modificationDate',
+    'statusModificationDate',
+    'validityStart',
+    'validityEnd',
+    'selfSigned',
+    'signatureAlgorithm',
+    'signatureHashAlgorithm',
+    'encryptionType',
+    'keyCurve',
+    'subjectKeyIdentifierHash',
+    'authorityKeyIdentifierHash',
+    'serialNumber',
+    'subjectDN',
+    'subjectCN',
+    'subjectO',
+    'subjectST',
+    'subjectC',
+    'subjectAlternativeNamesByType',
+    'subjectAlternativeNameDns',
+    'issuerDN',
+    'issuerCN',
+    'issuerST',
+    'issuerL',
+    'issuerC',
+    'keyUsage',
+    'extendedKeyUsage',
+    'ocspNoCheck',
+    'versionType'
+)


### PR DESCRIPTION
- field names and values are case sensitive in vaas.  this causes searches to fail eg. when using certificatestatus as opposed to certificateStatus.  update `New-VaasSearchQuery`:
  - ensure field name is proper case
  - convert field values to upper case where appropriate
- cache app data in `Find-VenafiCertificate` to keep from getting each time for each cert
- Add `Find-VaasObject` to search for ActivityLog, Machine, MachineIdentity, CertificateRequest, CertificateInstance
- `Import-VaasCertificate -PassThru` now returns usable certificate info
- Fix `Import-VaasCertificate` passing empty application value
- Add `-IssueDateBefore` and `-IssueDateAfter` to `Find-VenafiCertificate` for TPP