### PR TITLE
Vc workflow api key missing

### DIFF
--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -24,8 +24,8 @@ function Find-VcCertificate {
     .PARAMETER IsExpired
     Search for only expired certificates.
     This will search for only certificates that are expired including active, retired, current, old, etc.
-    Be sure to use other parameters if you want to filter even further.
-    
+    Use -IsExpired:$false for certificates that are NOT expired.
+
     .PARAMETER Status
     Search by one or more certificate statuses.  Valid values include ACTIVE, RETIRED, and DELETED.
 
@@ -262,8 +262,13 @@ function Find-VcCertificate {
                 'Fingerprint' { $null = $newFilter.Add(@('fingerprint', 'EQ', $Fingerprint)) }
                 'IsSelfSigned' { $null = $newFilter.Add(@('selfSigned', 'EQ', $IsSelfSigned.IsPresent.ToString())) }
                 'IsExpired' {
-                    $null = $newFilter.Add(@('validityEnd', 'LTE', (Get-Date)))
-                    $params.Order = @{'validityEnd' = 'desc' }
+                    if ( $IsExpired.IsPresent ) {
+                        $null = $newFilter.Add(@('validityEnd', 'LT', (Get-Date)))
+                        $params.Order = @{'validityEnd' = 'desc' }
+                    } else {
+                        $null = $newFilter.Add(@('validityEnd', 'GTE', (Get-Date)))
+                        $params.Order = @{'validityEnd' = 'asc' }
+                    }
                 }
                 'VersionType' { $null = $newFilter.Add(@('versionType', 'MATCH', $VersionType)) }
                 'Status' {

--- a/VenafiPS/Public/Get-VcApplication.ps1
+++ b/VenafiPS/Public/Get-VcApplication.ps1
@@ -5,6 +5,7 @@ function Get-VcApplication {
 
     .DESCRIPTION
     Get 1 or more applications.
+    Application level renewal configurations are included.
 
     .PARAMETER Application
     Application ID or name
@@ -24,7 +25,11 @@ function Get-VcApplication {
     Get-VcApplication -Application 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
 
     applicationId              : 96fc9310-67ec-11eb-a8a7-794fe75a8e6f
-    certificateIssuingTemplate : @{Name=MyTemplate; id=7fb6af20-b22e-11ea-9a24-930fb5d2b247}
+    issuingTemplate            : @{Name=MyTemplate; id=7fb6af20-b22e-11ea-9a24-930fb5d2b247}
+    autoRenew                  : True
+    autoProvision              : True
+    renewalWindowInherit       : False
+    renewalWindowDays          : 15
     companyId                  : 09b24f81-b22b-11ea-91f3-ebd6dea5452e
     name                       : myapp
     description                :
@@ -101,19 +106,44 @@ function Get-VcApplication {
             }
         }
 
-        if ( $response.PSObject.Properties.Name -contains 'applications' ) {
-            $applications = $response | Select-Object -ExpandProperty applications
+        $applications = if ( $response.PSObject.Properties.Name -contains 'applications' ) {
+            $response | Select-Object -ExpandProperty applications
         }
         else {
-            $applications = $response
+            $response
         }
 
-        if ( $applications ) {
+        foreach ($app in $applications) {
+            $thisConfig = Invoke-VenafiRestMethod -UriLeaf ('autorenewal/{0}/configuration' -f $app.id)
             $applications | Select-Object @{'n' = 'applicationId'; 'e' = { $_.Id } },
             @{
                 'n' = 'issuingTemplate'
                 'e' = {
                     $_.certificateIssuingTemplateAliasIdMap.psobject.Properties | Select-Object @{'n' = 'name'; 'e' = { $_.Name } }, @{'n' = 'issuingTemplateId'; 'e' = { $_.Value } }
+                }
+            },
+            @{
+                'n' = 'autoRenew'
+                'e' = {
+                    $thisConfig.renewalActions.renew
+                }
+            },
+            @{
+                'n' = 'autoProvision'
+                'e' = {
+                    $thisConfig.renewalActions.provision
+                }
+            },
+            @{
+                'n' = 'renewalWindowInherit'
+                'e' = {
+                    $thisConfig.renewalWindow.inherit
+                }
+            },
+            @{
+                'n' = 'renewalWindowDays'
+                'e' = {
+                    $thisConfig.renewalWindow.days
                 }
             }, * -ExcludeProperty Id, certificateIssuingTemplateAliasIdMap
         }

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -105,7 +105,7 @@ function Invoke-VcWorkflow {
     end {
 
         Invoke-VenafiParallel -InputObject $allIDs -ScriptBlock {
-
+            # $allIDs | ForEach-Object {
             $thisID = $PSItem
             $workflow = $using:Workflow
             $thisWebSocketID = (New-Guid).Guid
@@ -115,15 +115,16 @@ function Invoke-VcWorkflow {
                 $WS = New-Object System.Net.WebSockets.ClientWebSocket
                 $CT = New-Object System.Threading.CancellationToken
 
-                if ( $VenafiSession -is [PSCustomObject] ) {
-                    $server = $VenafiSession.Server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession.Key.GetNetworkCredential().password)
+                if ( $script:VenafiSession -is [PSCustomObject] ) {
+                    $server = $script:VenafiSession.Server.Replace('https://', '')
+                    $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession.Key.GetNetworkCredential().password)
                 }
                 else {
                     # TODO: defaults to US, add other region support
+                    # for other regions, create a session first
                     $server = ($script:VcRegions).'us'
                     $server = $server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $VenafiSession)
+                    $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession)
                 }
                 $URL = 'wss://{0}/ws/notificationclients/{1}' -f $server, $thisWebSocketID
 
@@ -214,7 +215,8 @@ function Invoke-VcWorkflow {
                     $WS.Dispose()
                 }
             }
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Invoking workflow'
+            # } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Invoking workflow'
+        }
     }
 }
 

--- a/VenafiPS/Public/New-VcMachine.ps1
+++ b/VenafiPS/Public/New-VcMachine.ps1
@@ -200,7 +200,7 @@ function New-VcMachine {
             }
         }
 
-        $ownerId = Get-VcData -InputObject $Owner -Type 'Team'
+        $ownerId = Get-VcData -InputObject $Owner -Type 'Team' -FailOnMultiple
         if ( -not $ownerId ) {
             Write-Error "'$Owner' is not a valid team id or name"
             return


### PR DESCRIPTION
- Fix `Invoke-VcWorkflow` not properly referencing the script scope VenafiSession
- Enforce specifying only 1 team with `New-VcMachine` and other New-VcMachine variants.  When specifying the team by name, more than 1 might be returned, but only 1 can be associated with the machine.
- Add renewal configuration details to `Get-VcApplication`
- Add support for finding non expired certs with `Find-VcCertificate -IsExpired:$false`