### PR TITLE
VC Export pkcs12, fix vdc custom field get/set

### DIFF
--- a/VenafiPS/Classes/TppPermission.ps1
+++ b/VenafiPS/Classes/TppPermission.ps1
@@ -13,6 +13,21 @@ class TppPermission {
     [bool] $IsViewAllowed
     [bool] $IsWriteAllowed
 
+    TppPermission () {
+        $this.IsAssociateAllowed = $false
+        $this.IsCreateAllowed = $false
+        $this.IsDeleteAllowed = $false
+        $this.IsManagePermissionsAllowed = $false
+        $this.IsPolicyWriteAllowed = $false
+        $this.IsPrivateKeyReadAllowed = $false
+        $this.IsPrivateKeyWriteAllowed = $false
+        $this.IsReadAllowed = $false
+        $this.IsRenameAllowed = $false
+        $this.IsRevokeAllowed = $false
+        $this.IsViewAllowed = $false
+        $this.IsWriteAllowed = $false
+    }
+
     TppPermission ([pscustomobject] $InputObject) {
         $this.IsAssociateAllowed = $InputObject.IsAssociateAllowed
         $this.IsCreateAllowed = $InputObject.IsCreateAllowed

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -25,6 +25,7 @@ function Export-VcCertificate {
 
     .PARAMETER PKCS12
     Export the certificate and private key in PKCS12 format.
+    Requires PowerShell v7.1+.
 
     .PARAMETER ThrottleLimit
     Limit the number of threads when running in parallel; the default is 100.  Applicable to PS v7+ only.
@@ -67,7 +68,7 @@ function Export-VcCertificate {
 
     .NOTES
     This function requires the use of sodium encryption.
-    .net standard 2.0 or greater is required via PS Core.
+    PS v7.1+ is required.
     On Windows, the latest Visual C++ redist must be installed.  See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist.
     #>
 
@@ -81,6 +82,14 @@ function Export-VcCertificate {
 
         [Parameter(ParameterSetName = 'PEM')]
         [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
+        [ValidateScript(
+            {
+                if ($PSVersionTable.PSVersion -lt [version]'7.1') {
+                    throw 'Exporting private keys is only supported on PowerShell v7.1+'
+                }
+                $true
+            }
+        )]
         [psobject] $PrivateKeyPassword,
 
         [Parameter(ParameterSetName = 'PEM')]
@@ -115,10 +124,6 @@ function Export-VcCertificate {
         $allCerts = [System.Collections.Generic.List[hashtable]]::new()
 
         if ( $PrivateKeyPassword ) {
-
-            if ( $PSVersionTable.PSEdition -ne 'Core' ) {
-                throw 'Exporting private keys is only supported on PowerShell v7+'
-            }
 
             $params = @{
                 Method       = 'Post'

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -14,6 +14,7 @@ function Export-VcCertificate {
     .PARAMETER PrivateKeyPassword
     Password required to include the private key.
     You can either provide a String, SecureString, or PSCredential.
+    Requires PowerShell v7.0+.
 
     .PARAMETER IncludeChain
     Include the certificate chain with the exported or saved PEM certificate data.
@@ -84,8 +85,8 @@ function Export-VcCertificate {
         [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
         [ValidateScript(
             {
-                if ($PSVersionTable.PSVersion -lt [version]'7.1') {
-                    throw 'Exporting private keys is only supported on PowerShell v7.1+'
+                if ($PSVersionTable.PSVersion -lt [version]'7.0') {
+                    throw 'Exporting private keys is only supported on PowerShell v7.0+'
                 }
                 $true
             }
@@ -109,6 +110,14 @@ function Export-VcCertificate {
         [String] $OutPath,
 
         [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
+        [ValidateScript(
+            {
+                if ($PSVersionTable.PSVersion -lt [version]'7.1') {
+                    throw 'Exporting in PKCS#12 foramt is only supported on PowerShell v7.1+'
+                }
+                $true
+            }
+        )]
         [switch] $PKCS12,
 
         [Parameter()]

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -23,7 +23,7 @@ function Export-VcCertificate {
     For each certificate a directory will be created in this folder with the format Name-ID.
     In the case of PKCS12, the file will be saved to the root of the folder.
 
-    .PARAMETER Pkcs12
+    .PARAMETER PKCS12
     Export the certificate and private key in PKCS12 format.
 
     .PARAMETER ThrottleLimit
@@ -51,7 +51,7 @@ function Export-VcCertificate {
     Export certificate and private key data
 
     .EXAMPLE
-    $certId | Export-VcCertificate -PrivateKeyPassword 'myPassw0rd!' -Pkcs12 -OutPath '~/temp'
+    $certId | Export-VcCertificate -PrivateKeyPassword 'myPassw0rd!' -PKCS12 -OutPath '~/temp'
 
     Export certificate and private key in PKCS12 format
 
@@ -80,14 +80,14 @@ function Export-VcCertificate {
         [string] $ID,
 
         [Parameter(ParameterSetName = 'PEM')]
-        [Parameter(ParameterSetName = 'Pkcs12', Mandatory)]
+        [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
         [psobject] $PrivateKeyPassword,
 
         [Parameter(ParameterSetName = 'PEM')]
         [switch] $IncludeChain,
 
         [Parameter(ParameterSetName = 'PEM')]
-        [Parameter(ParameterSetName = 'Pkcs12', Mandatory)]
+        [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if (Test-Path $_ -PathType Container) {
@@ -99,8 +99,8 @@ function Export-VcCertificate {
             })]
         [String] $OutPath,
 
-        [Parameter(ParameterSetName = 'Pkcs12', Mandatory)]
-        [switch] $Pkcs12,
+        [Parameter(ParameterSetName = 'PKCS12', Mandatory)]
+        [switch] $PKCS12,
 
         [Parameter()]
         [int32] $ThrottleLimit = 100,
@@ -117,7 +117,7 @@ function Export-VcCertificate {
         if ( $PrivateKeyPassword ) {
 
             if ( $PSVersionTable.PSEdition -ne 'Core' ) {
-                throw 'Exporting private keys is only supported on PowerShell Core'
+                throw 'Exporting private keys is only supported on PowerShell v7+'
             }
 
             $params = @{
@@ -234,7 +234,7 @@ function Export-VcCertificate {
 
                     if ( $using:OutPath ) {
 
-                        if ( $using:Pkcs12 ) {
+                        if ( $using:PKCS12 ) {
                             $keyFile = Get-ChildItem -Path $unzipPath -Filter '*.key'
 
                             if ( $keyFile.Count -ne 1 ) {

--- a/VenafiPS/Public/Find-VdcObject.ps1
+++ b/VenafiPS/Public/Find-VdcObject.ps1
@@ -171,9 +171,6 @@ function Find-VdcObject {
             'FindByAttribute' {
 
                 $customField = $VenafiSessionNested.CustomField | Where-Object { $_.Label -eq $Attribute[0] -or $_.Guid -eq $Attribute[0] }
-                if ( -not $customField ) {
-                    $customField = $VenafiSession.CustomField | Where-Object { $_.Label -eq $Attribute[0] -or $_.Guid -eq $Attribute[0] }
-                }
 
                 # if attribute isn't a custom field or user doesn't want to perform a cf lookup for a conflicting attrib/cf name, perform standard find object
                 if ( $NoLookup -or (-not $customField) ) {

--- a/VenafiPS/Public/Get-VdcAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcAttribute.ps1
@@ -264,7 +264,7 @@ function Get-VdcAttribute {
             $customField = $null
 
             if ( -not $NoLookup ) {
-                $customField = $VenafiSession.CustomField | Where-Object { $_.Label -eq $thisAttribute -or $_.Guid -eq $thisAttribute }
+                $customField = $VenafiSessionNested.CustomField | Where-Object { $_.Label -eq $thisAttribute -or $_.Guid -eq $thisAttribute }
 
                 if ( $customField ) {
                     $params.Body.AttributeName = $customField.Guid

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -107,9 +107,9 @@ function Invoke-VcWorkflow {
                 $WS = New-Object System.Net.WebSockets.ClientWebSocket
                 $CT = New-Object System.Threading.CancellationToken
 
-                if ( $VenafiSession.GetType().Name -in 'PSCustomObject', 'VenafiSession' ) {
-                    $server = $VenafiSession.Server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession.Key.GetNetworkCredential().password)
+                if ( $VenafiSessionNested.GetType().Name -in 'PSCustomObject', 'VenafiSession' ) {
+                    $server = $VenafiSessionNested.Server.Replace('https://', '')
+                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSessionNested.Key.GetNetworkCredential().password)
                 }
                 else {
                     if ( $env:VC_SERVER ) {

--- a/VenafiPS/Public/Revoke-VdcGrant.ps1
+++ b/VenafiPS/Public/Revoke-VdcGrant.ps1
@@ -66,7 +66,7 @@ function Revoke-VdcGrant {
 
         Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VDC' -AuthType 'token'
 
-        if ( $VenafiSession.Version -lt [Version]::new('22', '3', '0') ) {
+        if ( $VenafiSessionNested.Version -lt [Version]::new('22', '3', '0') ) {
             throw 'Revoke-VdcGrant is available on TLSPDC v22.3 and greater'
         }
 

--- a/VenafiPS/Public/Revoke-VdcToken.ps1
+++ b/VenafiPS/Public/Revoke-VdcToken.ps1
@@ -82,7 +82,7 @@ function Revoke-VdcToken {
         [switch] $Force,
 
         [Parameter(ParameterSetName = 'Session')]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {

--- a/VenafiPS/Public/Set-VdcAttribute.ps1
+++ b/VenafiPS/Public/Set-VdcAttribute.ps1
@@ -166,7 +166,8 @@ function Set-VdcAttribute {
             }
             $customFieldError = $null
 
-            $customField = $VenafiSession.CustomField | Where-Object { $_.Label -eq $thisKey -or $_.Guid -eq $thisKey }
+            $customField = $VenafiSessionNested.CustomField | Where-Object { $_.Label -eq $thisKey -or $_.Guid -eq $thisKey }
+            Write-Verbose ('found custom field {0} - {1}' -f $customField.DN, $customField|ConvertTo-Json)
             if ( $customField ) {
                 if ( -not $BypassValidation ) {
                     switch ( $customField.Type.ToString() ) {

--- a/VenafiPS/Public/Test-VdcToken.ps1
+++ b/VenafiPS/Public/Test-VdcToken.ps1
@@ -77,7 +77,7 @@ function Test-VdcToken {
 
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'AccessToken')]
+    [CmdletBinding(DefaultParameterSetName = 'Session')]
     [Alias('Test-TppToken')]
     [OutputType([System.Boolean])]
 
@@ -115,7 +115,7 @@ function Test-VdcToken {
         [switch] $GrantDetail,
 
         [Parameter(ParameterSetName = 'Session')]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = $script:VenafiSession
     )
 
     begin {


### PR DESCRIPTION
- Add `Export-VcCertificate -Pkcs12`, #251 
- Fix `Get-VdcAttribute` and `Set-VdcAttribute` not recognizing custom field labels
- Add ability to set permissions with `Set-VdcPermission` for a new id, not just an update
- Add -AdditionalParameters support to `Invoke-VcCertificateAction -Renew`