### PR TITLE
Vsat workers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,5 @@
-- Add `Set-VcCertificate`.  This replaces `Add-VcCertificateAssociation` to set the applications associated with a certificate.  Certificate tagging is now supported, both add and replace.
-- Add support for URL port during TLSPDC token operations, [#305](https://github.com/Venafi/VenafiPS/issues/305)
+- Add `Get-VcSatelliteWorker`, either all, by id or all workers associated with a specific satellite
+- Add `Remove-VcSatelliteWorker`, you guessed it...removes vsat workers
+- Add `Get-VcSatellite -IncludeWorkers` to get vsats and their associated workers in one call.
+- Add `Invoke-VcCertificateAction -Provision` to push a certificate to associated machine identities.  You can also use `-Renew -Provision` together and it will renew and then provision the new certificate.
+- Add `Set-VcApplication -IssuingTemplate` to add one or more issuing templates to an application.  It will overwrite by default or use `-NoOverwrite` to append.

--- a/VenafiPS/Public/Get-VcApplication.ps1
+++ b/VenafiPS/Public/Get-VcApplication.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
     Get 1 or more applications.
 
-    .PARAMETER ID
+    .PARAMETER Application
     Application ID or name
 
     .PARAMETER All
@@ -21,7 +21,7 @@
     ID
 
     .EXAMPLE
-    Get-VcApplication -ApplicationID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    Get-VcApplication -Application 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     applicationId              : 96fc9310-67ec-11eb-a8a7-794fe75a8e6f
     certificateIssuingTemplate : @{Name=MyTemplate; id=7fb6af20-b22e-11ea-9a24-930fb5d2b247}
@@ -39,7 +39,7 @@
     Get a single object by ID
 
     .EXAMPLE
-    Get-VcApplication -ID 'My Awesome App'
+    Get-VcApplication -Application 'My Awesome App'
 
     Get a single object by name.  The name is case sensitive.
 
@@ -56,8 +56,8 @@
     param (
 
         [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('applicationId')]
-        [string] $ID,
+        [Alias('applicationId', 'ID')]
+        [string] $Application,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch] $All,
@@ -77,13 +77,13 @@
             UriLeaf = 'applications'
         }
 
