### PR TITLE
Saved search find, add Get-VaasSatellite, add Set-VaasCertificateAssignment

### DIFF
--- a/VenafiPS/Public/Get-VaasSatellite.ps1
+++ b/VenafiPS/Public/Get-VaasSatellite.ps1
@@ -1,0 +1,152 @@
+function Get-VaasSatellite {
+    <#
+    .SYNOPSIS
+    Get VSatellite info
+
+    .DESCRIPTION
+    Get info for either a specific VSatellite or all.
+    There is an option to also include the encryption key and algorithm.
+
+    .PARAMETER ID
+    Name or uuid to get info for a specific VSatellite
+
+    .PARAMETER All
+    Get all VSatellites
+
+    .PARAMETER IncludeKey
+    Include the encryption key and algorithm
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A VaaS key can also provided.
+
+    .INPUTS
+    ID
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    Get-VaasSatellite -ID 'VSatellite Hub 0001'
+
+    Get info for a specific VSatellite by name
+
+    .EXAMPLE
+    Get-VaasSatellite -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+
+    Get info for a specific VSatellite
+
+    .EXAMPLE
+    Get-VaasSatellite -All
+
+    Get info for all VSatellites
+
+    .EXAMPLE
+    Get-VaasSatellite -All -IncludeKey
+
+    Get info for VSatellites including the encryption key and algorithm
+
+    .LINK
+    http://VenafiPS.readthedocs.io/en/latest/functions/Get-VaasSatellite/
+
+    .LINK
+    https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Get-VaasSatellite.ps1
+
+    .LINK
+    https://developer.venafi.com/tlsprotectcloud/reference/edgeinstances_getall
+
+    .LINK
+    https://developer.venafi.com/tlsprotectcloud/reference/edgeencryptionkeys_getall
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'ID')]
+
+    param (
+
+        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('applicationId')]
+        [string] $ID,
+
+        [Parameter(ParameterSetName = 'All', Mandatory)]
+        [switch] $All,
+
+        [Parameter()]
+        [switch] $IncludeKey,
+
+        [Parameter()]
+        [psobject] $VenafiSession = $script:VenafiSession
+    )
+
+    begin {
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
+
+        $params = @{
+            VenafiSession = $VenafiSession
+            Method        = 'Get'
+        }
+
+        # get all keys once and perform lookup later
+        if ( $IncludeKey ) {
+            $allKeys = Invoke-VenafiRestMethod -UriLeaf 'edgeencryptionkeys' -VenafiSession $VenafiSession | Select-Object -ExpandProperty encryptionKeys
+        }
+    }
+
+    process {
+
+        if ( $PSCmdlet.ParameterSetName -eq 'All' ) {
+            $params.UriLeaf = 'edgeinstances'
+            $response = Invoke-VenafiRestMethod @params
+        }
+        else {
+            if ( [guid]::TryParse($ID, $([ref][guid]::Empty)) ) {
+                $guid = [guid] $ID
+                $params.UriLeaf = 'edgeinstances/{0}' -f $guid.ToString()
+                $response = Invoke-VenafiRestMethod @params
+            }
+            else {
+                # assume team name
+                $params.UriLeaf = 'edgeinstances'
+                $allInstances = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty edgeinstances
+                $response = $allInstances | Where-Object { $_.name -eq $ID }
+            }
+        }
+
+        if ( -not $response ) {
+            continue
+        }
+
+        if ( $response.PSObject.Properties.Name -contains 'edgeinstances' ) {
+            $thisInstance = $response | Select-Object -ExpandProperty edgeinstances
+        }
+        else {
+            $thisInstance = $response
+        }
+
+        $thisInstance | Select-Object *,
+        @{
+            'n' = 'vsatelliteId'
+            'e' = {
+                $_.Id
+            }
+        },
+        @{
+            'n' = 'encryptionKey'
+            'e' = {
+                if ( $IncludeKey ) {
+                    $thisId = $_.encryptionKeyId
+                    ($allKeys | Where-Object { $_.id -eq $thisId }).key
+                }
+            }
+        },
+        @{
+            'n' = 'encryptionKeyAlgorithm'
+            'e' = {
+                if ( $IncludeKey ) {
+                    $thisId = $_.encryptionKeyId
+                    ($allKeys | Where-Object { $_.id -eq $thisId }).KeyAlgorithm
+                }
+            }
+        } -ExcludeProperty Id
+    }
+}

