### PR TITLE
`Add-VcCertificateAssociation` search on guid fix

### DIFF
--- a/VenafiPS/Public/Add-VcCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-VcCertificateAssociation.ps1
@@ -104,9 +104,15 @@
     }
 
     process {
-        $certIDs = Get-VcData -InputObject $Certificate -Type 'Certificate'
-        foreach ($certID in @($certIDs)) {
-            $allCerts.Add($certID)
+        if ( Test-IsGuid($Certificate) ) {
+            $allCerts.Add($Certificate)
+        }
+        else {
+            # search by name
+            $certIDs = Get-VcData -InputObject $Certificate -Type 'Certificate'
+            foreach ($certID in @($certIDs)) {
+                $allCerts.Add($certID)
+            }
         }
     }
 


### PR DESCRIPTION
- `Add-VcCertificateAssociation` was performing a name search when certificate objects were piped in.  Use the guid instead of name search.