-        if ( $PSBoundParameters.ContainsKey('ID') ) {
-            if ( Test-IsGuid($ID) ) {
-                $params.UriLeaf += "/{0}" -f $ID
+        if ( $PSBoundParameters.ContainsKey('Application') ) {
+            if ( Test-IsGuid($Application) ) {
+                $params.UriLeaf += "/{0}" -f $Application
             }
             else {
                 # search by name
-                $params.UriLeaf += "/name/$ID"
+                $params.UriLeaf += "/name/$Application"
             }
         }
 

--- a/VenafiPS/Public/Get-VcCertificate.ps1
+++ b/VenafiPS/Public/Get-VcCertificate.ps1
@@ -42,7 +42,7 @@
     param (
 
         [Parameter(ParameterSetName = 'Id', Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('certificateID')]
+        [Alias('certificateId')]
         [string] $ID,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]

--- a/VenafiPS/Public/Get-VcConnector.ps1
+++ b/VenafiPS/Public/Get-VcConnector.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
     Get details on 1 or all connectors
 
-    .PARAMETER ID
+    .PARAMETER Connector
     Connector ID or name
 
     .PARAMETER All
@@ -21,7 +21,7 @@
     ID
 
     .EXAMPLE
-    Get-VcConnector -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' | ConvertTo-Json
+    Get-VcConnector -Connector 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' | ConvertTo-Json
 
     {
         "connectorId": "a7ddd210-0a39-11ee-8763-134b935c90aa",
@@ -45,7 +45,7 @@
     Get a single object by ID
 
     .EXAMPLE
-    Get-VcConnector -ID 'My Connector'
+    Get-VcConnector -Connector 'My Connector'
 
     Get a single object by name.  The name is case sensitive.
 
@@ -62,8 +62,8 @@
     param (
 
         [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('connectorId')]
-        [string] $ID,
+        [Alias('connectorId', 'ID')]
+        [string] $Connector,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch] $All,
@@ -82,13 +82,13 @@
             UriLeaf = 'plugins'
         }
 
-        if ( $PSBoundParameters.ContainsKey('ID') ) {
-            if ( Test-IsGuid($ID) ) {
-                $params.UriLeaf += "/{0}" -f $ID
+        if ( $PSBoundParameters.ContainsKey('Connector') ) {
+            if ( Test-IsGuid($Connector) ) {
+                $params.UriLeaf += "/{0}" -f $Connector
             }
             else {
                 # search by name
-                return Get-VcConnector -All | Where-Object { $_.name -eq $ID }
+                return Get-VcConnector -All | Where-Object { $_.name -eq $Connector }
             }
         }
         else {

--- a/VenafiPS/Public/Get-VcIssuingTemplate.ps1
+++ b/VenafiPS/Public/Get-VcIssuingTemplate.ps1
@@ -4,9 +4,9 @@
     Get issuing template info
 
     .DESCRIPTION
-    Get 1 or more issuing templates
+    Get 1 or more issuing template details
 
-    .PARAMETER ID
+    .PARAMETER IssuingTemplate
     Issuing template ID or name
 
     .PARAMETER All
@@ -21,7 +21,7 @@
     ID
 
     .EXAMPLE
-    Get-VcIssuingTemplate -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    Get-VcIssuingTemplate -IssuingTemplate 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     issuingTemplateId                   : 0a19eaf2-b22b-11ea-a1eb-a37c69eabd4e
     companyId                           : 09b24f81-b22b-11ea-91f3-ebd6dea5452f
@@ -57,7 +57,7 @@
     Get a single object by ID
 
     .EXAMPLE
-    Get-VcIssuingTemplate -ID 'MyTemplate'
+    Get-VcIssuingTemplate -IssuingTemplate 'MyTemplate'
 
     Get a single object by name.  The name is case sensitive.
 
@@ -74,8 +74,8 @@
     param (
 
         [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('issuingTemplateId')]
-        [string] $ID,
+        [Alias('issuingTemplateId', 'ID')]
+        [string] $IssuingTemplate,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch] $All,
@@ -94,13 +94,13 @@
             UriLeaf = 'certificateissuingtemplates'
         }
 
-        if ( $PSBoundParameters.ContainsKey('ID') ) {
-            if ( Test-IsGuid($ID) ) {
-                $params.UriLeaf += "/{0}" -f $ID
+        if ( $PSBoundParameters.ContainsKey('IssuingTemplate') ) {
+            if ( Test-IsGuid($IssuingTemplate) ) {
+                $params.UriLeaf += "/{0}" -f $IssuingTemplate
             }
             else {
                 # search by name
-                return Get-VcIssuingTemplate -All | Where-Object { $_.name -eq $ID }
+                return Get-VcIssuingTemplate -All | Where-Object { $_.name -eq $IssuingTemplate }
             }
         }
 

--- a/VenafiPS/Public/Get-VcMachine.ps1
+++ b/VenafiPS/Public/Get-VcMachine.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
     Get machine details for 1 or all.
 
-    .PARAMETER ID
+    .PARAMETER Machine
     Machine ID or name
 
     .PARAMETER All
@@ -23,10 +23,10 @@
     A TLSPC key can also provided.
 
     .INPUTS
-    ID
+    Machine
 
     .EXAMPLE
-    Get-VcMachine -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    Get-VcMachine -Machine 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     machineId              : cf7cfdc0-2b2a-11ee-9546-5136c4b21504
     companyId              : cf7cfdc0-2b2a-11ee-9546-5136c4b21504
@@ -47,7 +47,7 @@
     Get a single machine by ID
 
     .EXAMPLE
-    Get-VcMachine -ID 'MyCitrix'
+    Get-VcMachine -Machine 'MyCitrix'
 
     Get a single machine by name.  The name is case sensitive.
 
@@ -102,8 +102,8 @@
     param (
 
         [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('machineId')]
-        [string] $ID,
+        [Alias('machineId', 'ID')]
+        [string] $Machine,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch] $All,
@@ -137,9 +137,9 @@
             }
         }
         else {
-            if ( Test-IsGuid($ID) ) {
+            if ( Test-IsGuid($Machine) ) {
                 try {
-                    $response = Invoke-VenafiRestMethod -UriLeaf ('machines/{0}' -f $ID)
+                    $response = Invoke-VenafiRestMethod -UriLeaf ('machines/{0}' -f $Machine)
                 }
                 catch {
                     if ( $_.Exception.Response.StatusCode.value__ -eq 404 ) {
@@ -153,7 +153,7 @@
             }
             else {
                 # no lookup by name directly.  search for it and then get details
-                Find-VcObject -Type 'Machine' -Name $ID | Get-VcMachine
+                Find-VcObject -Type 'Machine' -Name $Machine | Get-VcMachine
             }
 
             if ( $response ) {

--- a/VenafiPS/Public/Get-VcSatelliteWorker.ps1
+++ b/VenafiPS/Public/Get-VcSatelliteWorker.ps1
@@ -1,0 +1,108 @@
+function Get-VcSatelliteWorker {
+    <#
+    .SYNOPSIS
+    Get VSatellite worker info
+
+    .DESCRIPTION
+    Get 1 or more VSatellite workers, the bridge between a vsatellite and ADCS
+
+    .PARAMETER ID
+    VSatellite worker ID
+
+    .PARAMETER All
+    Get all VSatellite workers
+
+    .PARAMETER VSatellite
+    Get workers associated with a specific VSatellite, specify either VSatellite ID or name
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TLSPC key can also provided.
+
+    .INPUTS
+    ID, VSatelliteID
+
+    .EXAMPLE
+    Get-VcSatelliteWorker -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+
+    vsatelliteWorkerId : 5df78790-a155-11ef-a5a8-8f3513444123
+    companyId          : 09b24f81-b22b-11ea-91f3-123456789098
+    host               : 1.2.3.4
+    port               : 555
+    pairingCode        : a138fe58-ecb6-45a4-a9af-01dd4d5c74d1
+    pairingPublicKey   : FDww6Nml8IUFQZ56j9LRweEWoCQ1732wi/ZfZaQj+s0=
+    status             : DRAFT
+
+    Get a single worker by ID
+
+    .EXAMPLE
+    Get-VcSatelliteWorker -All
+
+    Get all VSatellite workers
+
+    .EXAMPLE
+    Get-VcSatelliteWorker -VSatellite 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f3'
+
+    Get all workers associated with a specific VSatellite
+
+    #>
+
+    [CmdletBinding()]
+
+    param (
+
+        [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName)]
+        [Alias('vsatelliteWorkerId')]
+        [guid] $ID,
+
+        [Parameter(Mandatory, ParameterSetName = 'All')]
+        [switch] $All,
+
+        [Parameter(Mandatory, ParameterSetName = 'VSatellite', ValueFromPipelineByPropertyName)]
+        [Alias('vsatelliteId')]
+        [string] $VSatellite,
+
+        [Parameter()]
+        [psobject] $VenafiSession
+    )
+
+    begin {
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VC'
+    }
+
+    process {
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'All' {
+                $response = Invoke-VenafiRestMethod -UriLeaf 'edgeworkers' | Select-Object -ExpandProperty edgeWorkers
+            }
+
+            'ID' {
+                $guid = [guid] $ID
+                $response = Invoke-VenafiRestMethod -UriLeaf ('edgeworkers/{0}' -f $guid.ToString())
+            }
+
+            'VSatellite' {
+                # limit workers retrieved by the vsat they are associated with
+                
+                # if the value is a guid, we can look up the vsat directly otherwise get all and search by name
+                $vsatelliteId = if ( Test-IsGuid($VSatellite) ) {
+                    $guid = [guid] $VSatellite
+                    $guid.ToString()
+                }
+                else {
+                    Invoke-VenafiRestMethod -UriLeaf 'edgeinstances' | Select-Object -ExpandProperty edgeInstances | Where-Object { $_.name -eq $VSatellite } | Select-Object -ExpandProperty id
+                }
+
+                $response = Invoke-VenafiRestMethod -UriLeaf 'edgeworkers' -Body @{'edgeInstanceId' = $vsatelliteID } | Select-Object -ExpandProperty edgeWorkers
+            }
+        }
+
+        if ( -not $response ) { return }
+
+        $response | Select-Object `
+        @{'n' = 'vsatelliteWorkerId'; 'e' = { $_.Id } },
+        @{'n' = 'vsatelliteId'; 'e' = { $_.edgeInstanceId } }, * -ExcludeProperty Id, edgeInstanceId
+    }
+}

--- a/VenafiPS/Public/Get-VcTeam.ps1
+++ b/VenafiPS/Public/Get-VcTeam.ps1
@@ -7,7 +7,7 @@
     Get info on teams including members and owners.
     Retrieve info on 1 or all.
 
-    .PARAMETER ID
+    .PARAMETER Team
     Team name or guid.
 
     .PARAMETER All
@@ -25,12 +25,12 @@
     PSCustomObject
 
     .EXAMPLE
-    Get-VcTeam -ID 'MyTeam'
+    Get-VcTeam -Team 'MyTeam'
 
     Get info for a team by name
 
     .EXAMPLE
-    Get-VcTeam -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    Get-VcTeam -Team 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     Get info for a team by id
 
@@ -69,29 +69,19 @@
     process {
 
         if ( $PSCmdlet.ParameterSetName -eq 'All' ) {
-            $uriLeaf = 'teams'
+            $response = Invoke-VenafiRestMethod -UriLeaf 'teams'
         }
         else {
-            if ( $ID.Count -gt 1 ) {
-                foreach ($teamId in $ID) {
-                    Get-VcTeam -ID $teamId
-                }
-            }
-            else {
-                $thisID = $ID[0]
-            }
 
-            if ( Test-IsGuid -InputObject $thisID ) {
-                $guid = [guid] $thisID
-                $uriLeaf = 'teams/{0}' -f $guid.ToString()
+            if ( Test-IsGuid -InputObject $Team ) {
+                $guid = [guid] $Team
+                $response = Invoke-VenafiRestMethod -UriLeaf ('teams/{0}' -f $guid.ToString())
             }
             else {
                 # assume team name
-                return Get-VcTeam -All | Where-Object { $_.name -eq $thisID }
+                $response = Invoke-VenafiRestMethod -UriLeaf 'teams' | Where-Object { $_.name -eq $Team }
             }
         }
-
-        $response = Invoke-VenafiRestMethod -UriLeaf $uriLeaf
 
         if ( $response.PSObject.Properties.Name -contains 'teams' ) {
             $response | Select-Object -ExpandProperty teams | ConvertTo-VcTeam

--- a/VenafiPS/Public/Get-VcUser.ps1
+++ b/VenafiPS/Public/Get-VcUser.ps1
@@ -6,7 +6,7 @@ function Get-VcUser {
     .DESCRIPTION
     Returns user information for TLSPC.
 
-    .PARAMETER ID
+    .PARAMETER User
     Either be the user id (guid) or username which is the email address.
 
     .PARAMETER Me
@@ -74,8 +74,8 @@ function Get-VcUser {
     param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [Alias('userId', 'owningUser', 'owningUsers', 'owningUserId')]
-        [String[]] $ID,
+        [Alias('userId', 'owningUser', 'owningUsers', 'owningUserId', 'ID')]
+        [String] $User,
 
         [Parameter(Mandatory, ParameterSetName = 'Me')]
         [Switch] $Me,
@@ -95,24 +95,14 @@ function Get-VcUser {
 
         Switch ($PsCmdlet.ParameterSetName)	{
             'Id' {
-                if ( $ID.Count -gt 1 ) {
-                    foreach ($teamId in $ID) {
-                        Get-VcUser -ID $teamId
-                    }
-                }
-                else {
-                    $thisID = $ID[0]
-                }
-
                 # can search by user id (guid) or username
-                try {
-                    $guid = [guid] $thisID
+                if ( Test-IsGuid($User) ) {
+                    $guid = [guid] $User
                     $response = Invoke-VenafiRestMethod -UriLeaf ('users/{0}' -f $guid.ToString())
                 }
-                catch {
-                    $response = Invoke-VenafiRestMethod -UriLeaf "users/username/$thisID" | Select-Object -ExpandProperty users
+                else {
+                    $response = Invoke-VenafiRestMethod -UriLeaf "users/username/$User" | Select-Object -ExpandProperty users
                 }
-
             }
 
             'Me' {

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -264,12 +264,13 @@ function Invoke-VcCertificateAction {
 
                 try {
                     $renewResponse = Invoke-VenafiRestMethod -Method 'Post' -UriRoot 'outagedetection/v1' -UriLeaf 'certificaterequests' -Body $renewParams -ErrorAction Stop
-                    $out | Add-Member @{'renew' = $renewResponse }
+                    $out | Add-Member @{'Renew' = $renewResponse }
 
                     if ( $Provision ) {
                         $newCertId = $renewResponse.certificateRequests.certificateIds[0]
                         Write-Verbose "Renew was successful, now provisioning certificate ID $newCertId"
-                        $null = Invoke-VcCertificateAction -ID $newCertId -Provision
+                        $provisionResponse = Invoke-VcCertificateAction -ID $newCertId -Provision
+                        $out | Add-Member @{'Provision' = $provisionResponse }
                     }
 
                     $out.Success = $true

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -110,11 +110,12 @@ function Invoke-VcWorkflow {
                 $WS = New-Object System.Net.WebSockets.ClientWebSocket
                 $CT = New-Object System.Threading.CancellationToken
 
-                if ( $VenafiSessionNested.GetType().Name -in 'PSCustomObject', 'VenafiSession' ) {
-                    $server = $VenafiSessionNested.Server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSessionNested.Key.GetNetworkCredential().password)
+                if ( $VenafiSession -is [PSCustomObject] ) {
+                    $server = $VenafiSession.Server.Replace('https://', '')
+                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession.Key.GetNetworkCredential().password)
                 }
                 else {
+                    $VcRegions | ConvertTo-Json | Write-Verbose
                     if ( $env:VC_SERVER ) {
                         $server = $env:VC_SERVER
                     }

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -544,7 +544,7 @@ function New-VenafiSession {
     else {
 
         $newSession | Add-Member @{
-            User = (Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession | Select-Object -ExpandProperty user | Select-Object @{
+            User = (Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession -ErrorAction SilentlyContinue | Select-Object -ExpandProperty user | Select-Object @{
                     'n' = 'userId'
                     'e' = {
                         $_.Id

--- a/VenafiPS/Public/Remove-VcSatelliteWorker.ps1
+++ b/VenafiPS/Public/Remove-VcSatelliteWorker.ps1
@@ -1,0 +1,60 @@
+function Remove-VcSatelliteWorker {
+    <#
+    .SYNOPSIS
+    Remove a vsatellite worker
+
+    .DESCRIPTION
+    Remove a vsatellite worker from TLSPC
+
+    .PARAMETER ID
+    Worker ID
+
+    .PARAMETER VenafiSession
+    Authentication for the function.
+    The value defaults to the script session object $VenafiSession created by New-VenafiSession.
+    A TLSPC key can also provided.
+
+    .INPUTS
+    ID
+
+    .EXAMPLE
+    Remove-VcSatelliteWorker -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+
+    Remove a worker
+
+    .EXAMPLE
+    Remove-VcSatelliteWorker -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Confirm:$false
+
+    Remove a worker bypassing the confirmation prompt
+
+    .EXAMPLE
+    Get-VcSatelliteWorker -VSatellite 'My vsat1' | Remove-VcSatelliteWorker
+
+    Remove all workers associated with a specific vsatellite
+    #>
+
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+
+    param (
+
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('vsatelliteWorkerId')]
+        [guid] $ID,
+
+        [Parameter()]
+        [psobject] $VenafiSession
+    )
+
+    begin {
+        Test-VenafiSession -VenafiSession $VenafiSession -Platform 'VC'
+    }
+
+    process {
+        if ( $PSCmdlet.ShouldProcess($ID, "Delete VSatellite Worker") ) {
+            $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "edgeworkers/$ID"
+        }
+    }
+
+    end {
+    }
+}

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VenafiPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '6.5.2'
+ModuleVersion = '6.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -108,7 +108,7 @@ FunctionsToExport = 'Add-VcCertificateAssociation', 'Add-VcTeamMember', 'Add-VcT
                'Set-VcConnector', 'Set-VcTeam', 'Set-VdcAttribute',
                'Set-VdcCredential', 'Set-VdcPermission',
                'Set-VdcWorkflowTicketStatus', 'Test-VdcIdentity', 'Test-VdcObject',
-               'Test-VdcToken', 'Write-VdcLog', 'Set-VcCertificate'
+               'Test-VdcToken', 'Write-VdcLog', 'Set-VcCertificate', 'Get-VcSatelliteWorker', 'Remove-VcSatelliteWorker'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
- Add `Get-VcSatelliteWorker`, either all, by id or for those workers associated with a satellite
- Add `Remove-VcSatelliteWorker`, you guessed it...removes vsat workers
- Add `Get-VcSatellite -IncludeWorkers` to get vsats and their associated workers in one call.
- Add `Invoke-VcCertificateAction -Provision` to push a certificate to associated machine identities.  You can also use `-Renew -Provision` together and it will renew and then provision the new certificate.
- Add `Set-VcApplication -IssuingTemplate` to add one or more issuing templates to an application.  It will overwrite by default or use `-NoOverwrite` to append.