### PR TITLE
Custom field lookup, parallel cert removal

### DIFF
--- a/VenafiPS/Public/Find-VdcObject.ps1
+++ b/VenafiPS/Public/Find-VdcObject.ps1
@@ -14,7 +14,7 @@ function Find-VdcObject {
 
     .PARAMETER Pattern
     Filter against object paths.
-    If the Attribute parameter is provided, this will filter against an object's attribute values instead of the path.
+    If the Attribute parameter is provided, this will filter against an object's attribute/custom field values instead of the path.
 
     Follow the below rules:
     - To list DNs that include an asterisk (*) or question mark (?), prepend two backslashes (\\). For example, \\*.MyCompany.net treats the asterisk as a literal character and returns only certificates with DNs that match *.MyCompany.net.
@@ -24,9 +24,16 @@ function Find-VdcObject {
 
     .PARAMETER Attribute
     A list of attribute names to limit the search against.  Only valid when searching by pattern.
+    A custom field name can also be provided.
 
     .PARAMETER Recursive
     Searches the subordinates of the object specified in Path.
+
+    .PARAMETER NoLookup
+    Default functionality when finding by Attribute is to perform a lookup to see if they are custom fields or not.
+    If they are, pass along the guid instead of name required by the api for custom fields.
+    To override this behavior and use the attribute name as is, add -NoLookup.
+    Useful if on the off chance you have a custom field with the same name as a built-in attribute.
 
     .PARAMETER VenafiSession
     Authentication for the function.

--- a/VenafiPS/Public/Remove-VcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VcCertificate.ps1
@@ -43,9 +43,6 @@
         [string] $ID,
 
         [Parameter()]
-        [int32] $ThrottleLimit = 100,
-
-        [Parameter()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -6,12 +6,16 @@ function Remove-VdcCertificate {
     .DESCRIPTION
     Removes a Certificate object, all associated objects including pending workflow tickets, and the corresponding Secret Store vault information.
     You must either be a Master Admin or have Delete permission to the objects and have certificate:delete token scope.
+    Run this in parallel with PowerShell v7+ when you have a large number to process.
 
     .PARAMETER Path
     Path to the certificate to remove
 
     .PARAMETER KeepAssociatedApps
     Provide this switch to remove associations prior to certificate removal
+
+    .PARAMETER ThrottleLimit
+    Limit the number of threads when running in parallel; the default is 100.  Applicable to PS v7+ only.
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -70,34 +74,43 @@ function Remove-VdcCertificate {
         [switch] $KeepAssociatedApps,
 
         [Parameter()]
+        [int32] $ThrottleLimit = 100,
+
+        [Parameter()]
         [psobject] $VenafiSession
     )
 
     begin {
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VDC'
-
-        $params = @{
-            Method        = 'Delete'
-            UriLeaf       = 'placeholder'
-        }
+        $allCerts = [System.Collections.Generic.List[string]]::new()
 
         # use in shouldprocess messaging below
         $appsMessage = if ($KeepAssociatedApps) { 'but keep associated apps' } else { 'and associated apps' }
     }
 
     process {
-        $guid = $Path | ConvertTo-VdcGuid
-        $params.UriLeaf = "Certificates/$guid"
-
         if ( $PSCmdlet.ShouldProcess($Path, "Remove certificate $appsMessage") ) {
-            if ($KeepAssociatedApps) {
-                $associatedApps = $Path | Get-VdcAttribute -Attribute "Consumers" | Select-Object -ExpandProperty Consumers
+            $allCerts.Add($Path)
+        }
+    }
+
+    end {
+
+        Invoke-VenafiParallel -InputObject $allCerts -ScriptBlock {
+            $guid = $PSItem | ConvertTo-VdcGuid -ErrorAction SilentlyContinue
+            if ( -not $guid ) {
+                Write-Error "'$PSItem' is not a valid path"
+                return
+            }
+
+            if ($using:KeepAssociatedApps) {
+                $associatedApps = $PSItem | Get-VdcAttribute -Attribute "Consumers" | Select-Object -ExpandProperty Consumers
                 if ( $associatedApps ) {
-                    Remove-VdcCertificateAssociation -Path $Path -ApplicationPath $associatedApps -Confirm:$false
+                    Remove-VdcCertificateAssociation -Path $PSItem -ApplicationPath $associatedApps -Confirm:$false
                 }
             }
 
-            $null = Invoke-VenafiRestMethod @params
-        }
+            $null = Invoke-VenafiRestMethod -Method Delete -UriLeaf "Certificates/$guid"
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Deleting certificates'
     }
 }

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -104,7 +104,7 @@ function Remove-VdcCertificate {
             }
 
             if ($using:KeepAssociatedApps) {
-                $associatedApps = $PSItem | Get-VdcAttribute -Attribute "Consumers" | Select-Object -ExpandProperty Consumers
+                $associatedApps = ($PSItem | Get-VdcAttribute -Attribute "Consumers").Consumers
                 if ( $associatedApps ) {
                     Remove-VdcCertificateAssociation -Path $PSItem -ApplicationPath $associatedApps -Confirm:$false
                 }


### PR DESCRIPTION
- Add custom field value lookup to `Find-VdcObject`.  Utilizing existing `-Attribute` and `-Pattern` parameters, find objects where Attribute is a custom field name or guid and Pattern is the value you are looking for.
- Add parallel functionality to `Remove-VdcCertificate` for bulk cleanup