### PR TITLE
add 'all' scope

### DIFF
--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -60,7 +60,7 @@ function Write-VerboseWithSecret {
 
         foreach ($prop in $PropertyName) {
 
-            # look for values in json string, eg. "Body": "{"Password":"MyPass"}"
+            # look for values in json string, eg. "Body": "{"Password":"MyPass"}" or {\"Password\":\"MyPass\"}
             if ( $processMe -match "\\?""$prop\\?"":\\?""(.*?)\\?""" ) {
                 $processMe = $processMe.replace($matches[1], '***hidden***')
             }

--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -61,7 +61,7 @@ function Write-VerboseWithSecret {
         foreach ($prop in $PropertyName) {
 
             # look for values in json string, eg. "Body": "{"Password":"MyPass"}"
-            if ( $processMe -match "\""$prop\"":\""(.*?)\""" ) {
+            if ( $processMe -match "\\?""$prop\\?"":\\?""(.*?)\\?""" ) {
                 $processMe = $processMe.replace($matches[1], '***hidden***')
             }
         }

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -218,6 +218,10 @@ function Invoke-VenafiRestMethod {
         $params.Add('Certificate', $Certificate)
     }
 
+    if ( $env:VENAFIPS_SKIP_CERT_CHECK -eq '1' ) {
+        $params.Add('SkipCertificateCheck', $true)
+    }
+
     $oldProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
 

--- a/VenafiPS/Public/New-TppToken.ps1
+++ b/VenafiPS/Public/New-TppToken.ps1
@@ -2,18 +2,18 @@ function New-TppToken {
     <#
     .SYNOPSIS
     Get a new access token or refresh an existing one
-    
+
     .DESCRIPTION
     Get an access token and refresh token (if enabled) to be used with New-VenafiSession or other scripts/utilities that take such a token.
     You can also refresh an existing access token if you have the associated refresh token.
     Authentication can be provided as integrated, credential, or certificate.
-    
+
     .PARAMETER AuthServer
     Auth server or url, eg. venafi.company.com
-    
+
     .PARAMETER ClientId
     Applcation Id configured in Venafi for token-based authentication
-    
+
     .PARAMETER Scope
     Hashtable with Scopes and privilege restrictions.
     The key is the scope and the value is one or more privilege restrictions separated by commas.
@@ -23,45 +23,45 @@ function New-TppToken {
     Using a scope of {'all'='core'} will set all scopes except for admin.
     Using a scope of {'all'='admin'} will set all scopes including admin.
     Usage of the 'all' scope is not suggested for production.
-    
+
     .PARAMETER Credential
     Username / password credential used to request API Token
-    
+
     .PARAMETER State
     A session state, redirect URL, or random string to prevent Cross-Site Request Forgery (CSRF) attacks
-    
+
     .PARAMETER Certificate
     Certificate used to request API token.  Certificate authentication must be configured for remote web sdk clients, https://docs.venafi.com/Docs/current/TopNav/Content/CA/t-CA-ConfiguringInTPPandIIS-tpp.php.
-    
+
     .PARAMETER RefreshToken
     Provide RefreshToken along with ClientId to obtain a new access and refresh token.  Format should be a pscredential where the password is the refresh token.
-    
+
     .PARAMETER VenafiSession
     VenafiSession object created from New-VenafiSession method.
-    
+
     .EXAMPLE
     New-TppToken -AuthServer 'https://mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Credential $credential
     Get a new token with OAuth
-    
+
     .EXAMPLE
     New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId'
     Get a new token with Integrated authentication
-    
+
     .EXAMPLE
     New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Certificate $cert
     Get a new token with certificate authentication
-    
+
     .EXAMPLE
     New-TppToken -AuthServer 'mytppserver.example.com' -ClientId 'MyApp' -RefreshToken $refreshCred
     Refresh an existing access token by providing the refresh token directly
-    
+
     .EXAMPLE
     New-TppToken -VenafiSession $mySession
     Refresh an existing access token by providing a VenafiSession object
-    
+
     .INPUTS
     None
-    
+
     .OUTPUTS
     PSCustomObject with the following properties:
         Server
@@ -121,6 +121,9 @@ function New-TppToken {
         [Parameter(ParameterSetName = 'RefreshToken', Mandatory)]
         [pscredential] $RefreshToken,
 
+        [Parameter()]
+        [switch] $SkipCertificateCheck,
+
         [Parameter(ParameterSetName = 'RefreshSession', Mandatory)]
         [ValidateScript( {
                 if ( -not $_.Token.RefreshToken ) {
@@ -141,6 +144,7 @@ function New-TppToken {
         Method  = 'Post'
         UriRoot = 'vedauth'
         Body    = @{}
+        SkipCertificateCheck = $SkipCertificateCheck
     }
 
     if ( $PsCmdlet.ParameterSetName -eq 'RefreshSession' ) {

--- a/VenafiPS/Public/New-TppToken.ps1
+++ b/VenafiPS/Public/New-TppToken.ps1
@@ -1,76 +1,79 @@
-<#
-.SYNOPSIS
-Get a new access token or refresh an existing one
-
-.DESCRIPTION
-Get an access token and refresh token (if enabled) to be used with New-VenafiSession or other scripts/utilities that take such a token.
-You can also refresh an existing access token if you have the associated refresh token.
-Authentication can be provided as integrated, credential, or certificate.
-
-.PARAMETER AuthServer
-Auth server or url, eg. venafi.company.com
-
-.PARAMETER ClientId
-Applcation Id configured in Venafi for token-based authentication
-
-.PARAMETER Scope
-Hashtable with Scopes and privilege restrictions.
-The key is the scope and the value is one or more privilege restrictions separated by commas.
-A privilege restriction of none or read, use a value of $null.
-Scopes include Agent, Certificate, Code Signing, Configuration, Restricted, Security, SSH, and statistics.
-See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/AuthSDK/r-SDKa-OAuthScopePrivilegeMapping.php
-
-.PARAMETER Credential
-Username / password credential used to request API Token
-
-.PARAMETER State
-A session state, redirect URL, or random string to prevent Cross-Site Request Forgery (CSRF) attacks
-
-.PARAMETER Certificate
-Certificate used to request API token.  Certificate authentication must be configured for remote web sdk clients, https://docs.venafi.com/Docs/current/TopNav/Content/CA/t-CA-ConfiguringInTPPandIIS-tpp.php.
-
-.PARAMETER RefreshToken
-Provide RefreshToken along with ClientId to obtain a new access and refresh token.  Format should be a pscredential where the password is the refresh token.
-
-.PARAMETER VenafiSession
-VenafiSession object created from New-VenafiSession method.
-
-.EXAMPLE
-New-TppToken -AuthServer 'https://mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Credential $credential
-Get a new token with OAuth
-
-.EXAMPLE
-New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId'
-Get a new token with Integrated authentication
-
-.EXAMPLE
-New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Certificate $cert
-Get a new token with certificate authentication
-
-.EXAMPLE
-New-TppToken -AuthServer 'mytppserver.example.com' -ClientId 'MyApp' -RefreshToken $refreshCred
-Refresh an existing access token by providing the refresh token directly
-
-.EXAMPLE
-New-TppToken -VenafiSession $mySession
-Refresh an existing access token by providing a VenafiSession object
-
-.INPUTS
-None
-
-.OUTPUTS
-PSCustomObject with the following properties:
-    Server
-    AccessToken
-    RefreshToken
-    Scope
-    Identity
-    TokenType
-    ClientId
-    Expires
-    RefreshExpires (This property is null when TPP version is less than 21.1)
-#>
 function New-TppToken {
+    <#
+    .SYNOPSIS
+    Get a new access token or refresh an existing one
+    
+    .DESCRIPTION
+    Get an access token and refresh token (if enabled) to be used with New-VenafiSession or other scripts/utilities that take such a token.
+    You can also refresh an existing access token if you have the associated refresh token.
+    Authentication can be provided as integrated, credential, or certificate.
+    
+    .PARAMETER AuthServer
+    Auth server or url, eg. venafi.company.com
+    
+    .PARAMETER ClientId
+    Applcation Id configured in Venafi for token-based authentication
+    
+    .PARAMETER Scope
+    Hashtable with Scopes and privilege restrictions.
+    The key is the scope and the value is one or more privilege restrictions separated by commas.
+    A privilege restriction of none or read, use a value of $null.
+    Scopes include Agent, Certificate, Code Signing, Configuration, Restricted, Security, SSH, and statistics.
+    See https://docs.venafi.com/Docs/current/TopNav/Content/SDK/AuthSDK/r-SDKa-OAuthScopePrivilegeMapping.php
+    Using a scope of {'all'='core'} will set all scopes except for admin.
+    Using a scope of {'all'='admin'} will set all scopes including admin.
+    Usage of the 'all' scope is not suggested for production.
+    
+    .PARAMETER Credential
+    Username / password credential used to request API Token
+    
+    .PARAMETER State
+    A session state, redirect URL, or random string to prevent Cross-Site Request Forgery (CSRF) attacks
+    
+    .PARAMETER Certificate
+    Certificate used to request API token.  Certificate authentication must be configured for remote web sdk clients, https://docs.venafi.com/Docs/current/TopNav/Content/CA/t-CA-ConfiguringInTPPandIIS-tpp.php.
+    
+    .PARAMETER RefreshToken
+    Provide RefreshToken along with ClientId to obtain a new access and refresh token.  Format should be a pscredential where the password is the refresh token.
+    
+    .PARAMETER VenafiSession
+    VenafiSession object created from New-VenafiSession method.
+    
+    .EXAMPLE
+    New-TppToken -AuthServer 'https://mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Credential $credential
+    Get a new token with OAuth
+    
+    .EXAMPLE
+    New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId'
+    Get a new token with Integrated authentication
+    
+    .EXAMPLE
+    New-TppToken -AuthServer 'mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Configuration = "manage" } -ClientId 'MyAppId' -Certificate $cert
+    Get a new token with certificate authentication
+    
+    .EXAMPLE
+    New-TppToken -AuthServer 'mytppserver.example.com' -ClientId 'MyApp' -RefreshToken $refreshCred
+    Refresh an existing access token by providing the refresh token directly
+    
+    .EXAMPLE
+    New-TppToken -VenafiSession $mySession
+    Refresh an existing access token by providing a VenafiSession object
+    
+    .INPUTS
+    None
+    
+    .OUTPUTS
+    PSCustomObject with the following properties:
+        Server
+        AccessToken
+        RefreshToken
+        Scope
+        Identity
+        TokenType
+        ClientId
+        Expires
+        RefreshExpires (This property is null when TPP version is less than 21.1)
+    #>
 
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Integrated')]
     [OutputType([PSCustomObject])]
@@ -171,16 +174,23 @@ function New-TppToken {
         }
         else {
             # obtain new token
-            $scopeString = @(
-                $scope.GetEnumerator() | ForEach-Object {
-                    if ($_.Value) {
-                        '{0}:{1}' -f $_.Key, $_.Value
+
+            $scopeString = if ( $Scope.all -eq 'core' ) {
+                'agent:delete;certificate:approve,delete,discover,manage,revoke;configuration:delete,manage;restricted:delete,manage;security:delete,manage;ssh:approve,delete,discover,manage;statistics;codesign:delete,manage;codesignclient'
+            } elseif ($Scope.all -eq 'admin' ) {
+                'admin:delete,viewlogs,recyclebin;agent:delete;certificate:delete,discover,manage,revoke;configuration:delete,manage;restricted:delete,manage;security:delete,manage;ssh:approve,delete,discover,manage;statistics;codesign:approve,admin,delete,manage;codesignclient'
+            } else {
+                @(
+                    $scope.GetEnumerator() | ForEach-Object {
+                        if ($_.Value) {
+                            '{0}:{1}' -f $_.Key, $_.Value
+                        }
+                        else {
+                            $_.Key
+                        }
                     }
-                    else {
-                        $_.Key
-                    }
-                }
-            ) -join ';'
+                ) -join ';'
+            }
 
             $params.Body = @{
                 client_id = $ClientId

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -40,7 +40,6 @@ function New-VenafiSession {
     Name of the SecretManagement vault entry for the access token; the name of the vault must be VenafiPS.
     This value can be provided standalone or with credentials.  First time use requires it to be provided with credentials to retrieve the access token to populate the vault.
     With subsequent uses, it can be provided standalone and the access token will be retrieved without the need for credentials.
-    See -VaultMetadata to store server and clientid with the token.
 
     .PARAMETER RefreshToken
     PSCredential object with the refresh token as the password.  An access token will be retrieved and a new session created.
@@ -50,7 +49,6 @@ function New-VenafiSession {
     This value can be provided standalone or with credentials.  Each time this is used, a new access and refresh token will be obtained.
     First time use requires it to be provided with credentials to retrieve the refresh token and populate the vault.
     With subsequent uses, it can be provided standalone and the refresh token will be retrieved without the need for credentials.
-    See -VaultMetadata to store server and clientid with the token.
 
     .PARAMETER Certificate
     Certificate for token-based authentication


### PR DESCRIPTION
- add 'all' scope for testing purposes.  you can use @{'all'='core'} or @{'all'='admin'}.  not recommended for production.
- when vaulting metadata during session creation, the Scope will now be included
- hide secrets in json format, with delimited quotes, in `Write-VerboseWithSecret`.  eg {\\"Password\\":\\"MyPass\\"}
- skip certificate check with environment variable VENAFIPS_SKIP_CERT_CHECK=1 or -SkipCertificateCheck on New-VenafiSession