### PR TITLE
Import export pipe enhancements, session management

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
-
-* @gdbarron @brantpeery @Booyah!! @danguite-ven @wilddev65 @Saadi6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,6 @@
-- Add support for X509 (.pem, .cer, and .crt) to `Import-VcCertificate`.  Both by path and by data are supported.  Pull in a folder full of certificates or pipe from either TLSPDC or another TLSPC tenant.
-- Add `Find-VcCertificate -IsExpired`
-- Better support for exporting and importing certificates between TLSPDC and TLSPC via pipeline
-- Fix bug with `New-VcSearchQuery` when a specific number of filters were provided
+- Add `Get-VenafiSession` to centralize session management.  For nested and/or piped functions, pull the session from the call stack.
+- Add _PolicyPath_ to `Export-VdcCertificate` output and `Import-VdcCertificate -PolicyPath`.  This allows the imported certificate to be created in the same policy folder.  This could be used to synchronize across environments for example.  The addition of `Import-VdcCertificate -Force` will cause a policy path to be created if it does not already exist; policy subfolders are supported as well.
+- Add `Import-VcCertificate` blocklist functionality.  Override the blocklist by default and honor the blocklist if the environment variable _VC_ENABLE_BLOCKLIST_ is set to true.
+- Fix VC import failure with a large number of keystores, [#322](https://github.com/Venafi/VenafiPS/issues/322)
+- Hide _dekEncryptedPassword_ from verbose output
+- Remove _Filename_ from `Export-VdcCertificate` when outputting data and not writing to a file

--- a/VenafiPS/Private/Find-VcObject.ps1
+++ b/VenafiPS/Private/Find-VcObject.ps1
@@ -105,6 +105,7 @@ function Find-VcObject {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Private/Get-VenafiSession.ps1
+++ b/VenafiPS/Private/Get-VenafiSession.ps1
@@ -1,0 +1,44 @@
+function Get-VenafiSession {
+
+    process {
+        # find out if a session was passed in as a parameter from the calling function in the stack.
+        # this should only come from the first function which was initiated by the user
+
+        # this provides 2 benefits:
+        # - nested functions do not need VenafiSession provided
+        # - we can pipe between functions which use different sessions, eg. export from server1 -> import to server2.
+        #   this is only possible when core function processing occurs in the end block as the call stack during the process
+        #   block including the calling and current function and their parameters.  there shouldn't be too many functions
+        #   where we need to go between environments anyway, mainly export and import.  perhaps revisit this in the future if needed.
+
+        # if a session isn't explicitly provided, fallback to the script scope session variable created with New-VenafiSession
+
+        $venafiSessionNested = (Get-PSCallStack).InvocationInfo.BoundParameters.VenafiSession | Select-Object -First 1
+
+        if ($venafiSessionNested) {
+            $sess = $venafiSessionNested
+            Write-Debug 'Using nested session from call stack'
+        }
+        elseif ( $script:VenafiSession ) {
+            $sess = $script:VenafiSession
+            Write-Debug 'Using script session'
+        }
+        elseif ( $env:VDC_TOKEN ) {
+            $sess = $env:VDC_TOKEN
+            Write-Debug 'Using TLSPDC token environment variable'
+        }
+        elseif ( $env:VC_KEY ) {
+            $sess = $env:VC_KEY
+            Write-Debug 'Using TLSPC key environment variable'
+        }
+        else {
+            throw [System.ArgumentException]::new('Please run New-VenafiSession or provide a TLSPC key or TLSPDC token to -VenafiSession.')
+        }
+
+        if ( $sess.Token.Expires -and $sess.Token.Expires -lt (Get-Date).ToUniversalTime() ) {
+            throw 'TLSPDC token has expired.  Execute New-VenafiSession and rerun your command.'
+        }
+        
+        $sess
+    }
+}

--- a/VenafiPS/Private/Initialize-PSSodium.ps1
+++ b/VenafiPS/Private/Initialize-PSSodium.ps1
@@ -16,7 +16,7 @@ function Initialize-PSSodium {
             Install-Module -Name PSSodium -Force -RequiredVersion '0.4.2'
         }
         else {
-            throw 'The PSSodium module is not installed.  Add -Force for the module to be automatically installed.'
+            throw 'The PSSodium module is not installed.  Add -Force for the module to be automatically installed or install from the PowerShell Gallery.'
         }
     }
 

--- a/VenafiPS/Private/Invoke-VcGraphQL.ps1
+++ b/VenafiPS/Private/Invoke-VcGraphQL.ps1
@@ -9,7 +9,7 @@ function Invoke-VcGraphQL {
 
     param (
         [Parameter(ParameterSetName = 'Session')]
-        [AllowNull()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key', 'AccessToken')]
         [psobject] $VenafiSession,
 

--- a/VenafiPS/Private/Invoke-VcGraphQL.ps1
+++ b/VenafiPS/Private/Invoke-VcGraphQL.ps1
@@ -58,24 +58,7 @@ function Invoke-VcGraphQL {
 
     if ( $PSCmdLet.ParameterSetName -eq 'Session' ) {
 
-        if ( $env:VC_KEY ) {
-            $VenafiSession = $env:VC_KEY
-            Write-Verbose 'Using TLSPC key environment variable'
-        }
-        elseif ( $PSBoundParameters.VenafiSession ) {
-            Write-Verbose 'Using session provided'
-        }
-        elseif ($script:VenafiSessionNested) {
-            $VenafiSession = $script:VenafiSessionNested
-            Write-Verbose 'Using nested session'
-        }
-        elseif ( $script:VenafiSession ) {
-            $VenafiSession = $script:VenafiSession
-            Write-Verbose 'Using script session'
-        }
-        else {
-            throw 'Please run New-VenafiSession or provide a TLSPC key or TLSPDC token.'
-        }
+        $VenafiSession = Get-VenafiSession
 
         switch ($VenafiSession.GetType().Name) {
             'PSCustomObject' {
@@ -102,7 +85,7 @@ function Invoke-VcGraphQL {
             }
 
             Default {
-                throw "Unknown session '$VenafiSession'.  Please run New-VenafiSession or provide a TLSPC key or TLSPDC token."
+                throw "Unknown session '$VenafiSession'.  Please run New-VenafiSession or provide a TLSPC key."
             }
         }
 

--- a/VenafiPS/Private/Invoke-VenafiParallel.ps1
+++ b/VenafiPS/Private/Invoke-VenafiParallel.ps1
@@ -65,6 +65,7 @@ function Invoke-VenafiParallel {
         [string] $ProgressTitle = 'Performing action',
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
 
     )

--- a/VenafiPS/Private/Invoke-VenafiParallel.ps1
+++ b/VenafiPS/Private/Invoke-VenafiParallel.ps1
@@ -81,21 +81,7 @@ function Invoke-VenafiParallel {
             }
         }
 
-        if ( $VenafiSession ) {
-            # session provided directly, use it
-        }
-        elseif ( $script:VenafiSession ) {
-            $VenafiSession = $script:VenafiSession
-        }
-        elseif ($script:VenafiSessionNested) {
-            $VenafiSession = $script:VenafiSessionNested
-        }
-        elseif ( $env:VDC_TOKEN ) {
-            $VenafiSession = $env:VDC_TOKEN
-        }
-        elseif ( $env:VC_KEY ) {
-            $VenafiSession = $env:VC_KEY
-        }
+        $VenafiSession = Get-VenafiSession
     }
 
     process {
@@ -107,7 +93,7 @@ function Invoke-VenafiParallel {
 
         # throttle to 1 = no parallel
         if ( $ThrottleLimit -le 1 ) {
-            # ensure no $using: vars given not threaded and not needed
+            # remove $using: from vars, not threaded and not supported
             $InputObject | ForEach-Object -Process ([ScriptBlock]::Create(($ScriptBlock.ToString() -ireplace [regex]::Escape('$using:'), '$')))
             return
         }
@@ -126,6 +112,9 @@ function Invoke-VenafiParallel {
 
             # bring in verbose preference from calling ps session
             $VerbosePreference = $using:VerbosePreference
+
+            # bring in debug preference from calling ps session
+            $DebugPreference = $using:DebugPreference
         }
 
 

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -23,6 +23,10 @@ function Test-VenafiSession {
 
     process {
 
+        # moving the functionality into Get-VenafiSession which will be called by
+        # the Invoke functions
+        return
+        
         if ( (Get-PSCallStack).Count -gt 3 -and -not $InvocationInfo.BoundParameters['VenafiSession'] ) {
             # nested function, no need to continue testing session since it was already done
             return
@@ -108,7 +112,7 @@ function Test-VenafiSession {
             }
         }
 
-        $script:VenafiSessionNested = $VenafiSession
+        # $script:VenafiSessionNested = $VenafiSession
         # $script:PlatformNested = $Platform
     }
 }

--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData', 'certificate')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData', 'certificate', 'dekEncryptedPassword')
     )
 
     begin {

--- a/VenafiPS/Public/Add-VcTeamMember.ps1
+++ b/VenafiPS/Public/Add-VcTeamMember.ps1
@@ -46,6 +46,7 @@
         [string[]] $Member,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VcTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VcTeamOwner.ps1
@@ -41,6 +41,7 @@
         [string[]] $Owner,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VdcAdaptableHash.ps1
+++ b/VenafiPS/Public/Add-VdcAdaptableHash.ps1
@@ -86,6 +86,7 @@ function Add-VdcAdaptableHash {
         [string] $FilePath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VdcCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-VdcCertificateAssociation.ps1
@@ -88,6 +88,7 @@ function Add-VdcCertificateAssociation {
         [switch] $PushCertificate,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VdcEngineFolder.ps1
+++ b/VenafiPS/Public/Add-VdcEngineFolder.ps1
@@ -57,6 +57,7 @@ function Add-VdcEngineFolder {
         [String[]] $FolderPath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VdcTeamMember.ps1
+++ b/VenafiPS/Public/Add-VdcTeamMember.ps1
@@ -43,6 +43,7 @@
         [string[]] $Member,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Add-VdcTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VdcTeamOwner.ps1
@@ -42,6 +42,7 @@
         [string[]] $Owner,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Convert-VdcObject.ps1
+++ b/VenafiPS/Public/Convert-VdcObject.ps1
@@ -72,6 +72,7 @@ function Convert-VdcObject {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/ConvertTo-VdcGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcGuid.ps1
@@ -48,6 +48,7 @@ function ConvertTo-VdcGuid {
         [switch] $IncludeType,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/ConvertTo-VdcPath.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcPath.ps1
@@ -38,6 +38,7 @@ function ConvertTo-VdcPath {
         [switch] $IncludeType,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -366,7 +366,6 @@ function Export-VcCertificate {
             ScriptBlock   = $sb
             ThrottleLimit = $ThrottleLimit
             ProgressTitle = 'Exporting certificates'
-            VenafiSession = $VenafiSession
         }
         Invoke-VenafiParallel @invokeParams
     }

--- a/VenafiPS/Public/Export-VcCertificate.ps1
+++ b/VenafiPS/Public/Export-VcCertificate.ps1
@@ -140,6 +140,7 @@ function Export-VcCertificate {
         [switch] $Force,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -257,9 +257,12 @@ function Export-VdcCertificate {
                             throw $_
                         }
 
+                        # it could be we just don't have a private key so get just the cert
                         $thisBody.IncludePrivateKey = $false
                         $thisBody.Password = $null
                         $innerResponse = Invoke-VenafiRestMethod -Method 'Post' -UriLeaf 'certificates/retrieve' -Body $thisBody
+                    } else {
+                        throw $_
                     }
                 }
                 catch {
@@ -271,7 +274,7 @@ function Export-VdcCertificate {
                 }
             }
 
-            $out = $innerResponse | Select-Object Filename, @{
+            $out = $innerResponse | Select-Object @{
                 n = 'Path'
                 e = { $thisBody.CertificateDN }
             },
@@ -289,7 +292,12 @@ function Export-VdcCertificate {
             @{
                 n = 'Error'
                 e = { $_.Status }
-            }, CertificateData
+            }, 
+            @{
+                n = 'PolicyPath'
+                e = { $thisBody.CertificateDN.Substring(0, $thisBody.CertificateDN.LastIndexOf('\')) }
+            },
+            CertificateData
 
             if ( $innerResponse.CertificateData ) {
 
@@ -369,6 +377,6 @@ function Export-VdcCertificate {
 
             $out
 
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Exporting certificates' -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Exporting certificates'
     }
 }

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -193,6 +193,7 @@ function Export-VdcCertificate {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Export-VdcVaultObject.ps1
+++ b/VenafiPS/Public/Export-VdcVaultObject.ps1
@@ -54,6 +54,7 @@ function Export-VdcVaultObject {
         [String] $OutPath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -229,6 +229,7 @@ function Find-VcCertificate {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcCertificateInstance.ps1
+++ b/VenafiPS/Public/Find-VcCertificateInstance.ps1
@@ -69,6 +69,7 @@ function Find-VcCertificateInstance {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcCertificateRequest.ps1
+++ b/VenafiPS/Public/Find-VcCertificateRequest.ps1
@@ -56,6 +56,7 @@ function Find-VcCertificateRequest {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcLog.ps1
+++ b/VenafiPS/Public/Find-VcLog.ps1
@@ -105,6 +105,7 @@ function Find-VcLog {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcMachine.ps1
+++ b/VenafiPS/Public/Find-VcMachine.ps1
@@ -63,6 +63,7 @@ function Find-VcMachine {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Find-VcMachineIdentity.ps1
@@ -50,6 +50,7 @@ function Find-VcMachineIdentity {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcCertificate.ps1
+++ b/VenafiPS/Public/Find-VdcCertificate.ps1
@@ -377,6 +377,7 @@ function Find-VdcCertificate {
         [Switch] $CountOnly,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcCertificate.ps1
+++ b/VenafiPS/Public/Find-VdcCertificate.ps1
@@ -393,7 +393,6 @@ function Find-VdcCertificate {
                 Offset = 0
             }
             FullResponse = $true
-            VenafiSession = $VenafiSession
         }
 
         if ($PSCmdlet.PagingParameters.First -ne [uint64]::MaxValue -and $PSCmdlet.PagingParameters.First -le 1000) {

--- a/VenafiPS/Public/Find-VdcClient.ps1
+++ b/VenafiPS/Public/Find-VdcClient.ps1
@@ -50,6 +50,7 @@ function Find-VdcClient {
         [String] $ClientType,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcEngine.ps1
+++ b/VenafiPS/Public/Find-VdcEngine.ps1
@@ -41,6 +41,7 @@ function Find-VdcEngine {
         [String] $Pattern,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcIdentity.ps1
+++ b/VenafiPS/Public/Find-VdcIdentity.ps1
@@ -71,6 +71,7 @@ function Find-VdcIdentity {
         [Switch] $IncludeDistributionGroups,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcObject.ps1
+++ b/VenafiPS/Public/Find-VdcObject.ps1
@@ -150,6 +150,7 @@ function Find-VdcObject {
         [switch] $NoLookup,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Find-VdcVaultId.ps1
+++ b/VenafiPS/Public/Find-VdcVaultId.ps1
@@ -46,6 +46,7 @@ function Find-VdcVaultId {
         [hashtable] $Attribute,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcApplication.ps1
+++ b/VenafiPS/Public/Get-VcApplication.ps1
@@ -63,6 +63,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcCertificate.ps1
+++ b/VenafiPS/Public/Get-VcCertificate.ps1
@@ -52,6 +52,7 @@
         [switch] $IncludeVaasOwner,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcConnector.ps1
+++ b/VenafiPS/Public/Get-VcConnector.ps1
@@ -45,6 +45,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcIssuingTemplate.ps1
+++ b/VenafiPS/Public/Get-VcIssuingTemplate.ps1
@@ -81,6 +81,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcMachine.ps1
+++ b/VenafiPS/Public/Get-VcMachine.ps1
@@ -112,6 +112,7 @@
         [switch] $IncludeConnectionDetail,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Get-VcMachineIdentity.ps1
@@ -60,6 +60,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcSatellite.ps1
+++ b/VenafiPS/Public/Get-VcSatellite.ps1
@@ -81,6 +81,7 @@
         [switch] $IncludeWorkers,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcSatelliteWorker.ps1
+++ b/VenafiPS/Public/Get-VcSatelliteWorker.ps1
@@ -64,6 +64,7 @@ function Get-VcSatelliteWorker {
         [string] $VSatellite,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcTag.ps1
+++ b/VenafiPS/Public/Get-VcTag.ps1
@@ -44,6 +44,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcTeam.ps1
+++ b/VenafiPS/Public/Get-VcTeam.ps1
@@ -58,6 +58,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key', 'AccessToken')]
         [psobject] $VenafiSession
     )

--- a/VenafiPS/Public/Get-VcUser.ps1
+++ b/VenafiPS/Public/Get-VcUser.ps1
@@ -84,6 +84,7 @@ function Get-VcUser {
         [Switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VcWebhook.ps1
+++ b/VenafiPS/Public/Get-VcWebhook.ps1
@@ -68,6 +68,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcAttribute.ps1
@@ -215,6 +215,7 @@ function Get-VdcAttribute {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcCertificate.ps1
+++ b/VenafiPS/Public/Get-VdcCertificate.ps1
@@ -96,6 +96,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcClassAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcClassAttribute.ps1
@@ -36,7 +36,6 @@ function Get-VdcClassAttribute {
         Write-Verbose "Processing $ClassName"
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Post'
             UriLeaf       = 'configschema/class'
             Body          = @{

--- a/VenafiPS/Public/Get-VdcClassAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcClassAttribute.ps1
@@ -21,6 +21,7 @@ function Get-VdcClassAttribute {
         [string] $ClassName,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcCredential.ps1
+++ b/VenafiPS/Public/Get-VdcCredential.ps1
@@ -61,6 +61,7 @@ function Get-VdcCredential {
         [switch] $IncludeDetail,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcCredential.ps1
+++ b/VenafiPS/Public/Get-VdcCredential.ps1
@@ -69,7 +69,6 @@ function Get-VdcCredential {
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Post'
             UriLeaf       = 'Credentials/Retrieve'
             Body          = @{}

--- a/VenafiPS/Public/Get-VdcCustomField.ps1
+++ b/VenafiPS/Public/Get-VdcCustomField.ps1
@@ -60,6 +60,7 @@ function Get-VdcCustomField {
         [string] $Class,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcEngineFolder.ps1
+++ b/VenafiPS/Public/Get-VdcEngineFolder.ps1
@@ -66,6 +66,7 @@ function Get-VdcEngineFolder {
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcIdentity.ps1
+++ b/VenafiPS/Public/Get-VdcIdentity.ps1
@@ -103,6 +103,7 @@ function Get-VdcIdentity {
         [Switch] $IncludeMembers,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcIdentityAttribute.ps1
@@ -56,6 +56,7 @@ function Get-VdcIdentityAttribute {
         [string[]] $Attribute,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcObject.ps1
+++ b/VenafiPS/Public/Get-VdcObject.ps1
@@ -58,6 +58,7 @@ function Get-VdcObject {
         [guid[]] $Guid,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcObject.ps1
+++ b/VenafiPS/Public/Get-VdcObject.ps1
@@ -69,13 +69,13 @@ function Get-VdcObject {
     process {
 
         if ( $PSCmdLet.ParameterSetName -eq 'ByPath' ) {
-            $Path | ConvertTo-VdcFullPath | ForEach-Object {
-                ConvertTo-VdcObject -Path $_
+            foreach ($p in $Path) {
+                ConvertTo-VdcObject -Path ($p | ConvertTo-VdcFullPath)
             }
         }
         else {
-            $Guid | ForEach-Object {
-                ConvertTo-VdcObject -Guid $_
+            foreach ($g in $Guid) {
+                ConvertTo-VdcObject -Guid $g
             }
         }
     }

--- a/VenafiPS/Public/Get-VdcPermission.ps1
+++ b/VenafiPS/Public/Get-VdcPermission.ps1
@@ -152,6 +152,7 @@
         [switch] $Explicit,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcSystemStatus.ps1
+++ b/VenafiPS/Public/Get-VdcSystemStatus.ps1
@@ -37,6 +37,7 @@ function Get-VdcSystemStatus {
 
     param (
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcTeam.ps1
+++ b/VenafiPS/Public/Get-VdcTeam.ps1
@@ -56,6 +56,7 @@
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcVersion.ps1
+++ b/VenafiPS/Public/Get-VdcVersion.ps1
@@ -39,6 +39,7 @@ function Get-VdcVersion {
 
     param (
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
@@ -79,6 +79,7 @@ function Get-VdcWorkflowTicket {
         [String[]] $Path,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Import-VcCertificate.ps1
+++ b/VenafiPS/Public/Import-VcCertificate.ps1
@@ -37,7 +37,7 @@ function Import-VcCertificate {
     100 keystores will be imported at a time so it's less important to have a very high throttle limit.
 
     .PARAMETER Force
-    Force installation of PSSodium if not already installed
+    Force installation of PSSodium if not already installed.  This is required for the import of keys.
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -74,8 +74,8 @@ function Import-VcCertificate {
     https://developer.venafi.com/tlsprotectcloud/reference/certificates_import
 
     .NOTES
-    This function requires the use of sodium encryption.
-    .net standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
+    This function requires the use of sodium encryption via the PSSodium PowerShell module.
+    Dotnet standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
     On Windows, the latest Visual C++ redist must be installed.  See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist.
 
     Non keystore imports, just certs no keys, will override the blocklist by default.

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -94,7 +94,7 @@ function Import-VdcCertificate {
     https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Import.php
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'ByData', SupportsShouldProcess)]
+    [CmdletBinding(DefaultParameterSetName = 'ByData')]
     [Alias('Import-TppCertificate')]
 
     param (

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -146,6 +146,7 @@ function Invoke-VcCertificateAction {
         [hashtable] $AdditionalParameters,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -373,7 +373,10 @@ function Invoke-VcCertificateAction {
                 $params.UriLeaf = "certificates/deletion"
 
                 if ( $PSCmdlet.ShouldProcess('TLSPC', ('Delete {0} certificate(s) in batches of {1}' -f $allCerts.Count, $BatchSize) ) ) {
+
+                    # only retired certs can be deleted, product requirement
                     $null = $allCerts | Invoke-VcCertificateAction -Retire -BatchSize $BatchSize -Confirm:$false
+                    
                     $allCerts | Select-VenBatch -Activity 'Deleting certificates' -BatchSize $BatchSize -BatchType 'string' -TotalCount $allCerts.Count | ForEach-Object {
                         $params.Body = @{"certificateIds" = $_ }
 

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -85,6 +85,7 @@ function Invoke-VcWorkflow {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Invoke-VdcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VdcCertificateAction.ps1
@@ -150,6 +150,7 @@ function Invoke-VdcCertificateAction {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -44,7 +44,7 @@ function Invoke-VenafiRestMethod {
 
     param (
         [Parameter(ParameterSetName = 'Session')]
-        [AllowNull()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key', 'AccessToken')]
         [psobject] $VenafiSession,
 

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -95,33 +95,10 @@ function Invoke-VenafiRestMethod {
         TimeoutSec      = $TimeoutSec
     }
 
-
+    # default parameter set, no explicit session will come here
     if ( $PSCmdLet.ParameterSetName -eq 'Session' ) {
 
-        # if ( -not $VenafiSession ) {
-        if ( $env:VDC_TOKEN ) {
-            $VenafiSession = $env:VDC_TOKEN
-            Write-Verbose 'Using TLSPDC token environment variable'
-        }
-        elseif ( $env:VC_KEY ) {
-            $VenafiSession = $env:VC_KEY
-            Write-Verbose 'Using TLSPC key environment variable'
-        }
-        elseif ( $PSBoundParameters.VenafiSession ) {
-            Write-Verbose 'Using session provided'
-        }
-        elseif ($script:VenafiSessionNested) {
-            $VenafiSession = $script:VenafiSessionNested
-            Write-Verbose 'Using nested session'
-        }
-        elseif ( $script:VenafiSession ) {
-            $VenafiSession = $script:VenafiSession
-            Write-Verbose 'Using script session'
-        }
-        else {
-            throw 'Please run New-VenafiSession or provide a TLSPC key or TLSPDC token.'
-        }
-        # }
+        $VenafiSession = Get-VenafiSession
 
         switch ($VenafiSession.GetType().Name) {
             'PSCustomObject' {
@@ -197,7 +174,8 @@ function Invoke-VenafiRestMethod {
 
     if ( $UriRoot -eq 'graphql' ) {
         $params.Uri = "$Server/graphql"
-    } else {
+    }
+    else {
         $params.Uri = '{0}/{1}/{2}' -f $Server, $UriRoot, $UriLeaf
     }
 

--- a/VenafiPS/Public/Move-VdcObject.ps1
+++ b/VenafiPS/Public/Move-VdcObject.ps1
@@ -78,6 +78,7 @@ function Move-VdcObject {
         [String] $TargetPath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcApplication.ps1
+++ b/VenafiPS/Public/New-VcApplication.ps1
@@ -95,6 +95,7 @@ function New-VcApplication {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcApplication.ps1
+++ b/VenafiPS/Public/New-VcApplication.ps1
@@ -161,7 +161,6 @@ function New-VcApplication {
         }
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Post'
             UriRoot       = 'outagedetection/v1'
             UriLeaf       = 'applications'

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -173,6 +173,7 @@ function New-VcCertificate {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcConnector.ps1
+++ b/VenafiPS/Public/New-VcConnector.ps1
@@ -75,6 +75,7 @@ function New-VcConnector {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcMachine.ps1
+++ b/VenafiPS/Public/New-VcMachine.ps1
@@ -171,6 +171,7 @@ function New-VcMachine {
         [switch] $Force,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 
@@ -286,7 +287,7 @@ function New-VcMachine {
                     'e' = { $workflowResponse | Select-Object Success, Error, WorkflowID }
                 }, * -ExcludeProperty id
             }
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
 
         if ( $PassThru ) {
             $response

--- a/VenafiPS/Public/New-VcMachine.ps1
+++ b/VenafiPS/Public/New-VcMachine.ps1
@@ -112,8 +112,8 @@ function New-VcMachine {
     .NOTES
     To see a full list of tab-completion options, be sure to set the Tab option, Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete.
 
-    This function requires the use of sodium encryption via PSSodium, https://github.com/TylerLeonhardt/PSSodium, to be installed.
-    .net standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
+    This function requires the use of sodium encryption via the PSSodium PowerShell module.
+    Dotnet standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
     On Windows, the latest Visual C++ redist must be installed.  See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist.
     #>
 

--- a/VenafiPS/Public/New-VcMachineCommonKeystore.ps1
+++ b/VenafiPS/Public/New-VcMachineCommonKeystore.ps1
@@ -110,8 +110,8 @@ function New-VcMachineCommonKeystore {
     Create a new machine with SSH password authentication
 
     .NOTES
-    This function requires the use of sodium encryption.
-    .net standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
+    This function requires the use of sodium encryption via the PSSodium PowerShell module.
+    Dotnet standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
     On Windows, the latest Visual C++ redist must be installed.  See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist.
     #>
 

--- a/VenafiPS/Public/New-VcMachineCommonKeystore.ps1
+++ b/VenafiPS/Public/New-VcMachineCommonKeystore.ps1
@@ -187,6 +187,7 @@ function New-VcMachineCommonKeystore {
         [switch] $Force,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcMachineIis.ps1
+++ b/VenafiPS/Public/New-VcMachineIis.ps1
@@ -165,6 +165,7 @@ function New-VcMachineIis {
         [switch] $Force,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcMachineIis.ps1
+++ b/VenafiPS/Public/New-VcMachineIis.ps1
@@ -101,8 +101,8 @@ function New-VcMachineIis {
     Create a new machine with Kerberos authentication
 
     .NOTES
-    This function requires the use of sodium encryption.
-    .net standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
+    This function requires the use of sodium encryption via the PSSodium PowerShell module.
+    Dotnet standard 2.0 or greater is required via PS Core (recommended) or supporting .net runtime.
     On Windows, the latest Visual C++ redist must be installed.  See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist.
     #>
 

--- a/VenafiPS/Public/New-VcTeam.ps1
+++ b/VenafiPS/Public/New-VcTeam.ps1
@@ -88,6 +88,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VcWebhook.ps1
+++ b/VenafiPS/Public/New-VcWebhook.ps1
@@ -127,7 +127,6 @@ function New-VcWebhook {
     process {
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Post'
             UriRoot       = 'v1'
             UriLeaf       = 'connectors'

--- a/VenafiPS/Public/New-VcWebhook.ps1
+++ b/VenafiPS/Public/New-VcWebhook.ps1
@@ -100,6 +100,7 @@ function New-VcWebhook {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcCapiApplication.ps1
+++ b/VenafiPS/Public/New-VdcCapiApplication.ps1
@@ -197,6 +197,7 @@ function New-VdcCapiApplication {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcCertificate.ps1
+++ b/VenafiPS/Public/New-VdcCertificate.ps1
@@ -205,6 +205,7 @@ function New-VdcCertificate {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcCustomField.ps1
+++ b/VenafiPS/Public/New-VdcCustomField.ps1
@@ -165,6 +165,7 @@ function New-VdcCustomField {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcDevice.ps1
+++ b/VenafiPS/Public/New-VdcDevice.ps1
@@ -103,6 +103,7 @@ function New-VdcDevice {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcObject.ps1
+++ b/VenafiPS/Public/New-VdcObject.ps1
@@ -103,6 +103,7 @@ function New-VdcObject {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcPolicy.ps1
+++ b/VenafiPS/Public/New-VdcPolicy.ps1
@@ -137,6 +137,7 @@ function New-VdcPolicy {
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/New-VdcTeam.ps1
+++ b/VenafiPS/Public/New-VdcTeam.ps1
@@ -101,6 +101,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Read-VdcLog.ps1
+++ b/VenafiPS/Public/Read-VdcLog.ps1
@@ -130,6 +130,7 @@ function Read-VdcLog {
         [int] $First,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Read-VdcLog.ps1
+++ b/VenafiPS/Public/Read-VdcLog.ps1
@@ -139,7 +139,6 @@ function Read-VdcLog {
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Get'
             UriLeaf       = 'Log/'
             Body          = @{ }

--- a/VenafiPS/Public/Remove-VcApplication.ps1
+++ b/VenafiPS/Public/Remove-VcApplication.ps1
@@ -1,4 +1,4 @@
-function Remove-VcApplication {
+﻿function Remove-VcApplication {
     <#
     .SYNOPSIS
     Remove a application
@@ -56,6 +56,6 @@ function Remove-VcApplication {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriRoot 'outagedetection/v1' -UriLeaf "applications/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcApplication.ps1
+++ b/VenafiPS/Public/Remove-VcApplication.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcApplication {
+function Remove-VcApplication {
     <#
     .SYNOPSIS
     Remove a application
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VcCertificate.ps1
@@ -43,6 +43,7 @@
         [string] $ID,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcConnector.ps1
+++ b/VenafiPS/Public/Remove-VcConnector.ps1
@@ -43,6 +43,7 @@
         [string] $ID,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
+++ b/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcIssuingTemplate {
+function Remove-VcIssuingTemplate {
     <#
     .SYNOPSIS
     Remove a issuing template
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
+++ b/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
@@ -1,4 +1,4 @@
-function Remove-VcIssuingTemplate {
+﻿function Remove-VcIssuingTemplate {
     <#
     .SYNOPSIS
     Remove a issuing template
@@ -56,6 +56,6 @@ function Remove-VcIssuingTemplate {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "certificateissuingtemplates/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcMachine.ps1
+++ b/VenafiPS/Public/Remove-VcMachine.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcMachine {
+function Remove-VcMachine {
     <#
     .SYNOPSIS
     Remove a machine
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcMachine.ps1
+++ b/VenafiPS/Public/Remove-VcMachine.ps1
@@ -1,4 +1,4 @@
-function Remove-VcMachine {
+﻿function Remove-VcMachine {
     <#
     .SYNOPSIS
     Remove a machine
@@ -56,6 +56,6 @@ function Remove-VcMachine {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "machines/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Remove-VcMachineIdentity.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcMachineIdentity {
+function Remove-VcMachineIdentity {
     <#
     .SYNOPSIS
     Remove a machine identity
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Remove-VcMachineIdentity.ps1
@@ -1,4 +1,4 @@
-function Remove-VcMachineIdentity {
+﻿function Remove-VcMachineIdentity {
     <#
     .SYNOPSIS
     Remove a machine identity
@@ -56,6 +56,6 @@ function Remove-VcMachineIdentity {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "machineidentities/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcSatelliteWorker.ps1
+++ b/VenafiPS/Public/Remove-VcSatelliteWorker.ps1
@@ -42,6 +42,7 @@ function Remove-VcSatelliteWorker {
         [guid] $ID,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcTag.ps1
+++ b/VenafiPS/Public/Remove-VcTag.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcTag {
+function Remove-VcTag {
     <#
     .SYNOPSIS
     Remove a tag
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcTag.ps1
+++ b/VenafiPS/Public/Remove-VcTag.ps1
@@ -1,4 +1,4 @@
-function Remove-VcTag {
+﻿function Remove-VcTag {
     <#
     .SYNOPSIS
     Remove a tag
@@ -56,6 +56,6 @@ function Remove-VcTag {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "tags/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcTeam.ps1
+++ b/VenafiPS/Public/Remove-VcTeam.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcTeam {
+function Remove-VcTeam {
     <#
     .SYNOPSIS
     Remove a team
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcTeam.ps1
+++ b/VenafiPS/Public/Remove-VcTeam.ps1
@@ -1,4 +1,4 @@
-function Remove-VcTeam {
+﻿function Remove-VcTeam {
     <#
     .SYNOPSIS
     Remove a team
@@ -56,6 +56,6 @@ function Remove-VcTeam {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "teams/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VcTeamMember.ps1
@@ -47,6 +47,7 @@
         [string[]] $Member,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VcTeamOwner.ps1
@@ -47,6 +47,7 @@
         [string[]] $Owner,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VcWebhook.ps1
+++ b/VenafiPS/Public/Remove-VcWebhook.ps1
@@ -1,4 +1,4 @@
-function Remove-VcWebhook {
+﻿function Remove-VcWebhook {
     <#
     .SYNOPSIS
     Remove a webhook
@@ -56,6 +56,6 @@ function Remove-VcWebhook {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "connectors/$PSItem"
-        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit
     }
 }

--- a/VenafiPS/Public/Remove-VcWebhook.ps1
+++ b/VenafiPS/Public/Remove-VcWebhook.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-VcWebhook {
+function Remove-VcWebhook {
     <#
     .SYNOPSIS
     Remove a webhook
@@ -38,6 +38,7 @@
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -101,6 +101,7 @@ function Remove-VdcCertificate {
     end {
 
         Invoke-VenafiParallel -InputObject $allCerts -ScriptBlock {
+            
             $guid = $PSItem | ConvertTo-VdcGuid -ErrorAction SilentlyContinue
             if ( -not $guid ) {
                 Write-Error "'$PSItem' is not a valid path"
@@ -115,6 +116,6 @@ function Remove-VdcCertificate {
             }
 
             $null = Invoke-VenafiRestMethod -Method Delete -UriLeaf "Certificates/$guid"
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Deleting certificates' -VenafiSession $VenafiSession
+        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Deleting certificates'
     }
 }

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -80,6 +80,7 @@ function Remove-VdcCertificate {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcCertificateAssociation.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificateAssociation.ps1
@@ -90,6 +90,7 @@ function Remove-VdcCertificateAssociation {
         [switch] $All,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcClient.ps1
+++ b/VenafiPS/Public/Remove-VdcClient.ps1
@@ -58,6 +58,7 @@ function Remove-VdcClient {
         [switch] $RemoveAssociatedDevice,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcEngineFolder.ps1
+++ b/VenafiPS/Public/Remove-VdcEngineFolder.ps1
@@ -72,6 +72,7 @@ function Remove-VdcEngineFolder {
         [String[]] $EnginePath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcObject.ps1
+++ b/VenafiPS/Public/Remove-VdcObject.ps1
@@ -74,6 +74,7 @@ function Remove-VdcObject {
         [int32] $ThrottleLimit = 100,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcPermission.ps1
+++ b/VenafiPS/Public/Remove-VdcPermission.ps1
@@ -77,6 +77,7 @@ function Remove-VdcPermission {
         [string[]] $IdentityId,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcTeam.ps1
+++ b/VenafiPS/Public/Remove-VdcTeam.ps1
@@ -37,6 +37,7 @@
         [string] $ID,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcTeamMember.ps1
+++ b/VenafiPS/Public/Remove-VdcTeamMember.ps1
@@ -48,6 +48,7 @@
         [string[]] $Member,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Remove-VdcTeamOwner.ps1
+++ b/VenafiPS/Public/Remove-VdcTeamOwner.ps1
@@ -43,6 +43,7 @@
         [string[]] $Owner,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Rename-VdcObject.ps1
+++ b/VenafiPS/Public/Rename-VdcObject.ps1
@@ -63,6 +63,7 @@ function Rename-VdcObject {
         [String] $NewPath,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Revoke-VdcGrant.ps1
+++ b/VenafiPS/Public/Revoke-VdcGrant.ps1
@@ -42,7 +42,7 @@ function Revoke-VdcGrant {
     https://github.com/Venafi/VenafiPS/blob/main/VenafiPS/Public/Revoke-VdcGrant.ps1
 
     .LINK
-    https://doc.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-oauth-revokegrants.htm
+    https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-oauth-revokegrants.php
 
     #>
 

--- a/VenafiPS/Public/Revoke-VdcToken.ps1
+++ b/VenafiPS/Public/Revoke-VdcToken.ps1
@@ -103,7 +103,7 @@ function Revoke-VdcToken {
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession = $script:VenafiSession
+        [psobject] $VenafiSession
     )
 
     begin {
@@ -120,8 +120,8 @@ function Revoke-VdcToken {
 
         switch ($PsCmdlet.ParameterSetName) {
             'Session' {
-                $params.VenafiSession = $VenafiSession
-                $target = $VenafiSession.Server
+                $params.VenafiSession = (Get-VenafiSession)
+                $target = $params.VenafiSession.Server
             }
 
             'AccessToken' {

--- a/VenafiPS/Public/Revoke-VdcToken.ps1
+++ b/VenafiPS/Public/Revoke-VdcToken.ps1
@@ -102,6 +102,7 @@ function Revoke-VdcToken {
         [switch] $Force,
 
         [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession = $script:VenafiSession
     )
 

--- a/VenafiPS/Public/Set-VcApplication.ps1
+++ b/VenafiPS/Public/Set-VcApplication.ps1
@@ -81,6 +81,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key')]
         [psobject] $VenafiSession
     )

--- a/VenafiPS/Public/Set-VcCertificate.ps1
+++ b/VenafiPS/Public/Set-VcCertificate.ps1
@@ -97,6 +97,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key')]
         [psobject] $VenafiSession
     )

--- a/VenafiPS/Public/Set-VcCertificateRequest.ps1
+++ b/VenafiPS/Public/Set-VcCertificateRequest.ps1
@@ -90,6 +90,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key')]
         [psobject] $VenafiSession
     )

--- a/VenafiPS/Public/Set-VcConnector.ps1
+++ b/VenafiPS/Public/Set-VcConnector.ps1
@@ -87,6 +87,7 @@
         [switch] $Disable,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Set-VcTeam.ps1
+++ b/VenafiPS/Public/Set-VcTeam.ps1
@@ -114,6 +114,7 @@
         [switch] $PassThru,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [Alias('Key')]
         [psobject] $VenafiSession
     )

--- a/VenafiPS/Public/Set-VcTeam.ps1
+++ b/VenafiPS/Public/Set-VcTeam.ps1
@@ -123,7 +123,6 @@
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         $params = @{
-            VenafiSession = $VenafiSession
             Method        = 'Patch'
             Body          = @{}
         }

--- a/VenafiPS/Public/Set-VdcAttribute.ps1
+++ b/VenafiPS/Public/Set-VdcAttribute.ps1
@@ -132,6 +132,7 @@ function Set-VdcAttribute {
         [switch] $NoOverwrite,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Set-VdcAttribute.ps1
+++ b/VenafiPS/Public/Set-VdcAttribute.ps1
@@ -13,6 +13,7 @@ function Set-VdcAttribute {
     .PARAMETER Attribute
     Hashtable with names and values to be set.
     If setting a custom field, you can use either the name or guid as the key.
+    If using a custom field name, you must have created a session with New-VenafiSession and not just a TLSPDC token.
     To clear a value overwriting policy, set the value to $null.
 
     .PARAMETER Class
@@ -71,6 +72,16 @@ function Set-VdcAttribute {
     Set-VdcAttribute -Path '\VED\Policy\My Folder' -Class 'X509 Certificate' -Attribute @{'Notification Disabled'='0'} -Lock
 
     Set a policy attribute and lock the value
+
+    .EXAMPLE
+    Set-VdcAttribute -Path '\VED\Policy\app.company.com' -Attribute @{'X509 SubjectAltName IPAddress'='1.2.3.4'; 'X509 SubjectAltName DNS'='me.x.com'}
+
+    Update SAN field(s).  The SAN key names are:
+    - X509 SubjectAltName DNS
+    - X509 SubjectAltName IPAddress
+    - X509 SubjectAltName OtherName UPN
+    - X509 SubjectAltName RFC822
+    - X509 SubjectAltName URI
 
     .LINK
     http://VenafiPS.readthedocs.io/en/latest/functions/Set-VdcAttribute/

--- a/VenafiPS/Public/Set-VdcAttribute.ps1
+++ b/VenafiPS/Public/Set-VdcAttribute.ps1
@@ -140,8 +140,7 @@ function Set-VdcAttribute {
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         $params = @{
-
-            Method        = 'Post'
+            Method = 'Post'
         }
 
         $baseFields = @()
@@ -168,8 +167,8 @@ function Set-VdcAttribute {
             $customFieldError = $null
 
             $customField = $VenafiSessionNested.CustomField | Where-Object { $_.Label -eq $thisKey -or $_.Guid -eq $thisKey }
-            Write-Verbose ('found custom field {0} - {1}' -f $customField.DN, $customField|ConvertTo-Json)
             if ( $customField ) {
+                Write-Verbose ('found custom field {0} - {1}' -f $customField.DN, $customField | ConvertTo-Json)
                 if ( -not $BypassValidation ) {
                     switch ( $customField.Type.ToString() ) {
                         '1' {

--- a/VenafiPS/Public/Set-VdcCredential.ps1
+++ b/VenafiPS/Public/Set-VdcCredential.ps1
@@ -179,6 +179,7 @@ function Set-VdcCredential {
         [hashtable] $Value,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Set-VdcPermission.ps1
+++ b/VenafiPS/Public/Set-VdcPermission.ps1
@@ -228,6 +228,7 @@
         [switch] $Force,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Set-VdcWorkflowTicketStatus.ps1
+++ b/VenafiPS/Public/Set-VdcWorkflowTicketStatus.ps1
@@ -78,6 +78,7 @@ function Set-VdcWorkflowTicketStatus {
         [DateTime] $ScheduledStop,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Test-VdcIdentity.ps1
+++ b/VenafiPS/Public/Test-VdcIdentity.ps1
@@ -65,6 +65,7 @@ function Test-VdcIdentity {
         [Switch] $ExistOnly,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Test-VdcObject.ps1
+++ b/VenafiPS/Public/Test-VdcObject.ps1
@@ -76,6 +76,7 @@ function Test-VdcObject {
         [Switch] $ExistOnly,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/Public/Test-VdcToken.ps1
+++ b/VenafiPS/Public/Test-VdcToken.ps1
@@ -156,18 +156,12 @@ function Test-VdcToken {
 
     process {
 
-        Write-Verbose ('Parameter set: {0}' -f $PSCmdlet.ParameterSetName)
+        Write-Debug ('Parameter set: {0}' -f $PSCmdlet.ParameterSetName)
 
         switch ($PsCmdlet.ParameterSetName) {
             'Session' {
-                if ( -not $VenafiSession ) {
-                    throw [System.ArgumentNullException] 'VenafiSession'
-                }
-                if ( $VenafiSession -isnot [pscustomobject] -or -not $VenafiSession.Token ) {
-                    throw [System.ArgumentException]::new('Must provide a VenafiSession object', 'VenafiSession')
-                }
 
-                $params.VenafiSession = $VenafiSession
+                $params.VenafiSession = (Get-VenafiSession)
             }
 
             'AccessToken' {

--- a/VenafiPS/Public/Test-VdcToken.ps1
+++ b/VenafiPS/Public/Test-VdcToken.ps1
@@ -136,7 +136,8 @@ function Test-VdcToken {
         [switch] $GrantDetail,
 
         [Parameter(ParameterSetName = 'Session')]
-        [psobject] $VenafiSession = $script:VenafiSession
+        [ValidateNotNullOrEmpty()]
+        [psobject] $VenafiSession
     )
 
     begin {

--- a/VenafiPS/Public/Write-VdcLog.ps1
+++ b/VenafiPS/Public/Write-VdcLog.ps1
@@ -129,6 +129,7 @@ function Write-VdcLog {
         [int] $Value2,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [psobject] $VenafiSession
     )
 

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VenafiPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '6.7.4'
+ModuleVersion = '6.8'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Add `Get-VenafiSession` to centralize session management.  For nested and/or piped functions, pull the session from the call stack.
- Add _PolicyPath_ to `Export-VdcCertificate` output and `Import-VdcCertificate -PolicyPath`.  This allows the imported certificate to be created in the same policy folder.  This could be used to synchronize across environments for example.  The addition of `Import-VdcCertificate -Force` will cause a policy path to be created if it does not already exist; policy subfolders are supported as well.
- Add `Import-VcCertificate` blocklist functionality.  Override the blocklist by default and honor the blocklist if the environment variable _VC_ENABLE_BLOCKLIST_ is set to true.
- Fix #322 
- Hide _dekEncryptedPassword_ from verbose output
- Remove _Filename_ from `Export-VdcCertificate` when outputting data and not writing to a file
