### PR TITLE
290 import vdccertificate with data field is failing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,1 @@
-- Add `Export-VdcVaultObject` to retrieve historical certificates.  This function supports certificates, keys, and p12.  [#280](https://github.com/Venafi/VenafiPS/issues/280)
-- Add support in `New-VcConnector` for manifests from the simulator and 'full' ones which already have deployment details
-- Fix `Add-VcCertificateAssociation` when piping certificate objects, [#284](https://github.com/Venafi/VenafiPS/issues/284)
-- Fix examples in `Get-VcCertificate` and `Get-VdcCertificate` referencing old parameter names, [#279](https://github.com/Venafi/VenafiPS/issues/279)
+- Fix `Import-VdcCertificate -Data` failure due to being converted to an array.  [#290](https://github.com/Venafi/VenafiPS/issues/290)

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -59,15 +59,18 @@ function Import-VdcCertificate {
 
     .EXAMPLE
     Import-VdcCertificate -PolicyPath \ved\policy\mycerts -Path c:\www.VenafiPS.com.cer
+
     Import a certificate
 
     .EXAMPLE
     gci c:\certs | Import-VdcCertificate -PolicyPath \ved\policy\mycerts
-    Import multiple certificates
+
+    Import multiple certificates.  On PS v7+, the certificates will be imported in parallel.
 
     .EXAMPLE
-    Import-VdcCertificate -PolicyPath mycerts -Path (gci c:\certs).FullName
-    Import multiple certificates in parallel on PS v6+.  \ved\policy will be appended to the policy path.
+    Import-VdcCertificate -PolicyPath mycerts -Data $certData
+
+    Import a certificate from data instead of a path
 
     .INPUTS
     Path, Data
@@ -100,12 +103,12 @@ function Import-VdcCertificate {
                 }
             })]
         [Alias('FullName')]
-        [String[]] $Path,
+        [String] $Path,
 
         [Parameter(Mandatory, ParameterSetName = 'ByData', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'ByDataWithPrivateKey', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [String[]] $Data,
+        [String] $Data,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
- Fix `Import-VdcCertificate -Data` failure due to being converted to an array.  #290 