--- a/VenafiPS/Public/Get-VaasSatellite.ps1
+++ b/VenafiPS/Public/Get-VaasSatellite.ps1
@@ -30,6 +30,27 @@ function Get-VaasSatellite {
     .EXAMPLE
     Get-VaasSatellite -ID 'VSatellite Hub 0001'
 
+    companyId                   : a05013bd-921d-440c-bc22-c9ead5c8d548
+    productEntitlements         : {ANY}
+    environmentId               : a05013bd-921d-440c-bc22-c9ead5c8d548
+    pairingCodeId               : a05013bd-921d-440c-bc22-c9ead5c8d548
+    name                        : VSatellite Hub 0001
+    edgeType                    : HUB
+    edgeStatus                  : ACTIVE
+    clientId                    : a05013bd-921d-440c-bc22-c9ead5c8d548
+    modificationDate            : 6/15/2023 11:48:40 AM
+    address                     : 1.2.3.4
+    deploymentDate              : 6/15/2023 11:44:14 AM
+    lastSeenOnDate              : 7/13/2023 12:00:40 PM
+    reconciliationFailed        : False
+    encryptionKeyId             : mwU4oTet9KwTGggRfhek0UtvighIw=
+    encryptionKeyDeploymentDate : 6/15/2023 11:48:40 AM
+    kubernetesVersion           : v1.23.6+k3s1
+    integrationServicesCount    : 0
+    vsatelliteId                : a05013bd-921d-440c-bc22-c9ead5c8d548
+    encryptionKey               :
+    encryptionKeyAlgorithm      :
+
     Get info for a specific VSatellite by name
 
     .EXAMPLE
@@ -44,6 +65,27 @@ function Get-VaasSatellite {
 
     .EXAMPLE
     Get-VaasSatellite -All -IncludeKey
+
+    companyId                   : a05013bd-921d-440c-bc22-c9ead5c8d548
+    productEntitlements         : {ANY}
+    environmentId               : a05013bd-921d-440c-bc22-c9ead5c8d548
+    pairingCodeId               : a05013bd-921d-440c-bc22-c9ead5c8d548
+    name                        : VSatellite Hub 0001
+    edgeType                    : HUB
+    edgeStatus                  : ACTIVE
+    clientId                    : a05013bd-921d-440c-bc22-c9ead5c8d548
+    modificationDate            : 6/15/2023 11:48:40 AM
+    address                     : 1.2.3.4
+    deploymentDate              : 6/15/2023 11:44:14 AM
+    lastSeenOnDate              : 7/13/2023 12:00:40 PM
+    reconciliationFailed        : False
+    encryptionKeyId             : mwU4oTet9KwTGggRfhek0UtvighIw=
+    encryptionKeyDeploymentDate : 6/15/2023 11:48:40 AM
+    kubernetesVersion           : v1.23.6+k3s1
+    integrationServicesCount    : 0
+    vsatelliteId                : a05013bd-921d-440c-bc22-c9ead5c8d548
+    encryptionKey               : o4aFaJUTtCydprvgRupQ1ZiY=
+    encryptionKeyAlgorithm      : ED25519
 
     Get info for VSatellites including the encryption key and algorithm
 

--- a/VenafiPS/Public/Get-VaasSatellite.ps1
+++ b/VenafiPS/Public/Get-VaasSatellite.ps1
@@ -138,7 +138,7 @@ function Get-VaasSatellite {
 
         if ( $PSCmdlet.ParameterSetName -eq 'All' ) {
             $params.UriLeaf = 'edgeinstances'
-            $response = Invoke-VenafiRestMethod @params
+            $response = Invoke-VenafiRestMethod @params | Select-Object -ExpandProperty edgeinstances
         }
         else {
             if ( [guid]::TryParse($ID, $([ref][guid]::Empty)) ) {
@@ -158,14 +158,7 @@ function Get-VaasSatellite {
             continue
         }
 
-        if ( $response.PSObject.Properties.Name -contains 'edgeinstances' ) {
-            $thisInstance = $response | Select-Object -ExpandProperty edgeinstances
-        }
-        else {
-            $thisInstance = $response
-        }
-
-        $thisInstance | Select-Object *,
+        $response | Select-Object *,
         @{
             'n' = 'vsatelliteId'
             'e' = {

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -178,15 +178,6 @@ function New-VenafiSession {
         [Parameter(Mandatory, ParameterSetName = 'RefreshToken')]
         [Parameter(ParameterSetName = 'VaultAccessToken')]
         [Parameter(ParameterSetName = 'VaultRefreshToken')]
-        [ValidateScript( {
-                if ( $_ -match '^(https?:\/\/)?(((?!-))(xn--|_{1,1})?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$' ) {
-                    $true
-                }
-                else {
-                    throw "'$_' is not a valid server url, it should look like https://venafi.company.com or venafi.company.com"
-                }
-            }
-        )]
         [Alias('ServerUrl', 'Url')]
         [string] $Server,
 

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -505,7 +505,13 @@ function New-VenafiSession {
         $newSession | Add-Member @{ CustomField = $certFields.Items | Sort-Object -Property Guid -Unique }
     }
     else {
-        $userInfo = Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession -ErrorAction SilentlyContinue | Select-Object -ExpandProperty user
+        $userInfo = Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession -ErrorAction SilentlyContinue | Select-Object -ExpandProperty user | Select-Object *,
+        @{
+            'n' = 'userId'
+            'e' = {
+                $_.Id
+            }
+        } -ExcludeProperty id
         $newSession | Add-Member @{'User' = $userInfo }
         # $newSession | Add-Member @{
         #     MachineType = (Invoke-VenafiRestMethod -UriLeaf 'machinetypes' -VenafiSession $newSession | Select-Object -ExpandProperty machineTypes | Select-Object @{

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -451,6 +451,10 @@ function New-VenafiSession {
         'Vaas' {
             $newSession.Server = $script:CloudUrl
             $newSession.Key = $VaasKey
+
+            if ( $VaultVaasKeyName ) {
+                Set-Secret -Name $VaultVaasKeyName -Secret $newSession.Key -Vault 'VenafiPS'
+            }
         }
 
         'VaultVaasKey' {
@@ -460,8 +464,6 @@ function New-VenafiSession {
                 throw "'$VaultVaasKeyName' secret not found in vault VenafiPS."
             }
             $newSession.Key = $keySecret
-
-            Set-Secret -Name $VaultVaasKeyName -Secret $newSession.Key -Vault 'VenafiPS'
         }
 
         Default {

--- a/VenafiPS/Public/Set-VaasCertificateAssignment.ps1
+++ b/VenafiPS/Public/Set-VaasCertificateAssignment.ps1
@@ -1,0 +1,111 @@
+﻿function Set-VaasCertificateAssignment {
+    <#
+    .SYNOPSIS
+    Associate certificates with applications
+
+    .DESCRIPTION
+    Associate one or more certificates with one or more applications.
+    The associated applications can either replace or be added to existing.
+    By default, applications will be replaced.
+
+    .PARAMETER CertificateID
+    Certificate ID to be associated
+
+    .PARAMETER ApplicationID
+    One or more application IDs
+
+    .PARAMETER NoOverwrite
+    Append to existing applications as opposed to overwriting
+
+    .PARAMETER PassThru
+    Return the newly updated certificate object(s)
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A VaaS key can also provided.
+
+    .INPUTS
+    CertificateID
+
+    .OUTPUTS
+    PSCustomObject
+
+    .EXAMPLE
+    Set-VaasCertificateAssignment -CertificateID '7ac56ec0-2017-11ee-9417-a17dd25b82f9' -ApplicationID '96fc9310-67ec-11eb-a8a7-794fe75a8e6f'
+
+    Associate a certificate to an application
+
+    .EXAMPLE
+    Set-VaasCertificateAssignment -CertificateID '7ac56ec0-2017-11ee-9417-a17dd25b82f9' -ApplicationID '96fc9310-67ec-11eb-a8a7-794fe75a8e6f', 'a05013bd-921d-440c-bc22-c9ead5c8d548'
+
+    Associate a certificate to multiple applications
+
+    .EXAMPLE
+    Find-VenafiCertificate -First 5 | Set-VaasCertificateAssignment -ApplicationID '96fc9310-67ec-11eb-a8a7-794fe75a8e6f'
+
+    Associate multiple certificates to 1 application
+
+    .EXAMPLE
+    Set-VaasCertificateAssignment -CertificateID '7ac56ec0-2017-11ee-9417-a17dd25b82f9' -ApplicationID '96fc9310-67ec-11eb-a8a7-794fe75a8e6f' -NoOverwrite
+
+    Associate a certificate to another application, keeping the existing
+    #>
+
+    [CmdletBinding()]
+
+    param (
+
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string] $CertificateID,
+
+        [Parameter(Mandatory)]
+        [string[]] $ApplicationID,
+
+        [Parameter()]
+        [switch] $NoOverwrite,
+
+        [Parameter()]
+        [switch] $PassThru,
+
+        [Parameter()]
+        [Alias('Key')]
+        [psobject] $VenafiSession = $script:VenafiSession
+    )
+
+    begin {
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VaaS'
+
+        $params = @{
+            VenafiSession = $VenafiSession
+            Method        = 'Patch'
+            UriRoot       = 'outagedetection/v1'
+            UriLeaf       = 'applications/certificates'
+            Body          = @{
+                action                 = 'REPLACE'
+                targetedApplicationIds = $ApplicationID
+            }
+        }
+
+        if ( $NoOverwrite ) {
+            $params.Body.action = 'ADD'
+        }
+
+        $allCerts = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+        $allCerts.Add($CertificateID)
+    }
+
+    end {
+        $params.Body.certificateIds = $allCerts
+
+        $response = Invoke-VenafiRestMethod @params
+
+        if ( $PassThru ) {
+            $response.certificates
+        }
+
+    }
+}

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -107,7 +107,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Remove-TppEngineFolder', 'Add-TppEngineFolder', 'Revoke-TppGrant',
                'Add-TppAdaptableHash', 'New-VaasCertificate', 'Find-VaasObject',
                'Remove-TppObject', 'Set-VaasTeam', 'Remove-VaasObject',
-               'Invoke-VaasWorkflow'
+               'Invoke-VaasWorkflow', 'Get-VaasSatellite'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -107,7 +107,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'Convert-TppObject',
                'Remove-TppEngineFolder', 'Add-TppEngineFolder', 'Revoke-TppGrant',
                'Add-TppAdaptableHash', 'New-VaasCertificate', 'Find-VaasObject',
                'Remove-TppObject', 'Set-VaasTeam', 'Remove-VaasObject',
-               'Invoke-VaasWorkflow', 'Get-VaasSatellite'
+               'Invoke-VaasWorkflow', 'Get-VaasSatellite', 'Set-VaasCertificateAssignment'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
- Add `Find-VenafiCertificate -SavedSearchName` to find VaaS certificate details via an existing saved search filter
- Add `Get-VaasSatellite` to retrieve vsatellite details optionally including encryption key and algorithm
- Add `Set-VaasCertificateAssignment` to add or replace applications associated to certificates
- Fix credentials not being written to the vault with `New-VenafiSession -VaultVaasKeyName`