### PR TITLE
313 does not honour api alias value as issuingtemplate variable

### DIFF
--- a/VenafiPS/Private/Get-VcData.ps1
+++ b/VenafiPS/Private/Get-VcData.ps1
@@ -157,7 +157,7 @@ function Get-VcData {
         }
 
         if ( $FailOnNotFound -and -not $returnObject ) {
-            throw "'$InputObject' of type $Type not found"
+            throw "$Type '$InputObject' not found"
         }
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -181,21 +181,19 @@ function New-VcCertificate {
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         # validation
-        $thisApp = Get-VcData -Type Application -InputObject $Application -Object
-        if ( -not $thisApp ) {
-            throw "Application $Application does not exist"
+        $thisApp = Get-VcData -Type Application -InputObject $Application -Object -FailOnNotFound
+
+        if ( $thisApp.issuingTemplate.Count -eq 0 ) {
+            throw 'No templates associated with this application'
         }
 
         if ( -not $IssuingTemplate ) {
             # issuing template not provided, see if the app has one
             switch ($thisApp.issuingTemplate.Count) {
-                0 {
-                    throw 'No templates associated with this application'
-                }
-
                 1 {
                     # there is only one template, use it
                     $thisTemplateId = $thisApp.issuingTemplate[0].issuingTemplateId
+                    break
                 }
 
                 Default {

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -7,11 +7,12 @@ function New-VcCertificate {
     Create certificate request from automated secure keypair details or CSR
 
     .PARAMETER Application
-    Application name (wildcards supported) or id to associate this certificate.
+    Application name or id to associate this certificate with.
 
     .PARAMETER IssuingTemplate
-    Issuing template name (wildcards supported) or id to use.
-    The template must be available with the selected Application.
+    Issuing template id, name, or alias.
+    The template must be associated with the provided Application.
+    If the application has only one template, this parameter is optional.
 
     .PARAMETER Csr
     CSR in PKCS#10 format which conforms to the rules of the issuing template
@@ -69,6 +70,11 @@ function New-VcCertificate {
     New-VcCertificate -Application 'MyApp' -IssuingTemplate 'MSCA - 1 year' -CommonName 'app.mycert.com'
 
     Create certificate
+
+    .EXAMPLE
+    New-VcCertificate -Application 'MyApp' -CommonName 'app.mycert.com'
+
+    Create certificate with the template associated with the application
 
     .EXAMPLE
     New-VcCertificate -Application 'MyApp' -IssuingTemplate 'MSCA - 1 year' -CommonName 'app.mycert.com' -SanIP '1.2.3.4'


### PR DESCRIPTION
- Enhance `New-VcCertificate -IssuingTemplate` to allow an alias to be provided.  `-IssuingTemplate` is now also optional if the associated application only has 1 associated template.  Closes #313.