### PR TITLE
Fix New-VenafiSession -AccessToken, undo double json on verbose

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,2 @@
-- Add parallel functionality to `Remove-VdcObject`.  PS Core for now, Windows PowerShell coming soon.
-- Fix invalid function reference with `New-VdcCapiApplication`, [#247](https://github.com/Venafi/VenafiPS/issues/247)
-- Fix wilcard certificate not accepted with `New-VdcCapiApplication`, [#248](https://github.com/Venafi/VenafiPS/issues/248)
+- Fix property not found error with `New-VenafiSession -AccessToken`, [#252](https://github.com/Venafi/VenafiPS/issues/252)
+- Update `Invoke-VenafiRestMethod` to ensure parameter verbose output does not convert the body to json twice

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -353,12 +353,15 @@ function New-VenafiSession {
                 # we don't have the expiry so create one
                 # rely on the api call itself to fail if access token is invalid
                 Expires = (Get-Date).AddMonths(12)
+                AccessToken = $null
             }
             $newSession.Token.AccessToken = if ( $AccessToken -is [string] ) { New-Object System.Management.Automation.PSCredential('AccessToken', ($AccessToken | ConvertTo-SecureString -AsPlainText -Force)) }
             elseif ($AccessToken -is [pscredential]) { $AccessToken }
             elseif ($AccessToken -is [securestring]) { New-Object System.Management.Automation.PSCredential('AccessToken', $AccessToken) }
             else { throw 'Unsupported type for -AccessToken.  Provide either a String, SecureString, or PSCredential.' }
 
+            # validate token
+            $null = Invoke-VenafiRestMethod -UriRoot 'vedauth' -UriLeaf 'Authorize/Verify' -VenafiSession $newSession
         }
 
         'VaultAccessToken' {


### PR DESCRIPTION
- Fix #252 
- Update Invoke-VenafiRestMethod to ensure non Get method body isn't converted to json twice when outputting to screen