### PR TITLE
Add dynamic tab completion framework

### DIFF
--- a/VenafiPS/Private/Get-VcData.ps1
+++ b/VenafiPS/Private/Get-VcData.ps1
@@ -1,0 +1,92 @@
+function Get-VcData {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [AllowEmptyString()] # providing empty string allows us to preload the script var
+        [string] $ID,
+
+        [parameter(Mandatory)]
+        [ValidateSet('Application', 'MachineType', 'VSatellite', 'Certificate')]
+        [string] $Type,
+
+        [parameter()]
+        [ValidateSet('ID', 'Name', 'Object')]
+        [string] $OutType = 'ID',
+
+        [parameter()]
+        [switch] $FailOnMultiple
+    )
+
+    begin {
+
+    }
+
+    process {
+        if ( $OutType -eq 'ID' -and $ID | Test-IsGuid ) {
+            return $ID
+        }
+
+        switch ($Type) {
+            'Application' {
+
+                if ( -not $script:vcApplication ) {
+                    $script:vcApplication = Get-VcApplication -All | Sort-Object -Property name
+                }
+
+                $thisObject = $script:vcApplication | Where-Object { $ID -in $_.name, $_.applicationId }
+            }
+
+            'VSatellite' {
+
+                if ( -not $script:vcSatellite ) {
+                    $script:vcSatellite = Get-VcSatellite -All | Sort-Object -Property name
+                }
+
+                $thisObject = $script:vcSatellite | Where-Object { $ID -in $_.name, $_.vsatelliteId }
+            }
+
+            'MachineType' {
+                if ( -not $script:vcMachineType ) {
+                    $script:vcMachineType = Invoke-VenafiRestMethod -UriLeaf 'machinetypes' |
+                    Select-Object -ExpandProperty machineTypes |
+                    Select-Object -Property @{'n' = 'machineTypeId'; 'e' = { $_.Id } }, * -ExcludeProperty id |
+                    Sort-Object -Property machineType
+                }
+                $thisObject = $script:vcMachineType | Where-Object { $ID -in $_.machineType, $_.machineTypeId }
+            }
+
+            'Certificate' {
+                $thisObject = Find-VcCertificate -Name $ID
+            }
+        }
+
+        if ( $FailOnMultiple -and @($thisObject).Count -gt 1 ) {
+            throw "Multiple $Type found"
+        }
+
+        switch ($OutType) {
+            'ID' {
+                if ( $thisObject ) {
+                    $thisObject."$("$Type")id"
+                }
+                else {
+                    if ( $ID ) {
+                        throw "$Type '$ID' does not exist"
+                    }
+                }
+            }
+
+            'Name' {
+                # TODO
+            }
+
+            'Object' {
+                $thisObject
+            }
+        }
+    }
+
+    end {
+
+    }
+}

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -38,6 +38,9 @@ function Find-VcCertificate {
     .PARAMETER SanDns
     Search for certificates with SAN DNS matching part or all of the value
 
+    .PARAMETER Application
+    Application ID or name that this certificate is associated with
+
     .PARAMETER Filter
     Array or multidimensional array of fields and values to filter on.
     Each array should be of the format @(field, comparison operator, value).
@@ -174,6 +177,9 @@ function Find-VcCertificate {
         [Parameter(ParameterSetName = 'All')]
         [string] $SanDns,
 
+        [Parameter(ParameterSetName = 'All')]
+        [string] $Application,
+
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
         [System.Collections.ArrayList] $Filter,
 
@@ -232,6 +238,9 @@ function Find-VcCertificate {
                 'ExpireBefore' { $null = $newFilter.Add(@('validityEnd', 'LTE', $ExpireBefore)) }
                 'ExpireAfter' { $null = $newFilter.Add(@('validityEnd', 'GTE', $ExpireAfter)) }
                 'SanDns' { $null = $newFilter.Add(@('subjectAlternativeNameDns', 'FIND', $SanDns)) }
+                'Application' {
+                    $newFilter.Add(@('applicationIds', 'MATCH', (Get-VcData -ID $Application -Type 'Application') ))
+                }
             }
 
             if ( $newFilter.Count -gt 1 ) { $params.Filter = $newFilter }

--- a/VenafiPS/Public/Find-VcMachine.ps1
+++ b/VenafiPS/Public/Find-VcMachine.ps1
@@ -20,8 +20,8 @@ function Find-VcMachine {
     .PARAMETER Name
     Machine name to find via regex match
 
-    .PARAMETER Type
-    Machine type.  You can use tab-ahead autocompletion for this field if you created a session with New-VenafiSession and the list of machine types are pre-populated.
+    .PARAMETER MachineType
+    Machine type.  You can use tab-ahead autocompletion for a list.
 
     .PARAMETER Status
     Machine status, either DRAFT, VERIFIED, OR UNVERIFIED.
@@ -46,7 +46,8 @@ function Find-VcMachine {
         [string] $Name,
 
         [Parameter(ParameterSetName = 'All')]
-        [string] $Type,
+        [Alias('Type')]
+        [string] $MachineType,
 
         [Parameter(ParameterSetName = 'All')]
         [ValidateSet('DRAFT', 'VERIFIED', 'UNVERIFIED')]

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -12,6 +12,7 @@ if ([Net.ServicePointManager]::SecurityProtocol.value__ -lt 3072) {
 }
 
 $folders = @('Enum', 'Classes', 'Public', 'Private')
+$publicFunction = @()
 
 foreach ( $folder in $folders) {
 
@@ -23,8 +24,10 @@ foreach ( $folder in $folders) {
             . $thisFile.fullname
             if ( $folder -eq 'Public' ) {
                 Export-ModuleMember -Function $thisFile.Basename
+                $publicFunction += $thisFile.BaseName
             }
-        } Catch {
+        }
+        Catch {
             Write-Error ("Failed to import function {0}: {1}" -f $thisFile.fullname, $folder)
         }
     }
@@ -85,3 +88,84 @@ $script:vaasFields = @(
     'activityName',
     'criticality'
 )
+
+$vcGenericArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    $objectType = $parameterName
+    if ( $parameterName -eq 'ID' ) {
+        # figure out object type based on function name since 'ID' is used in many functions
+
+    }
+
+    switch ($objectType) {
+        'Application' {
+            if ( -not $script:vcApplication ) {
+                $script:vcApplication = Get-VcApplication -All | Sort-Object -Property name
+            }
+            $script:vcApplication | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object { "'$($_.name)'" }
+        }
+
+        'MachineType' {
+            if ( -not $script:vcMachineType ) {
+                $script:vcMachineType = Invoke-VenafiRestMethod -UriLeaf 'machinetypes' |
+                Select-Object -ExpandProperty machineTypes |
+                Select-Object -Property @{'n' = 'machineTypeId'; 'e' = { $_.Id } }, * -ExcludeProperty id |
+                Sort-Object -Property machineType
+            }
+            $script:vcMachineType | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object { "'$($_.machineType)'" }
+        }
+
+        'IssuingTemplate' {
+            if ( -not $script:vcIssuingTemplate ) {
+                $script:vcIssuingTemplate = Get-VcIssuingTemplate -All | Sort-Object -Property name
+            }
+            $script:vcIssuingTemplate | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object { "'$($_.name)'" }
+        }
+
+        'VSatellite' {
+            if ( -not $script:vcVSatellite ) {
+                $script:vcVSatellite = Get-VcSatellite -All | Sort-Object -Property name
+            }
+            $script:vcVSatellite | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object { "'$($_.name)'" }
+        }
+
+        'Certificate' {
+            # there might be a ton of certs so ensure they provide at least 3 characters
+            if ( $wordToComplete.Length -ge 3 ) {
+                Find-VcCertificate -Name $wordToComplete | ForEach-Object { "'$($_.certificateName)'" }
+            }
+        }
+    }
+}
+
+# 'Application', 'MachineType', 'IssuingTemplate', 'VSatellite', 'CertificateID' | ForEach-Object {
+'Application', 'MachineType', 'VSatellite', 'Certificate' | ForEach-Object {
+    Register-ArgumentCompleter -CommandName ($publicFunction | Where-Object { $_ -like '*-Vc*' }) -ParameterName $_ -ScriptBlock $vcGenericArgCompleterSb
+}
+
+$vdcPathArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    if ( -not $wordToComplete ) {
+        # if no word provided, default to \ved\policy
+        $wordToComplete = '\VED\Policy\'
+    }
+
+    # if the path starts with ' or ", that will come along for the ride so ensure we trim that first
+    $fullWord = $wordToComplete.Trim("`"'") | ConvertTo-VdcFullPath
+    $leaf = $fullWord.Split('\')[-1]
+    $parent = $fullWord.Substring(0, $fullWord.LastIndexOf("\$leaf"))
+
+    # get items in parent folder
+    $objs = Find-VdcObject -Path $parent
+    $objs | Where-Object { $_.name -like "$leaf*" } | ForEach-Object {
+        if ( $_.TypeName -eq 'Policy' ) {
+            "'$($_.Path)\"
+        }
+        else {
+            "'$($_.Path)"
+        }
+    }
+}
+Register-ArgumentCompleter -CommandName ($publicFunction | Where-Object { $_ -like '*-Vdc*' }) -ParameterName 'Path' -ScriptBlock $vdcPathArgCompleterSb


### PR DESCRIPTION
Add framework for dynamic tab completion.

TLSPDC: currently, the Path variable is enabled.  For any Vdc functions with a Path parameter, you can now use tab completion to provide the path.  Tabbing without a value will default to '\ved\policy'. Future versions will be aware of the type of item you are looking for and filter appropriately.

TLSPC: Application, MachineType, VSatellite, and Certificate have all been enabled.  Tab completion will provide a list of names which are much easier to remember than a uuid.  All functions with these parameters have been updated to accept an id or name.

To see a bash style listing where you can see a full list and select with arrow keys, be sure to set your tab key action via `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete`