### PR TITLE
Add batching functionality to Invoke-VcCertificateAction

### DIFF
--- a/VenafiPS/Private/Select-VenBatch.ps1
+++ b/VenafiPS/Private/Select-VenBatch.ps1
@@ -1,0 +1,83 @@
+function Select-VenBatch {
+    <#
+    .SYNOPSIS
+    Batches pipeline input. 
+
+    .DESCRIPTION
+    Batches up pipeline input into consistently sized List[T]s of objects. Used to ensure that processing occurs in specific sized batches. 
+    Useful for not recieving API timouts due to sending more objects than can be processed in the connection timeout period.
+
+    .PARAMETER InputObject 
+    The pipeline input objects binds to this parameter one by one.
+    Do not use it directly.
+
+    .PARAMETER BatchSize
+    The size of the batches to separate the pipeline input into. 
+
+    .PARAMETER BatchType
+    Type of object to group things into. Defaults to a Powershell custom object
+
+    Valid Values: "pscustomobject", "string", "int", "guid"
+
+    .OUTPUTS
+    System.Collections.Generic.List[T]
+
+    .EXAMPLE
+    1..6000 | Select-VenBatch -batchsize 1000 -BatchType string
+
+    #>
+
+    [CmdletBinding(PositionalBinding = $false)]
+    param (
+      [Parameter(ValueFromPipeline)] 
+      $InputObject,
+
+      [Parameter(Mandatory)]
+      [int] $BatchSize,
+
+      [Parameter(Mandatory, Position = 0)]
+      [ValidateSet("pscustomobject","string","int","guid")]
+      [string] $BatchType = "pscustomobject"
+
+      )
+
+    Begin {
+        switch ($BatchType) {
+            'string'         {
+                $Batch = [System.Collections.Generic.Queue[string]]::new($BatchSize)
+                $OutList =  [System.Collections.Generic.List[string]]::new()
+            }
+            'int'            {
+                $Batch = [System.Collections.Generic.Queue[int]]::new($BatchSize)
+                $OutList =  [System.Collections.Generic.List[int]]::new()
+            }
+            'guid'           {
+                $Batch = [System.Collections.Generic.Queue[guid]]::new($BatchSize)
+                $OutList =  [System.Collections.Generic.List[guid]]::new()
+            }
+            'pscustomobject' {
+                $Batch = [System.Collections.Generic.Queue[pscustomobject]]::new($BatchSize)
+                $OutList =  [System.Collections.Generic.List[pscustomobject]]::new()
+            }
+        }
+    }
+
+    Process {
+        $Batch.Enqueue($_)
+        if ($Batch.Count -eq $BatchSize) { 
+            $OutList.AddRange($Batch)
+            ,$OutList
+            $Batch.Clear() # start next batch
+            $OutList.clear()
+        }
+    }
+
+    end {
+        if ($batch.Count) { #scriptblock geos here. 
+            $OutList.AddRange($Batch)
+            ,$OutList
+            $Batch.Clear() # start next batch
+            $OutList.clear()
+        }
+    }
+}

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -28,6 +28,10 @@ function Invoke-VcCertificateAction {
     Delete a certificate.
     As only retired certificates can be deleted, this will be performed first.
 
+    .PARAMETER BatchSize
+    How many certificates to retire per retirement API call. Useful to prevent API call timeouts. 
+    Defaults to 1000
+
     .PARAMETER AdditionalParameters
     Additional items specific to the action being taken, if needed.
     See the api documentation for appropriate items, many are in the links in this help.
@@ -82,9 +86,9 @@ function Invoke-VcCertificateAction {
     Perform an action bypassing the confirmation prompt.  Only applicable to Delete.
 
     .EXAMPLE
-    Find-VcObject -Type Certificate -Filter @('certificateStatus','eq','retired') | Invoke-VcCertificateAction -Delete
+    Find-VcObject -Type Certificate -Filter @('certificateStatus','eq','retired') | Invoke-VcCertificateAction -Delete -BatchSize 100
 
-    Search for all retired certificates and delete them
+    Search for all retired certificates and delete them using a non default batch size of 100
 
     .LINK
     https://api.venafi.cloud/webjars/swagger-ui/index.html?configUrl=%2Fv3%2Fapi-docs%2Fswagger-config&urls.primaryName=outagedetection-service
@@ -119,6 +123,9 @@ function Invoke-VcCertificateAction {
 
         [Parameter(Mandatory, ParameterSetName = 'Delete')]
         [switch] $Delete,
+
+        [Parameter()]
+        [int] $BatchSize = 1000,
 
         [Parameter(ParameterSetName = 'Renew')]
         [switch] $Force,
@@ -252,58 +259,68 @@ function Invoke-VcCertificateAction {
         switch ($PSCmdLet.ParameterSetName) {
             'Retire' {
                 $params.UriLeaf = "certificates/retirement"
-                $params.Body = @{"certificateIds" = $allCerts }
-
+                
                 if ( $AdditionalParameters ) {
                     $params.Body += $AdditionalParameters
                 }
 
-                $response = Invoke-VenafiRestMethod @params
-
-                $processedIds = $response.certificates.id
-
-                foreach ($certId in $allCerts) {
-                    [pscustomobject] @{
-                        CertificateID = $certId
-                        Success       = ($certId -in $processedIds)
+                $allCerts | Select-VenBatch -batchsize $BatchSize -BatchType string | ForEach-Object {
+                    $params.Body = @{"certificateIds" = $_ }
+    
+                    $response = Invoke-VenafiRestMethod @params
+    
+                    $processedIds = $response.certificates.id
+    
+                    foreach ($certId in $_) {
+                        [pscustomobject] @{
+                            CertificateID = $certId
+                            Success       = ($certId -in $processedIds)
+                        }
                     }
                 }
             }
 
             'Recover' {
                 $params.UriLeaf = "certificates/recovery"
-                $params.Body = @{"certificateIds" = $allCerts }
 
                 if ( $AdditionalParameters ) {
                     $params.Body += $AdditionalParameters
                 }
 
-                $response = Invoke-VenafiRestMethod @params
-
-                $processedIds = $response.certificates.id
-
-                foreach ($certId in $allCerts) {
-                    [pscustomobject] @{
-                        CertificateID = $certId
-                        Success       = ($certId -in $processedIds)
+                $allCerts | Select-VenBatch -batchsize $BatchSize -BatchType string | ForEach-Object {
+                    $params.Body = @{"certificateIds" = $_ }
+    
+                    $response = Invoke-VenafiRestMethod @params
+    
+                    $processedIds = $response.certificates.id
+    
+                    foreach ($certId in $_) {
+                        [pscustomobject] @{
+                            CertificateID = $certId
+                            Success       = ($certId -in $processedIds)
+                        }
                     }
                 }
             }
 
             'Validate' {
                 $params.UriLeaf = "certificates/validation"
-                $params.Body = @{"certificateIds" = $allCerts }
 
-                $response = Invoke-VenafiRestMethod @params
+                $allCerts | Select-VenBatch -batchsize $BatchSize -BatchType string | ForEach-Object {
+                    $params.Body = @{"certificateIds" = $_ }
+    
+                    $response = Invoke-VenafiRestMethod @params
+                }
             }
 
             'Delete' {
                 $null = $allCerts | Invoke-VcCertificateAction -Retire
 
-                $params.UriLeaf = "certificates/deletion"
-                $params.Body = @{"certificateIds" = $allCerts }
-
-                $response = Invoke-VenafiRestMethod @params
+                $allCerts | Select-VenBatch -batchsize $BatchSize -BatchType string | ForEach-Object {
+                    $params.Body = @{"certificateIds" = $_ }
+    
+                    $response = Invoke-VenafiRestMethod @params
+                }
             }
         }
 

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -125,6 +125,7 @@ function Invoke-VcCertificateAction {
         [switch] $Delete,
 
         [Parameter()]
+        [ValidateRange(1,10000)]
         [int] $BatchSize = 1000,
 
         [Parameter(ParameterSetName = 'Renew')]


### PR DESCRIPTION
Adds batching of API calls for `Invoke-VcCertificateAction` when retiring, recovering, validating, or deleting certificates. The default batch size is 1000 certificates and is customizable with the new `-BatchSize` parameter.

Piping or supplying more certificates than the batch size to `Invoke-VcCertificateAction` will result in multiple separate API calls to VCP to perform the chosen action with the maximum number of certs in the API call equal to the chosen batch size. Previously, retiring, validating, recovering, or deleting a large number of certificates would result in the API call timing out after a minute due to `invoke-webrequest`/`invoke-restmethod` defaults.

Added new private function `Select-VenBatch` that separates incoming pipeline objects into batches of `[System.Collections.Generic.List[<T>]]` objects. Currently supports `string`, `int`, `guid`, and `pscustomobject` list types and can be expanded later.


In testing, no significant difference in performance was found between the method of batching in this PR and the method below when testing with 5000 cert IDs. 
Testing performed in PS 5.1
```
for ($i = 0; $i -lt $allCerts.Count; $i += 1000) {

            Write-Verbose "Processing certificates $i to $($i + 999)"
            $certsPaged = $allCerts[$i..($i + 999)]

            switch ($PSCmdLet.ParameterSetName) {
                'Retire' {
                    $params.UriLeaf = "certificates/retirement"
                    $params.Body = @{"certificateIds" = $certsPaged }

           ....
           }
}
```