### PR TITLE
329 export vdccertificate producing wrong file type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,1 @@
-- Add `New-VenafiSession -RefreshSession` to retrieve a new access token from the current session refresh token
-- Add `Find-VdcCertificate -IsExpired` for an easy way to find expired certificates on TLSPDC
-- Standardized VDC object creation/conversion with `Get-VdcObject`.  `ConvertTo-VdcPath` and `ConvertTo-VdcGuid` to be deprecated.
-- Add unit test for function help and resolve the issues
-- Update `Find-VdcVaultId` to retrieve via object path
-- Update `Find-VdcVaultId` to output via pipeline by default.  Providing `-OutPath` will remain unchanged.
-- New pipeline options from `Find-VdcVaultId` and `Get-VdcCertificate -IncludePreviousVersions` to `Export-VdcVaultObject`, the latter will export all historical certificates
-- Add `Export-VdcCertificate -VaultId` for exporting any certificate via vault id.  If exporting historical certificates and would like the associated key, this is the preferred approach.
-- Add `Find-VdcObject -Class` when using `-Attribute -Pattern` to filter attribute searches by a specific class/type
-- Fix error in `New-VcConnector` causing manifest import to fail
-- Performance updates to Invoke-VenafiRestMethod, Invoke-VenafiParallel, and more
-- `Search-VdcHistory` to be deprecated.
+- Fix [#329](https://github.com/Venafi/VenafiPS/issues/329), parameter set name unavailable

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -353,6 +353,7 @@ function Export-VdcCertificate {
                 'e' = {
                     # standardize the format for pkcs8 and pkcs12 across tlspdc and tlspc
                     switch ($thisBody.Format) {
+                        'Base64' { 'X509' }
                         'Base64 (PKCS#8)' { 'PKCS8' }
                         'PKCS #12' { 'PKCS12' }
                         Default { $_ }

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -245,31 +245,26 @@ function Export-VdcCertificate {
         $allCerts = [System.Collections.Generic.List[hashtable]]::new()
 
         $body = @{ Format = 'Base64' }
-        switch ($PSCmdlet.ParameterSetName) {
+        switch ($PSBoundParameters.Keys) {
             'Pkcs7' { $body.Format = 'PKCS #7' }
             'Pkcs8' { $body.Format = 'Base64 (PKCS#8)' }
             'Pkcs12' { $body.Format = 'PKCS #12' }
             'Der' { $body.Format = 'DER' }
             'Jks' { $body.Format = 'JKS' }
-        }
-
-        $body.IncludePrivateKey = $PSBoundParameters.ContainsKey('PrivateKeyPassword')
-
-        if ( $body.IncludePrivateKey ) {
-            $body.Password = $PrivateKeyPassword | ConvertTo-PlaintextString
-        }
-
-        if ( $PSBoundParameters.ContainsKey('KeystorePassword') ) {
-            $body.Format = 'JKS'
-            $body.KeystorePassword = $KeystorePassword | ConvertTo-PlaintextString
-        }
-
-        if ( $PSBoundParameters.ContainsKey('FriendlyName') ) {
-            $body.FriendlyName = $FriendlyName
-        }
-
-        if ($IncludeChain) {
-            $body.IncludeChain = $true
+            'PrivateKeyPassword' {
+                $body.IncludePrivateKey = $true
+                $body.Password = $PrivateKeyPassword | ConvertTo-PlaintextString
+            }
+            'KeystorePassword' {
+                $body.Format = 'JKS'
+                $body.KeystorePassword = $KeystorePassword | ConvertTo-PlaintextString
+            }
+            'FriendlyName' {
+                $body.FriendlyName = $FriendlyName
+            }
+            'IncludeChain' {
+                $body.IncludeChain = $true
+            }
         }
 
         $body | Write-VerboseWithSecret
@@ -300,7 +295,7 @@ function Export-VdcCertificate {
             $outPath = $using:OutPath
             # foreach ($thisBody in $allCerts) {
             $isByPath = $null -eq $thisBody.VaultId
-       
+
             try {
                 if ( $isByPath ) {
                     $innerResponse = Invoke-VenafiRestMethod -Method 'Post' -UriLeaf 'certificates/retrieve' -Body $thisBody
@@ -348,7 +343,7 @@ function Export-VdcCertificate {
                             'CertificateData' = $null
                         }
                     }
-    
+
                 }
             }
 


### PR DESCRIPTION
- Fix [#329](https://github.com/Venafi/VenafiPS/issues/329), parameter set name unavailable causing incorrect file type