### PR TITLE
Import/Export VC updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,3 @@
-- Fix API parameter in `Import-VdcCertificate`, [#316](https://github.com/Venafi/VenafiPS/issues/316)
-- Fix Invalid JSON response in `Find-VdcObject`, [#318](https://github.com/Venafi/VenafiPS/issues/318)
+- Add ability to import all certificates from a folder with `Import-VcCertificate -Path`
+- Fix parameter set issue where `-PrivateKeyPassword` could not be provided with `Import-VcCertificate -Path`
+- Fix [#315](https://github.com/Venafi/VenafiPS/issues/315), appending certificate id to exported file name

--- a/VenafiPS/Private/Split-CertificateData.ps1
+++ b/VenafiPS/Private/Split-CertificateData.ps1
@@ -17,7 +17,12 @@ function Split-CertificateData {
     }
 
     process {
-        $pemLines = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($CertificateData)).Split("`n")
+        if ( $CertificateData -match '-----BEGIN' ) {
+            $pemLines = $CertificateData.Split("`n")
+        }
+        else {
+            $pemLines = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($CertificateData)).Split("`n")
+        }
 
         $certPem = @()
 

--- a/VenafiPS/Private/Split-CertificateData.ps1
+++ b/VenafiPS/Private/Split-CertificateData.ps1
@@ -18,9 +18,11 @@ function Split-CertificateData {
 
     process {
         if ( $CertificateData -match '-----BEGIN' ) {
+            # we got base64 surrounded by headers and footers
             $pemLines = $CertificateData.Split("`n")
         }
         else {
+            # we got just base64 data
             $pemLines = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($CertificateData)).Split("`n")
         }
 

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -211,7 +211,7 @@ function Export-VcCertificate {
                 # pkcs12 is a byte array of a pfx file so its easy to handle
                 if ( $using:pset -eq 'PKCS12' ) {
                     if ( $using:OutPath ) {
-                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath ('{0}-{1}.pfx' -f $thisCert.certificateName, $thisCert.certificateId)
+                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath ('{0}.pfx' -f $thisCert.certificateName)
                         [IO.File]::WriteAllBytes($dest, $innerResponse.Content)
                         $out | Add-Member @{'outPath' = $dest }
                     }
@@ -339,7 +339,7 @@ function Export-VcCertificate {
 
                 if ( $certificateData ) {
                     if ( $using:OutPath ) {
-                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath ('{0}-{1}' -f $thisCert.certificateName, $thisCert.certificateId)
+                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath $thisCert.certificateName
                         $null = New-Item -Path $dest -ItemType Directory -Force
                         $outFile = Join-Path -Path $dest -ChildPath ('{0}.{1}' -f $PSItem, $params.Body.format)
                         try {


### PR DESCRIPTION
- Add ability to import all certificates from a path with `Import-VcCertificate -Path`
- Fix parameter set issue where the private key password could not be provided with `Import-VcCertificate -Path`
- Fix #315 appending certificate id to exported file name