### PR TITLE
Fix duplicate parameter error with `Get-VdcAttribute -All` on PS5

### DIFF
--- a/VenafiPS/Public/Get-VdcAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcAttribute.ps1
@@ -273,7 +273,10 @@ function Get-VdcAttribute {
 
             # disabled is a special kind of attribute which cannot be read with readeffectivepolicy
             if ( $params.Body.AttributeName -eq 'Disabled' ) {
-                $response = Invoke-VenafiRestMethod @params -UriLeaf 'Config/Read'
+                $oldUri = $params.UriLeaf
+                $params.UriLeaf = 'Config/Read'
+                $response = Invoke-VenafiRestMethod @params
+                $params.UriLeaf = $oldUri
             }
             else {
                 $response = Invoke-VenafiRestMethod @params


### PR DESCRIPTION
- Fix -UriLeaf being passed twice with `Get-VdcAttribute -All` on Windows PowerShell.