### PR TITLE
Import-VcCertificate PKCS #8 support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,26 +1,2 @@
-This is a major release.  Although every attempt has been made to be backwards compatible, **existing scripts will likely require some updates**.  Please read the full release notes.
-
-- TPP is now TLS Protect Datacenter (TLSPDC) and VaaS is now TLS Protect Cloud (TLSPC).  All functions have been renamed to prefix with `-Vdc` (Venafi Datacenter) or `-Vc` (Venafi Cloud).  Combined platform functions, those prefixed with `-Venafi`, have all been updated to dedicated platform functions.  The desire to add additional functionality for each platform and reduce parameter set complexity drove this decision.  The only exception to this rule are the functions related to the session.  Aliases have been added where applicable.
-- VenafiPS is now signed.  `Test-ModuleHash` has been deprecated.
-- VenafiSession is stored for nested operations each time a function is called directly.  This has 2 main benefits:
-   - Performance enhancement bypassing `Test-VenafiSession` in nested functions
-   - No longer need to pass VenafiSession to each function when sending function output down the pipeline
- - Parallel functionality added for many functions, notably export and import certificates.  Ensure you are using PowerShell v7!
- - Add Certificate, Key, and Chain PEM to `Export-VdcCertificate` and `Export-VcCertificate` Base64 output
- - For PSCredential objects which only required a password and not username, add the ability to provide either a password String, SecureString, or PSCredential.
- - `Find-VaasObject` has been replaced with dedicated functions `Find-VcCertificateRequest`, `Find-VcLog`, `Find-VcMachine`, and `Find-VcMachineIdentity`.  These functions have property filters specific to their types making it super easy to search.
- - Environment variable names updated:
-  - TPP_SERVER -> VDC_SERVER
-  - TPP_TOKEN -> VDC_TOKEN
-  - VAAS_KEY -> VC_KEY
- - Add keystore/private key import to `Import-VcCertificate`
- - Update `Invoke-VenafiParallel` to be version aware.  Parallel on PowerShell v7+, synchronous otherwise
- - Add option to save .crt/.key with `Export-VdcCertificate` , [#226](https://github.com/Venafi/VenafiPS/issues/226)
- - Update TLSPC searching to make -Order case insensitive
- - Fix `Get-TppAttribute -Disabled` not working, [#221](https://github.com/Venafi/VenafiPS/issues/221)
- - Fix exporting JKS to a file, [#225](https://github.com/Venafi/VenafiPS/issues/225)
- - Add option to save exported certificate and key to separate files, [#226](https://github.com/Venafi/VenafiPS/issues/226)
- - `Revoke-TppCertificate` deprecated, use `Invoke-VdcCertificateAction -Revoke`
- - Dedicated removal functions created for TLSPC
- - Add filters `-IsSelfSigned` and `-IsWildcard` to `Find-VdcCertificate`
- - CodeSign Protect functions have been deprecated
+- Update `Export-VdcCertificate` to return just certificate if private key isn't available for supporting formats
+- Add support for PKCS #8 in `Import-VcCertificate`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,2 @@
 - Update `Export-VdcCertificate` to return just certificate if private key isn't available for supporting formats
-- Add support for PKCS #8 in `Import-VcCertificate`
+- Add support for PKCS #8 in `Import-VcCertificate -Data`, by file will come in a future release

--- a/VenafiPS/Private/Split-CertificateData.ps1
+++ b/VenafiPS/Private/Split-CertificateData.ps1
@@ -23,10 +23,10 @@ function Split-CertificateData {
             if ($pemLines[$i].Contains('-----END')) {
                 $thisPemLines = $pemLines[$iStart..$i]
                 if ( $pemLines[$i].Contains('KEY-----')) {
-                    $keyPem = $thisPemLines | Join-String
+                    $keyPem = ($thisPemLines | Join-String -Separator "`n") -replace "`r"
                 }
                 else {
-                    $certPem += $thisPemLines | Join-String
+                    $certPem += ($thisPemLines | Join-String -Separator "`n") -replace "`r"
                 }
                 continue
             }

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -290,7 +290,7 @@ function Export-VdcCertificate {
 
                     Write-Verbose "Saved $outFile"
 
-                    $out | Add-Member @{'OutPath' = @($outFile) }
+                    $out | Add-Member @{'OutFile' = @($outFile) }
 
                     if ( $thisBody.Format -in 'Base64 (PKCS#8)' -and $thisBody.IncludePrivateKey) {
                         # outFile will be .pem with cert and key
@@ -302,7 +302,7 @@ function Export-VdcCertificate {
                             $sw.WriteLine($splitData.CertPem)
                             Write-Verbose "Saved $crtFile"
 
-                            $out.OutPath += $crtFile
+                            $out.OutFile += $crtFile
                         }
                         finally {
                             if ($null -ne $sw) { $sw.Close() }
@@ -316,7 +316,7 @@ function Export-VdcCertificate {
                                 $sw.WriteLine($splitData.KeyPem)
                                 Write-Verbose "Saved $keyFile"
 
-                                $out.OutPath += $keyFile
+                                $out.OutFile += $keyFile
                             }
                             finally {
                                 if ($null -ne $sw) { $sw.Close() }


### PR DESCRIPTION
- Update `Export-VdcCertificate` to return just certificate if private key isn't available for supporting formats
- Add support for PKCS #8 in `Import-VcCertificate -Data`, by file will come in a future release
