### PR TITLE
Perf updates

### DIFF
--- a/VenafiPS/Private/Find-VcObject.ps1
+++ b/VenafiPS/Private/Find-VcObject.ps1
@@ -185,7 +185,7 @@ function Find-VcObject {
 
     if ( $PSBoundParameters.ContainsKey('SavedSearchName') ) {
         # get saved search data and update payload
-        $thisSavedSearch = Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf 'savedsearches' | Select-Object -ExpandProperty savedSearchInfo | Where-Object { $_.name -eq $SavedSearchName }
+        $thisSavedSearch = Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf 'savedsearches' | Select-Object -ExpandProperty savedSearchInfo | Where-Object name -eq $SavedSearchName
         if ( $thisSavedSearch ) {
             $body.expression = $thisSavedSearch.searchDetails.expression
             $body.ordering = $thisSavedSearch.searchDetails.ordering

--- a/VenafiPS/Private/Invoke-VenafiParallel.ps1
+++ b/VenafiPS/Private/Invoke-VenafiParallel.ps1
@@ -70,91 +70,91 @@ function Invoke-VenafiParallel {
 
     )
 
-    begin {
+    if (-not $InputObject) { return }
 
-        if (-not $InputObject) { return }
-
-        # if ThreadJob module is not available, throttle to 1 so multithreading isn't used
-        if ( $PSVersionTable.PSVersion.Major -eq 5 ) {
-            if ( -not $script:ThreadJobAvailable ) {
-                $ThrottleLimit = 1
-            }
+    # if ThreadJob module is not available, throttle to 1 so multithreading isn't used
+    if ( $PSVersionTable.PSVersion.Major -eq 5 ) {
+        if ( -not $script:ThreadJobAvailable ) {
+            $ThrottleLimit = 1
         }
-
-        $VenafiSession = Get-VenafiSession
     }
 
-    process {
+    # no need for parallel processing overhead if just processing 1 item
+    if ( $InputObject.Count -eq 1 ) {
+        $ThrottleLimit = 1
+    }
+    
+    # throttle to 1 = no parallel
+    if ( $ThrottleLimit -le 1 ) {
+        # remove $using: from vars, not threaded and not supported
+        $InputObject | ForEach-Object -Process ([ScriptBlock]::Create(($ScriptBlock.ToString() -ireplace [regex]::Escape('$using:'), '$')))
+        return
+    }
+    
+    # parallel processing from here down
+
+    $VenafiSession = Get-VenafiSession
+    
+    $starterSb = {
+
+        # need to import module until https://github.com/PowerShell/PowerShell/issues/12240 is complete
+        # import via path instead of just module name to support non-standard paths, eg. development work
+
+        # ParallelImportPath is set during module import
+        Import-Module $using:script:ParallelImportPath -Force
+
+        # bring in the venafi session from the calling ps session
+        $script:VenafiSession = $using:VenafiSession
+
+        # bring in verbose preference from calling ps session
+        $VerbosePreference = $using:VerbosePreference
+
+        # bring in debug preference from calling ps session
+        $DebugPreference = $using:DebugPreference
     }
 
-    end {
 
-        if (-not $InputObject) { return }
+    if ( $PSVersionTable.PSVersion.Major -eq 5 ) {
+        # Start-ThreadJob does not have any child jobs for some reason so there will be no progress and just exist
+        $sb = ([ScriptBlock]::Create($starterSb.ToString() + '$using:InputObject | % { ' + $ScriptBlock.ToString() + '}'))
+        return Start-ThreadJob -ScriptBlock $sb -ThrottleLimit $ThrottleLimit | Receive-Job -Wait -AutoRemoveJob
+    }
+    else {
+        # PS7
+        $sb = ([ScriptBlock]::Create($starterSb.ToString() + $ScriptBlock.ToString()))
 
-        # throttle to 1 = no parallel
-        if ( $ThrottleLimit -le 1 ) {
-            # remove $using: from vars, not threaded and not supported
-            $InputObject | ForEach-Object -Process ([ScriptBlock]::Create(($ScriptBlock.ToString() -ireplace [regex]::Escape('$using:'), '$')))
-            return
-        }
-
-        # parallel processing from here down
-        $starterSb = {
-
-            # need to import module until https://github.com/PowerShell/PowerShell/issues/12240 is complete
-            # import via path instead of just module name to support non-standard paths, eg. development work
-
-            # ParallelImportPath is set during module import
-            Import-Module $using:script:ParallelImportPath -Force
-
-            # bring in the venafi session from the calling ps session
-            $script:VenafiSession = $using:VenafiSession
-
-            # bring in verbose preference from calling ps session
-            $VerbosePreference = $using:VerbosePreference
-
-            # bring in debug preference from calling ps session
-            $DebugPreference = $using:DebugPreference
-        }
-
-
-        if ( $PSVersionTable.PSVersion.Major -eq 5 ) {
-            # Start-ThreadJob does not have any child jobs for some reason so there will be no progress and just exist
-            $sb = ([ScriptBlock]::Create($starterSb.ToString() + '$using:InputObject | % { ' + $ScriptBlock.ToString() + '}'))
-            return Start-ThreadJob -ScriptBlock $sb -ThrottleLimit $ThrottleLimit | Receive-Job -Wait -AutoRemoveJob
+        if ( $ProgressPreference -ne 'Continue' ) {
+            # no progress, arguably faster
+            return $InputObject | Foreach-Object -AsJob -ThrottleLimit $ThrottleLimit -Parallel $sb | Receive-Job -Wait -AutoRemoveJob
         }
         else {
-            $sb = ([ScriptBlock]::Create($starterSb.ToString() + $ScriptBlock.ToString()))
 
-            # no progress, arguably faster
-            if ( $ProgressPreference -ne 'Continue' ) {
-                return $InputObject | Foreach-Object -AsJob -ThrottleLimit $ThrottleLimit -Parallel $sb | Receive-Job -Wait -AutoRemoveJob
+            Write-Progress -Activity $ProgressTitle -Status "Initializing..."
+        
+            $job = $InputObject | Foreach-Object -AsJob -ThrottleLimit $ThrottleLimit -Parallel $sb
+        
+            if ( -not $job.ChildJobs ) {
+                return
             }
+        
+            $childJobs = $job.ChildJobs
+            $childJobsCount = $childJobs.Count
+        
+            do {
+                Start-Sleep -Milliseconds 100
+        
+                $completedJobs = $childJobs | Where-Object State -in 'Completed', 'Failed', 'Stopped'
+        
+                # get latest job info
+                $job | Receive-Job
+        
+                [int] $percent = ($completedJobs.Count / $childJobsCount) * 100
+                Write-Progress -Activity $ProgressTitle -Status "$percent% complete" -PercentComplete $percent
+        
+            } while ($completedJobs.Count -lt $childJobsCount)
+        
+            Write-Progress -Completed -Activity 'done'
         }
-
-        Write-Progress -Activity $ProgressTitle -Status "Initializing..."
-
-        $job = $InputObject | Foreach-Object -AsJob -ThrottleLimit $ThrottleLimit -Parallel $sb
-
-        if ( -not $job.ChildJobs ) {
-            return
-        }
-
-        do {
-
-            # let threads run
-            Start-Sleep -Seconds 0.1
-
-            $completedJobsCount = $job.ChildJobs.Where({ $_.State -notin 'NotStarted', 'Running' }).Count
-
-            # get latest job info
-            $job | Receive-Job
-
-            [int] $percent = ($completedJobsCount / $job.ChildJobs.Count) * 100
-            Write-Progress -Activity $ProgressTitle -Status "$percent% complete" -PercentComplete $percent
-
-        } while ($completedJobsCount -lt $job.ChildJobs.Count)
-
-        Write-Progress -Completed -Activity 'done'
     }
+
 }

--- a/VenafiPS/Public/ConvertTo-VdcGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcGuid.ps1
@@ -53,6 +53,7 @@ function ConvertTo-VdcGuid {
     )
 
     begin {
+        Write-Warning 'ConvertTo-VdcGuid to be deprecated.  Use Get-VdcObject instead.'
         Test-VenafiSession $PSCmdlet.MyInvocation
 
         $params = @{

--- a/VenafiPS/Public/ConvertTo-VdcPath.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcPath.ps1
@@ -43,6 +43,7 @@ function ConvertTo-VdcPath {
     )
 
     begin {
+        Write-Warning 'ConvertTo-VdcPath to be deprecated.  Use Get-VdcObject instead.'
 
         Test-VenafiSession $PSCmdlet.MyInvocation
 

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -299,7 +299,7 @@ function Find-VcCertificate {
         'e' = {
             if ( $ApplicationDetail ) {
                 foreach ($thisAppId in $_.applicationIds) {
-                    $thisApp = $apps | Where-Object { $_.applicationId -eq $thisAppId }
+                    $thisApp = $apps | Where-Object applicationId -eq $thisAppId
                     if ( -not $thisApp ) {
                         $thisApp = Get-VcApplication -ID $thisAppId | Select-Object -Property * -ExcludeProperty ownerIdsAndTypes, ownership
                         $apps.Add($thisApp)
@@ -319,7 +319,7 @@ function Find-VcCertificate {
 
                 # this scriptblock requires ?ownershipTree=true be part of the url
                 foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {
-                    $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                    $thisOwnerDetail = $appOwners | Where-Object id -eq $thisOwner
                     if ( -not $thisOwnerDetail ) {
                         $thisOwnerDetail = Get-VcIdentity -ID $thisOwner | Select-Object firstName, lastName, emailAddress,
                         @{
@@ -346,7 +346,7 @@ function Find-VcCertificate {
                 }
 
                 foreach ($thisOwner in $_.ownership.owningContainers.owningTeams) {
-                    $thisOwnerDetail = $appOwners | Where-Object { $_.id -eq $thisOwner }
+                    $thisOwnerDetail = $appOwners | Where-Object id -eq $thisOwner
                     if ( -not $thisOwnerDetail ) {
                         $thisOwnerDetail = Get-VcTeam -ID $thisOwner | Select-Object name, role, members,
                         @{

--- a/VenafiPS/Public/Find-VdcCertificate.ps1
+++ b/VenafiPS/Public/Find-VdcCertificate.ps1
@@ -98,6 +98,9 @@ function Find-VdcCertificate {
     .PARAMETER IsWildcard
     Only include wilcard certificates
 
+    .PARAMETER IsExpired
+    Only include expired certificates
+
     .PARAMETER NetworkValidationEnabled
     Only include certificates with network validation enabled or disabled.
 
@@ -155,7 +158,12 @@ function Find-VdcCertificate {
     Find first 1000 certificates
 
     .EXAMPLE
-    Find-VdcCertificate -ExpireBefore [datetime]'2018-01-01'
+    Find-VdcCertificate -IsExpired
+
+    Find expired certificates
+
+    .EXAMPLE
+    Find-VdcCertificate -ExpireBefore '2018-01-01'
 
     Find certificates expiring before a certain date
 
@@ -331,6 +339,9 @@ function Find-VdcCertificate {
         [switch] $IsWildcard,
 
         [Parameter()]
+        [switch] $IsExpired,
+
+        [Parameter()]
         [bool] $NetworkValidationEnabled,
 
         [Parameter()]
@@ -410,167 +421,129 @@ function Find-VdcCertificate {
         switch ($PSBoundParameters.Keys) {
             'CreatedDate' {
                 $params.Body.Add( 'CreatedOn', ($CreatedDate | ConvertTo-UtcIso8601) )
-                break
             }
             'CreatedBefore' {
                 $params.Body.Add( 'CreatedOnLess', ($CreatedBefore | ConvertTo-UtcIso8601) )
-                break
             }
             'CreatedAfter' {
                 $params.Body.Add( 'CreatedOnGreater', ($CreatedAfter | ConvertTo-UtcIso8601) )
-                break
             }
             'CertificateType' {
                 $params.Body.Add( 'CertificateType', $CertificateType -join ',' )
-                break
             }
             'Country' {
                 $params.Body.Add( 'C', $Country )
-                break
             }
             'CommonName' {
                 $params.Body.Add( 'CN', $CommonName )
-                break
             }
             'Issuer' {
                 $params.Body.Add( 'Issuer', '"{0}"' -f $Issuer )
-                break
             }
             'KeyAlgorithm' {
                 $params.Body.Add( 'KeyAlgorithm', $KeyAlgorithm -join ',' )
-                break
             }
             'KeySize' {
                 $params.Body.Add( 'KeySize', $KeySize -join ',' )
-                break
             }
             'KeySizeGreaterThan' {
                 $params.Body.Add( 'KeySizeGreater', $KeySizeGreaterThan )
-                break
             }
             'KeySizeLessThan' {
                 $params.Body.Add( 'KeySizeLess', $KeySizeLessThan )
-                break
             }
             'Locale' {
                 $params.Body.Add( 'L', $Locale -join ',' )
-                break
             }
             'Organization' {
                 $params.Body.Add( 'O', $Organization -join ',' )
-                break
             }
             'OrganizationUnit' {
                 $params.Body.Add( 'OU', $OrganizationUnit -join ',' )
-                break
             }
             'State' {
                 $params.Body.Add( 'S', $State -join ',' )
-                break
             }
             'SanDns' {
                 $params.Body.Add( 'SAN-DNS', $SanDns )
-                break
             }
             'SanEmail' {
                 $params.Body.Add( 'SAN-Email', $SanEmail )
-                break
             }
             'SanIP' {
                 $params.Body.Add( 'SAN-IP', $SanIP )
-                break
             }
             'SanUpn' {
                 $params.Body.Add( 'SAN-UPN', $SanUpn )
-                break
             }
             'SanUri' {
                 $params.Body.Add( 'SAN-URI', $SanUri )
-                break
             }
             'SerialNumber' {
                 $params.Body.Add( 'Serial', $SerialNumber )
-                break
             }
             'SignatureAlgorithm' {
                 $params.Body.Add( 'SignatureAlgorithm', $SignatureAlgorithm -join ',' )
-                break
             }
             'Thumbprint' {
                 $params.Body.Add( 'Thumbprint', $Thumbprint )
-                break
             }
             'IssueDateAfter' {
                 $params.Body.Add( 'ValidFromGreater', ($IssueDateAfter | ConvertTo-UtcIso8601) )
-                break
             }
             'IssueDateBefore' {
                 $params.Body.Add( 'ValidFromLess', ($IssueDateBefore | ConvertTo-UtcIso8601) )
-                break
             }
             'IssueDate' {
                 $params.Body.Add( 'ValidFrom', ($IssueDate | ConvertTo-UtcIso8601) )
-                break
             }
             'ExpireDate' {
                 $params.Body.Add( 'ValidTo', ($ExpireDate | ConvertTo-UtcIso8601) )
-                break
             }
             'ExpireAfter' {
                 $params.Body.Add( 'ValidToGreater', ($ExpireAfter | ConvertTo-UtcIso8601) )
-                break
             }
             'ExpireBefore' {
                 $params.Body.Add( 'ValidToLess', ($ExpireBefore | ConvertTo-UtcIso8601) )
-                break
             }
             'Enabled' {
                 $params.Body.Add( 'Disabled', [int] (-not $Enabled) )
-                break
             }
             'InError' {
                 $params.Body.Add( 'InError', [int]$InError.IsPresent )
-                break
             }
             'IsSelfSigned' {
                 $params.Body.Add( 'IsSelfSigned', [int] $IsSelfSigned.IsPresent )
-                break
             }
             'IsWildcard' {
                 $params.Body.Add( 'IsWildcard', [int] $IsWildcard.IsPresent )
-                break
+            }
+            'IsExpired' {
+                $params.Body.Add( 'ValidToLess', ((Get-Date) | ConvertTo-UtcIso8601) )
             }
             'NetworkValidationEnabled' {
                 $params.Body.Add( 'NetworkValidationDisabled', [int] (-not $NetworkValidationEnabled) )
-                break
             }
             'ManagementType' {
                 $params.Body.Add( 'ManagementType', $ManagementType -join ',' )
-                break
             }
             'PendingWorkflow' {
                 $params.Body.Add( 'PendingWorkflow', '')
-                break
             }
             'Stage' {
                 $params.Body.Add( 'Stage', ($Stage | ForEach-Object { [TppCertificateStage]::$_.value__ }) -join ',' )
-                break
             }
             'StageGreaterThan' {
                 $params.Body.Add( 'StageGreater', [TppCertificateStage]::$StageGreaterThan.value__ )
-                break
             }
             'StageLessThan' {
                 $params.Body.Add( 'StageLess', [TppCertificateStage]::$StageLessThan.value__ )
-                break
             }
             'ValidationEnabled' {
                 $params.Body.Add( 'ValidationDisabled', [int] (-not $ValidationEnabled) )
-                break
             }
             'ValidationState' {
                 $params.Body.Add( 'ValidationState', $ValidationState -join ',' )
-                break
             }
         }
     }
@@ -582,7 +555,12 @@ function Find-VdcCertificate {
         }
         elseif ( $PSBoundParameters.ContainsKey('Guid') ) {
             # guid provided, get path
-            $thisPath = $Guid | ConvertTo-VdcPath
+            $pathObject = ConvertTo-VdcObject -Guid $Guid
+            if ( $pathObject.TypeName -ne 'Policy' ) {
+                throw [System.Management.Automation.PSArgumentOutOfRangeException]::new('Guid', $pathObject.TypeName, 'Must be a Policy')
+                return
+            }
+            $thisPath = $pathObject.Path
         }
 
         if ( $thisPath ) {

--- a/VenafiPS/Public/Get-VcTeam.ps1
+++ b/VenafiPS/Public/Get-VcTeam.ps1
@@ -80,7 +80,7 @@
             }
             else {
                 # assume team name
-                $response = Invoke-VenafiRestMethod -UriLeaf 'teams' | Where-Object { $_.name -eq $Team }
+                $response = Invoke-VenafiRestMethod -UriLeaf 'teams' | Where-Object name -eq $Team
             }
         }
 

--- a/VenafiPS/Public/Get-VdcCertificate.ps1
+++ b/VenafiPS/Public/Get-VdcCertificate.ps1
@@ -128,7 +128,7 @@
 
             if ( $PSItem -like '\ved*' ) {
                 # a path was provided, get the guid
-                $thisGuid = ConvertTo-VdcGuid -Path $PSItem
+                $thisGuid = (ConvertTo-VdcObject -Path $PSItem).Guid
             } else {
                 $thisGuid = ([guid] $PSItem).ToString()
             }

--- a/VenafiPS/Public/Get-VdcObject.ps1
+++ b/VenafiPS/Public/Get-VdcObject.ps1
@@ -4,7 +4,7 @@ function Get-VdcObject {
     Get object information
 
     .DESCRIPTION
-    Return object information by either path or guid.  This will return a TppObject which can be used with many other functions.
+    Return object information by either path or guid.  This will return a standard object which can be used with many other functions.
 
     .PARAMETER Path
     The full path to the object.

--- a/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
@@ -6,14 +6,8 @@ function Get-VdcWorkflowTicket {
     .DESCRIPTION
     Get details about workflow tickets associated with a certificate.
 
-    .PARAMETER InputObject
-    TppObject which represents a certificate object
-
     .PARAMETER Path
     Path to the certificate
-
-    .PARAMETER Guid
-    Certificate guid
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -22,7 +16,7 @@ function Get-VdcWorkflowTicket {
     If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
-    InputObject, Path, or Guid
+    Path
 
     .OUTPUTS
     PSCustomObject with the following properties:

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -264,7 +264,13 @@ function Invoke-VenafiRestMethod {
     $ProgressPreference = 'SilentlyContinue'
 
     try {
-        $verboseOutput = $($response = Invoke-WebRequest @params -ErrorAction Stop) 4>&1
+        if ( $FullResponse ) {
+            $response = Invoke-WebRequest @params -ErrorAction Stop
+        }
+        else {
+            $response = Invoke-RestMethod @params -ErrorAction Stop
+        }
+        $verboseOutput = $response 4>&1
         $verboseOutput.Message | Write-VerboseWithSecret
     }
     catch {
@@ -331,17 +337,5 @@ function Invoke-VenafiRestMethod {
         $ProgressPreference = $oldProgressPreference
     }
 
-    if ( $FullResponse ) {
-        $response
-    }
-    else {
-        if ( $response.Content ) {
-            try {
-                $response.Content | ConvertFrom-Json
-            }
-            catch {
-                throw ('Invalid JSON response {0}' -f $response.Content)
-            }
-        }
-    }
+    $response
 }

--- a/VenafiPS/Public/Remove-VcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VcCertificate.ps1
@@ -53,23 +53,12 @@
     }
 
     process {
-        if ( $PSCmdlet.ShouldProcess($ID, "Delete certificate") ) {
-            $allObjects.Add($ID)
-        }
+        $allObjects.Add($ID)
     }
 
     end {
-
-        # handle certs differently since you send them all in 1 call
-        # and parallel functionality not needed
-        $params = @{
-            Method  = 'Post'
-            UriRoot = 'outagedetection/v1'
-            UriLeaf = 'certificates/deletion'
-            Body    = @{
-                certificateIds = $allObjects
-            }
-        }
-        $null = Invoke-VenafiRestMethod @params
+        # this function is just a placeholder for a standard named function
+        # all the logic is in Invoke-VcCertificateAction
+        $allObjects | Invoke-VcCertificateAction -Delete -Confirm:$ConfirmPreference
     }
 }

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -102,7 +102,7 @@ function Remove-VdcCertificate {
 
         Invoke-VenafiParallel -InputObject $allCerts -ScriptBlock {
             
-            $guid = $PSItem | ConvertTo-VdcGuid -ErrorAction SilentlyContinue
+            $guid = $PSItem | ConvertTo-VdcObject -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Guid
             if ( -not $guid ) {
                 Write-Error "'$PSItem' is not a valid path"
                 return

--- a/VenafiPS/Public/Remove-VdcPermission.ps1
+++ b/VenafiPS/Public/Remove-VdcPermission.ps1
@@ -102,7 +102,7 @@ function Remove-VdcPermission {
 
         foreach ($thisInputObject in $inputObject) {
             if ( $PSCmdLet.ParameterSetName -eq 'ByPath' ) {
-                $thisGuid = $thisInputObject | ConvertTo-VdcGuid
+                $thisGuid = $thisInputObject | ConvertTo-VdcObject | Select-Object -ExpandProperty Guid
             } else {
                 $thisGuid = $thisInputObject
             }

--- a/VenafiPS/Public/Set-VdcPermission.ps1
+++ b/VenafiPS/Public/Set-VdcPermission.ps1
@@ -249,7 +249,7 @@
         }
 
         if ( $Path ) {
-            $thisGuid = $Path | ConvertTo-VdcGuid
+            $thisGuid = $Path | ConvertTo-VdcObject | Select-Object -ExpandProperty Guid
         }
         else {
             $thisGuid = $Guid


### PR DESCRIPTION
- Add `New-VenafiSession -RefreshSession` to retrieve a new access token from the current session refresh token
- Add `Find-VdcCertificate -IsExpired`
- Performance updates to `Invoke-VenafiRestMethod`, `Invoke-VenafiParallel`, and more
- Centralizing VDC object creation with `Get-VdcObject`.  Deprecating `ConvertTo-VdcPath` and `ConvertTo-VdcGuid`. 