### PR TITLE
Minor bug fixes for issues

### DIFF
--- a/VenafiPS/Public/ConvertTo-TppGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-TppGuid.ps1
@@ -80,31 +80,5 @@ function ConvertTo-TppGuid {
         } else {
             throw $response.Error
         }
-        switch ([enum]::GetName([TppConfigResult], $response.Result)) {
-
-            'Success' {
-                if ( $IncludeType ) {
-                    [PSCustomObject] @{
-                        Guid     = [Guid] $response.Guid
-                        TypeName = $response.ClassName
-                    }
-                } else {
-                    [Guid] $response.Guid
-                }
-            }
-
-            'ObjectDoesNotExist' {
-                # return null instead of an error 
-                return $null
-            }
-
-            'ObjectAlreadyExists' {
-                throw "$Path already exists"
-            }
-
-            Default {
-                throw $response.Error
-            }
-        }
     }
 }

--- a/VenafiPS/Public/ConvertTo-TppGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-TppGuid.ps1
@@ -80,5 +80,31 @@ function ConvertTo-TppGuid {
         } else {
             throw $response.Error
         }
+        switch ([enum]::GetName([TppConfigResult], $response.Result)) {
+
+            'Success' {
+                if ( $IncludeType ) {
+                    [PSCustomObject] @{
+                        Guid     = [Guid] $response.Guid
+                        TypeName = $response.ClassName
+                    }
+                } else {
+                    [Guid] $response.Guid
+                }
+            }
+
+            'ObjectDoesNotExist' {
+                # return null instead of an error 
+                return $null
+            }
+
+            'ObjectAlreadyExists' {
+                throw "$Path already exists"
+            }
+
+            Default {
+                throw $response.Error
+            }
+        }
     }
 }

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -271,7 +271,7 @@ function Invoke-VenafiCertificateAction {
 
         if ( $performInvoke ) {
             try {
-                Invoke-VenafiRestMethod @params -FullResponse | Out-Null
+                $null = Invoke-VenafiRestMethod @params -FullResponse
             } catch {
                 $returnObject.Success = $false
                 $returnObject.Error = $_

--- a/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VenafiCertificateAction.ps1
@@ -271,7 +271,7 @@ function Invoke-VenafiCertificateAction {
 
         if ( $performInvoke ) {
             try {
-                Invoke-VenafiRestMethod @params -FullResponse -Verbose | Out-Null
+                Invoke-VenafiRestMethod @params -FullResponse | Out-Null
             } catch {
                 $returnObject.Success = $false
                 $returnObject.Error = $_

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -133,7 +133,11 @@ function Set-TppAttribute {
         $Attribute.GetEnumerator() | ForEach-Object {
 
             $thisKey = $_.Key
-            $thisValue = ($_.Value).ToString()
+            if ($null -ne $_.Value) {
+                $thisValue = ($_.Value).ToString()
+            } else {
+                $thisValue = $_.Value
+            }
             $customFieldError = $null
 
             $customField = $VenafiSession.CustomField | Where-Object { $_.Label -eq $thisKey -or $_.Guid -eq $thisKey }


### PR DESCRIPTION
ConvertTo-TppGuid return null instead of an error when search result is empty (part of 170)
Invoke-VenafiCertificateAction always run as verbose (https://github.com/Venafi/VenafiPS/issues/173)
Set-TppAttribute gives error when using $null as value (https://github.com/Venafi/VenafiPS/issues/176)
