### PR TITLE
Add support for TLSPC eu region

### DIFF
--- a/VenafiPS/Classes/VenafiSession.ps1
+++ b/VenafiPS/Classes/VenafiSession.ps1
@@ -158,7 +158,7 @@ class VenafiSession {
         }
 
         $this | Add-Member -MemberType ScriptProperty -Name Platform -Value {
-            if ( $this.Server -eq 'https://api.venafi.cloud' ) {
+            if ( $this.Server -like 'https://api.venafi.*' ) {
                 'VC'
             }
             else {

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -104,16 +104,25 @@ function Invoke-VcWorkflow {
 
             try {
 
-                $URL = 'wss://api.venafi.cloud/ws/notificationclients/' + $thisWebSocketID
                 $WS = New-Object System.Net.WebSockets.ClientWebSocket
                 $CT = New-Object System.Threading.CancellationToken
 
                 if ( $VenafiSession.GetType().Name -in 'PSCustomObject', 'VenafiSession' ) {
+                    $server = $VenafiSession.Server.Replace('https://', '')
                     $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession.Key.GetNetworkCredential().password)
                 }
                 else {
+                    if ( $env:VC_SERVER ) {
+                        $server = $env:VC_SERVER
+                    }
+                    else {
+                        # default to US region
+                        $server = ($script:VcRegions).'us'
+                    }
+                    $server = $server.Replace('https://', '')
                     $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession)
                 }
+                $URL = 'wss://{0}/ws/notificationclients/{1}' -f $server, $thisWebSocketID
 
                 #Get connected
                 $Conn = $WS.ConnectAsync($URL, $CT)

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -138,7 +138,16 @@ function Invoke-VenafiRestMethod {
                 $auth = $VenafiSession
 
                 if ( Test-IsGuid($VenafiSession) ) {
-                    $Server = $script:CloudUrl
+                    if ( $env:VC_SERVER ) {
+                        $Server = $env:VC_SERVER
+                    }
+                    else {
+                        # default to US region
+                        $Server = ($script:VcRegions).'us'
+                    }
+                    if ( $Server -notlike 'https://*') {
+                        $Server = 'https://{0}' -f $Server
+                    }
                     $platform = 'VC'
                 }
                 else {
@@ -235,7 +244,8 @@ function Invoke-VenafiRestMethod {
         $paramsToWrite = $params.Clone()
         $paramsToWrite.Body = $preJsonBody
         $paramsToWrite | Write-VerboseWithSecret
-    } else {
+    }
+    else {
         $params | Write-VerboseWithSecret
     }
 
@@ -297,7 +307,8 @@ function Invoke-VenafiRestMethod {
                         $permMsg += ("  The current scope of {0} is insufficient." -f $rejectedScope.Matches.Groups[1].Value.Replace('\u0027', "'"))
                     }
                     $permMsg += '  Call New-VenafiSession with the correct scope.'
-                } else {
+                }
+                else {
                     $permMsg = $originalError.ErrorDetails.Message
                 }
 

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -33,7 +33,11 @@ foreach ( $folder in $folders) {
     }
 }
 
-$script:CloudUrl = 'https://api.venafi.cloud'
+$script:VcRegions = @{
+    'us'='https://api.venafi.cloud'
+    'eu'='https://api.venafi.eu'
+}
+# the new version will be replaced below during deployment
 $script:ModuleVersion = '((NEW_VERSION))'
 $script:functionConfig = ConvertFrom-Json (Get-Content "$PSScriptRoot/config/functions.json" -Raw)
 


### PR DESCRIPTION
- Add support for TLSPC eu region with `New-VenafiSession -VcRegion`.  The default is 'us'.
- Environment variable VC_SERVER has been added
- Add support to `Invoke-VcWorkflow` which uses websockets and not `Invoke-VenafiRestMethod`