### PR TITLE
Import non key certs, IsExpired param, pipeline enhancements

### DIFF
--- a/VenafiPS/Private/New-VcSearchQuery.ps1
+++ b/VenafiPS/Private/New-VcSearchQuery.ps1
@@ -76,8 +76,7 @@ function New-VcSearchQuery {
             # if so, pull it off the list and process the rest
             if ($Filter[0] -is 'String' -and $Filter[0] -in 'AND', 'OR') {
                 $operator = $Filter[0].ToUpper()
-                $loopFilter = $Filter | Select-Object -Skip 1
-                $loopFilter = @(, $loopFilter)
+                $loopFilter.RemoveAt(0)
             }
 
             $operands = foreach ($thisItem in $loopFilter) {

--- a/VenafiPS/Private/Split-CertificateData.ps1
+++ b/VenafiPS/Private/Split-CertificateData.ps1
@@ -9,7 +9,8 @@ function Split-CertificateData {
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [String] $CertificateData
+        [Alias('CertificateData')]
+        [String] $InputObject
     )
 
     begin {
@@ -17,13 +18,13 @@ function Split-CertificateData {
     }
 
     process {
-        if ( $CertificateData -match '-----BEGIN' ) {
+        if ( $InputObject -match '-----BEGIN' ) {
             # we got base64 surrounded by headers and footers
-            $pemLines = $CertificateData.Split("`n")
+            $pemLines = $InputObject.Split("`n")
         }
         else {
             # we got just base64 data
-            $pemLines = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($CertificateData)).Split("`n")
+            $pemLines = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($InputObject)).Split("`n")
         }
 
         $certPem = @()

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -376,6 +376,7 @@ function Export-VcCertificate {
             ScriptBlock   = $sb
             ThrottleLimit = $ThrottleLimit
             ProgressTitle = 'Exporting certificates'
+            VenafiSession = $VenafiSession
         }
         Invoke-VenafiParallel @invokeParams
     }

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -293,7 +293,7 @@ function Export-VdcCertificate {
             if ( $innerResponse.CertificateData ) {
 
                 if ( $thisBody.Format -in 'Base64', 'Base64 (PKCS#8)' ) {
-                    $splitData = Split-CertificateData -CertificateData $innerResponse.CertificateData
+                    $splitData = Split-CertificateData -InputObject $innerResponse.CertificateData
                 }
 
                 if ( $using:OutPath ) {

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -368,6 +368,6 @@ function Export-VdcCertificate {
 
             $out
 
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Exporting certificates'
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Exporting certificates' -VenafiSession $VenafiSession
     }
 }

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -359,7 +359,7 @@ function Export-VdcCertificate {
 
                     if ( $thisBody.IncludePrivateKey ) {
                         $out | Add-Member @{
-                            'PrivateKeyPasswordCredential' = (New-Object System.Management.Automation.PSCredential('unused', ($thisBody.Password | ConvertTo-SecureString -AsPlainText -Force)))
+                            'PrivateKeyPassword' = (New-Object System.Management.Automation.PSCredential('unused', ($thisBody.Password | ConvertTo-SecureString -AsPlainText -Force)))
                         }
                     }
 

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -21,6 +21,11 @@ function Find-VcCertificate {
     .PARAMETER IsSelfSigned
     Search for only self signed certificates
 
+    .PARAMETER IsExpired
+    Search for only expired certificates.
+    This will search for only certificates that are expired including active, retired, current, old, etc.
+    Be sure to use other parameters if you want to filter even further.
+    
     .PARAMETER Status
     Search by one or more certificate statuses.  Valid values include ACTIVE, RETIRED, and DELETED.
 

--- a/VenafiPS/Public/Find-VdcCertificate.ps1
+++ b/VenafiPS/Public/Find-VdcCertificate.ps1
@@ -392,6 +392,7 @@ function Find-VdcCertificate {
                 Offset = 0
             }
             FullResponse = $true
+            VenafiSession = $VenafiSession
         }
 
         if ($PSCmdlet.PagingParameters.First -ne [uint64]::MaxValue -and $PSCmdlet.PagingParameters.First -le 1000) {

--- a/VenafiPS/Public/Import-VcCertificate.ps1
+++ b/VenafiPS/Public/Import-VcCertificate.ps1
@@ -187,7 +187,7 @@ function Import-VcCertificate {
                     }
 
                     { $_ -in '.pem', '.cer', '.crt' } {
-                        $split = Split-CertificateData -CertificateData (Get-Content $file -Raw)
+                        $split = Split-CertificateData -InputObject (Get-Content $file -Raw)
 
                         if ( $split.KeyPem ) {
                             $allCerts.Add(@{
@@ -239,7 +239,7 @@ function Import-VcCertificate {
                     # X509 and PKCS8 both use Base64, but 'Base64' is how tlspdc refers to x509
                     # this allows us to pipe from tlspdc to tlspc
                     { $_ -in 'PKCS8', 'X509', 'Base64' } {
-                        $splitData = Split-CertificateData -CertificateData $Data
+                        $splitData = Split-CertificateData -InputObject $Data
 
                         if ( $splitData.KeyPem ) {
                             $addMe.CertPem = $splitData.CertPem

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -240,6 +240,6 @@ function Import-VdcCertificate {
             catch {
                 Write-Error $_
             }
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Importing certificates'
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Importing certificates' -VenafiSession $VenafiSession
     }
 }

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -50,7 +50,6 @@ function Import-VdcCertificate {
     Setting the value to 1 will disable multithreading.
     On PS v5 the ThreadJob module is required.  If not found, multithreading will be disabled.
 
-
     .PARAMETER PassThru
     Return a TppObject representing the newly imported object.
 
@@ -75,11 +74,18 @@ function Import-VdcCertificate {
 
     Import a certificate from data instead of a path
 
+    .EXAMPLE
+    New-VenafiSession -VcKey <api_key>
+    $sess = New-VenafiSession -Server venafi.mycompany.com -Credential $cred -ClientId VenafiPS-MyApp -Scope @{'certificate'='manage'} -PassThru
+    Find-VcCertificate -VersionType CURRENT | Export-VcCertificate -PrivateKeyPassword 'myPassword!' -PKCS12 | Import-VdcCertificate -PolicyPath 'certificates' -VenafiSession $sess
+
+    Export 1 or more certificates from TLSPC and import to TLSPDC.  Note the use of 2 sessions at once where the TLSPDC session is stored in a variable.
+
     .INPUTS
     Path, Data
 
     .OUTPUTS
-    TppObject, if PassThru provided
+    PSCustomObject, if PassThru provided
 
     .LINK
     https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Import.php
@@ -111,6 +117,7 @@ function Import-VdcCertificate {
         [Parameter(Mandatory, ParameterSetName = 'ByData', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'ByDataWithPrivateKey', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
+        [Alias('CertificateData')]
         [String] $Data,
 
         [Parameter()]
@@ -127,9 +134,9 @@ function Import-VdcCertificate {
         [String] $PrivateKey,
 
         [Parameter(ParameterSetName = 'ByFile')]
-        [Parameter(ParameterSetName = 'ByData')]
+        [Parameter(ParameterSetName = 'ByData', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'ByFileWithPrivateKey')]
-        [Parameter(Mandatory, ParameterSetName = 'ByDataWithPrivateKey')]
+        [Parameter(Mandatory, ParameterSetName = 'ByDataWithPrivateKey', ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript(
             {
@@ -183,16 +190,24 @@ function Import-VdcCertificate {
             $params.Body.ObjectName = $Name
         }
 
-        if ( $PSBoundParameters.ContainsKey('PrivateKeyPassword') ) {
-            $params.Body.Password = $PrivateKeyPassword | ConvertTo-PlaintextString
-        }
-
         if ( $PSBoundParameters.ContainsKey('PrivateKey') ) {
             $params.Body.PrivateKeyData = $PrivateKey
         }
     }
-
+    
     process {
+        Write-Debug ('paramset={0}' -f $PSCmdlet.ParameterSetName)
+
+        if ( $PSBoundParameters.ContainsKey('PrivateKeyPassword') ) {
+            $params.Body.Password = $PrivateKeyPassword | ConvertTo-PlaintextString
+        }
+        else {
+            # password not provided for this pipeline object
+            if ( $params.Body.ContainsKey('Password') ) {
+                $params.Body.Remove('Password')
+            }
+        }
+
         $allCerts.Add(
             @{
                 InvokeParams = $params

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -242,9 +242,11 @@ function Invoke-VenafiRestMethod {
         $paramsToWrite = $params.Clone()
         $paramsToWrite.Body = $preJsonBody
         $paramsToWrite | Write-VerboseWithSecret
+        Write-Debug -Message ($paramsToWrite | ConvertTo-Json -Depth 5)
     }
     else {
         $params | Write-VerboseWithSecret
+        Write-Debug -Message ($params | ConvertTo-Json -Depth 5)
     }
 
     # ConvertTo-Json, used in Write-VerboseWithSecret, has an issue with certificates

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -97,47 +97,58 @@ function New-VenafiSession {
     VenafiSession, if -PassThru is provided
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -ClientId MyApp -Scope @{'certificate'='manage'}
+    New-VenafiSession -Server venafi.mycompany.com -ClientId VenafiPS-MyApp -Scope @{'certificate'='manage'}
+    
     Create token-based session using Windows Integrated authentication with a certain scope and privilege restriction
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -Credential $cred -ClientId MyApp -Scope @{'certificate'='manage'}
+    New-VenafiSession -Server venafi.mycompany.com -Credential $cred -ClientId VenafiPS-MyApp -Scope @{'certificate'='manage'}
+    
     Create token-based session
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -Certificate $myCert -ClientId MyApp -Scope @{'certificate'='manage'}
+    New-VenafiSession -Server venafi.mycompany.com -Certificate $myCert -ClientId VenafiPS-MyApp -Scope @{'certificate'='manage'}
+    
     Create token-based session using a client certificate
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -AuthServer tppauth.mycompany.com -ClientId MyApp -Credential $cred
+    New-VenafiSession -Server venafi.mycompany.com -AuthServer tppauth.mycompany.com -ClientId VenafiPS-MyApp -Credential $cred
+    
     Create token-based session using oauth authentication where the vedauth and vedsdk are hosted on different servers
 
     .EXAMPLE
-    $sess = New-VenafiSession -Server venafitpp.mycompany.com -Credential $cred -PassThru
+    $sess = New-VenafiSession -Server venafi.mycompany.com -Credential $cred -PassThru
+
     Create session and return the session object instead of setting to script scope variable
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -AccessToken $accessCred
+    New-VenafiSession -Server venafi.mycompany.com -AccessToken $accessCred
+    
     Create session using an access token obtained outside this module
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -RefreshToken $refreshCred -ClientId MyApp
+    New-VenafiSession -Server venafi.mycompany.com -RefreshToken $refreshCred -ClientId VenafiPS-MyApp
+    
     Create session using a refresh token
 
     .EXAMPLE
-    New-VenafiSession -Server venafitpp.mycompany.com -RefreshToken $refreshCred -ClientId MyApp -VaultRefreshTokenName TppRefresh
+    New-VenafiSession -Server venafi.mycompany.com -RefreshToken $refreshCred -ClientId VenafiPS-MyApp -VaultRefreshTokenName TppRefresh
+    
     Create session using a refresh token and store the newly created refresh token in the vault
 
     .EXAMPLE
     New-VenafiSession -VcKey $cred
+    
     Create session against TLSPC
 
     .EXAMPLE
     New-VenafiSession -VcKey $cred -VcRegion 'eu'
+    
     Create session against TLSPC in EU region
 
     .EXAMPLE
     New-VenafiSession -VaultVcKeyName vaas-key
+    
     Create session against TLSPC with a key stored in a vault
 
     .LINK

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -67,7 +67,7 @@ function Remove-VdcCertificate {
                     $true
                 }
                 else {
-                    throw "'$_' is not a valid DN path"
+                    throw "'$_' is not a valid path"
                 }
             })]
         [Alias('DN', 'CertificateDN')]
@@ -114,6 +114,6 @@ function Remove-VdcCertificate {
             }
 
             $null = Invoke-VenafiRestMethod -Method Delete -UriLeaf "Certificates/$guid"
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Deleting certificates'
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Deleting certificates' -VenafiSession $VenafiSession
     }
 }


### PR DESCRIPTION
- Add support for X509 (.pem, .cer, and .crt) to `Import-VcCertificate`
- Add `Find-VcCertificate -IsExpired`
- Better support for exporting and importing certificates between TLSPDC and TLSPC via pipeline
- Fix bug with `New-VcSearchQuery` when a specific number of filters were provided
