### PR TITLE
Invoke-VcCertificateAction -Renew not working

### DIFF
--- a/VenafiPS/Public/Get-VcCertificate.ps1
+++ b/VenafiPS/Public/Get-VcCertificate.ps1
@@ -105,8 +105,8 @@
         @{
             'n' = 'application'
             'e' = {
-                if ( $_.application ) {
-                    $_.application | Get-VcApplication | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
+                if ( $_.applicationIds ) {
+                    $_.applicationIds | Get-VcApplication | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
                 }
             }
         },


### PR DESCRIPTION
- Fix `Invoke-VcCertificateAction -Renew` not working, #260 
- Add messaging if multiple applications exist and support for overriding to provide a single application