### PR TITLE
Fix param name ID in exanmples

### DIFF
--- a/VenafiPS/Public/Get-VcCertificate.ps1
+++ b/VenafiPS/Public/Get-VcCertificate.ps1
@@ -21,13 +21,13 @@
     A TLSPC key can also be provided.
 
     .INPUTS
-    CertificateId
+    ID
 
     .OUTPUTS
     PSCustomObject
 
     .EXAMPLE
-    Get-VdcCertificate -CertificateId 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    Get-VdcCertificate -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     Get certificate info for a specific cert
 

--- a/VenafiPS/Public/Get-VdcCertificate.ps1
+++ b/VenafiPS/Public/Get-VdcCertificate.ps1
@@ -35,13 +35,13 @@
     If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
-    CertificateId
+    ID
 
     .OUTPUTS
     PSCustomObject
 
     .EXAMPLE
-    Get-VdcCertificate -CertificateId '\ved\policy\mycert.com'
+    Get-VdcCertificate -ID '\ved\policy\mycert.com'
 
     Get certificate info for a specific cert
 
@@ -51,12 +51,12 @@
     Get certificate info for all certs
 
     .EXAMPLE
-    Get-VdcCertificate -CertificateId '\ved\policy\mycert.com' -IncludePreviousVersions
+    Get-VdcCertificate -ID '\ved\policy\mycert.com' -IncludePreviousVersions
 
     Get certificate info for a specific cert, including historical versions of the certificate.
 
     .EXAMPLE
-    Get-VdcCertificate -CertificateId '\ved\policy\mycert.com' -IncludeTppPreviousVersions -ExcludeRevoked -ExcludeExpired
+    Get-VdcCertificate -ID '\ved\policy\mycert.com' -IncludeTppPreviousVersions -ExcludeRevoked -ExcludeExpired
 
     Get certificate info for a specific cert, including historical versions of the certificate that are not revoked or expired.
 


### PR DESCRIPTION
Get-VcCertificate and Get-VdcCertificate had examples referencing CertificateID from pre v6.  Get-VcCertificate was not affected as an alias was in place, but Get-VdcCertificate did not.  Examples fixed.

Closes #279 