### PR TITLE
Vc token auth, tab completion, pkix intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ Get-Command -Module VenafiPS -Name '*-Vc*' # for TLSPC functions
 
 For TLSPDC, [token based authentication](https://docs.venafi.com/Docs/current/TopNav/Content/SDK/AuthSDK/t-SDKa-Setup-OAuth.php) must be setup and configured.
 
-### Interactive Session
-
-For an interactive session, we want to create a Venafi session which will hold the details needed for future operations.  Start a new PowerShell prompt (even if you have one from the install-module step) and create a new VenafiPS session with:
+We want to create a Venafi session which will hold the details needed for future operations.  Start a new PowerShell prompt (even if you have one from the install-module step) and create a new VenafiPS session with:
 
 ```powershell
 # username/password for TLSPDC.  TLSPC uses any value for username and your api key for the password
@@ -66,10 +64,6 @@ View the help on all the ways you can create a new Venafi session with
 help New-VenafiSession -full
 ```
 To utilize the SecretManagement vault functionality, ensure you [complete the setup below](https://github.com/Venafi/VenafiPS#tokenkey-secret-storage).
-
-### Automated Scenarios
-
-For non-interactive usage including ci/cd, the module can be used without creating a session.  For all functions, you can substitute a VenafiSession object with either a TLSPDC token or TLSPC key, eg. `-VenafiSession 'e9fe8860-a4c5-427f-bece-18204b04ac85'`.  You can also provide these as environment variables, VDC_TOKEN or VC_KEY.  If providing a TLSPDC token, either as the value for -VenafiSession or as an environment variable, a server environment variable, VDC_SERVER, must also be set.
 
 ## TLSPDC Examples
 

--- a/VenafiPS/Enum/VdcVaultType.ps1
+++ b/VenafiPS/Enum/VdcVaultType.ps1
@@ -1,0 +1,46 @@
+enum VdcVaultType {
+    None = 0;
+
+    # Standard types
+    PrivateKey = 1;
+    Certificate = 2;
+    PKCS12 = 4;
+    SymmetricKey = 8;
+    State = 16;
+    Password = 32;
+    Csr = 64;
+    Blob = 128;
+    PKCS8 = 256;
+    PKCS10 = 512;
+    File = 1024;
+    RSAPublicKey = 2048;
+    PublicKey = 4096;
+    AccessGrant = 8192;
+    SshCertificate = 16384;
+
+    # Archived types (Archived overlay = 1073741824)
+    Archived = 1073741824;
+    ArchivedCertificate = 1073741826;      # Certificate + Archived
+    ArchivedPKCS12 = 1073741828;           # PKCS12 + Archived
+    ArchivedSymmetricKey = 1073741832;     # SymmetricKey + Archived
+    ArchivedState = 1073741840;            # State + Archived
+    ArchivedPassword = 1073741856;         # Password + Archived
+    ArchivedBlob = 1073741952;             # Blob + Archived
+    ArchivedPKCS8 = 1073742080;            # PKCS8 + Archived
+    ArchivedPKCS10 = 1073742336;           # PKCS10 + Archived
+    ArchivedFile = 1073742848;             # File + Archived
+    ArchivedRSAPublicKey = 1073743872;     # RSAPublicKey + Archived
+    ArchivedPublicKey = 1073745920;        # PublicKey + Archived
+    ArchivedSshCertificate = 1073758208;   # SshCertificate + Archived
+
+    # Refigram types (Refigram overlay = -2147483648)
+    Refigram = -2147483648;
+    RefigramPKCS8 = -2147483392;           # PKCS8 + Refigram
+    RefigramPublicKey = -2147479552;       # PublicKey + Refigram
+    RefigramSymmetricKey = -2147483640;    # SymmetricKey + Refigram
+
+    # Archived Refigram types
+    ArchivedRefigramPKCS8 = -1073741568;          # RefigramPKCS8 + Archived
+    ArchivedRefigramPublicKey = -1073737728;      # RefigramPublicKey + Archived
+    ArchivedRefigramSymmetricKey = -1073741816;   # RefigramSymmetricKey + Archived
+}

--- a/VenafiPS/Private/Get-VcData.ps1
+++ b/VenafiPS/Private/Get-VcData.ps1
@@ -18,7 +18,7 @@ function Get-VcData {
         [string] $InputObject,
 
         [parameter(Mandatory)]
-        [ValidateSet('Application', 'VSatellite', 'Certificate', 'IssuingTemplate', 'Team', 'Machine', 'Tag', 'Plugin', 'Credential', 'Algorithm')]
+        [ValidateSet('Application', 'VSatellite', 'Certificate', 'IssuingTemplate', 'Team', 'Machine', 'Tag', 'Plugin', 'Credential', 'Algorithm', 'User')]
         [string] $Type,
 
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Name')]
@@ -173,6 +173,24 @@ function Get-VcData {
                 break
             }
 
+            'User' {
+                if ( -not $script:vcUser ) {
+                    $script:vcUser = Get-VcUser -All | Sort-Object -Property username
+                    $latest = $true
+                }
+
+                $allObject = $script:vcUser
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.userId, $_.username }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcUser = Get-VcUser -All | Sort-Object -Property username
+                        $thisObject = $script:vcTag | Where-Object { $InputObject -in $_.userId, $_.username }
+                    }
+                }
+                break
+            }
+
             'Certificate' {
                 $thisObject = Find-VcCertificate -Name $InputObject
                 break
@@ -192,10 +210,10 @@ function Get-VcData {
                 $allObject = $script:vcTag
 
                 if ( $InputObject ) {
-                    $thisObject = $allObject | Where-Object $InputObject -eq $_.tagId
+                    $thisObject = $allObject | Where-Object tagId -eq $InputObject
                     if ( -not $thisObject -and -not $latest ) {
                         $script:vcTag = Get-VcTag -All | Sort-Object -Property tagId
-                        $thisObject = $script:vcTag | Where-Object $InputObject -eq $_.tagId
+                        $thisObject = $script:vcTag | Where-Object tagId -eq $InputObject
                     }
                 }
                 break

--- a/VenafiPS/Private/Get-VcData.ps1
+++ b/VenafiPS/Private/Get-VcData.ps1
@@ -6,7 +6,11 @@ function Get-VcData {
     #>
 
 
-    [CmdletBinding(DefaultParameterSetName = 'ID')]
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    # at some point we'll have types that overlap between products
+    # use this alias to differentiate between vc and vdc
+    [Alias('Get-VdcData')]
+
     param (
         [parameter(ValueFromPipeline, ParameterSetName = 'ID', Position = '0')]
         [parameter(ValueFromPipeline, ParameterSetName = 'Name', Position = '0')]
@@ -39,6 +43,8 @@ function Get-VcData {
 
     process {
 
+        $latest = $false
+
         # if we already have a guid and are just looking for the ID, return it
         if ( $PSCmdlet.ParameterSetName -eq 'ID' -and (Test-IsGuid($InputObject)) ) {
             return $InputObject
@@ -58,12 +64,18 @@ function Get-VcData {
             # object or first
             switch ($Type) {
                 'Application' {
-                    $allObject = Get-VcApplication -All
+                    if ( -not $script:vcApplication ) {
+                        $script:vcApplication = Get-VcApplication -All | Sort-Object -Property name
+                    }
+                    $allObject = $script:vcApplication
                     $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.applicationId }
                     break
                 }
                 'Team' {
-                    $allObject = Get-VcTeam -All | Sort-Object -Property name
+                    if ( -not $script:vcTeam ) {
+                        $script:vcTeam = Get-VcTeam -All | Sort-Object -Property name
+                    }
+                    $allObject = $script:vcTeam
                     $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.teamId }
                     break
                 }
@@ -72,26 +84,83 @@ function Get-VcData {
 
         switch ($Type) {
             'VSatellite' {
-                $allObject = Get-VcSatellite -All | Where-Object { $_.edgeStatus -eq 'ACTIVE' } | Sort-Object -Property name
-                $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.vsatelliteId }
+                if ( -not $script:vcSatellite ) {
+                    $script:vcSatellite = Get-VcSatellite -All | Sort-Object -Property name
+                    $latest = $true
+                }
+
+                $allObject = $script:vcSatellite
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.vsatelliteId }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcSatellite = Get-VcSatellite -All | Sort-Object -Property name
+                        $thisObject = $script:vcSatellite | Where-Object { $InputObject -in $_.name, $_.vsatelliteId }
+                    }
+                }
+
                 break
             }
 
             'IssuingTemplate' {
-                $allObject = Get-VcIssuingTemplate -All | Sort-Object -Property name
-                $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.issuingTemplateId }
+                if ( -not $script:vcIssuingTemplate ) {
+                    $script:vcIssuingTemplate = Get-VcIssuingTemplate -All | Sort-Object -Property name
+                    $latest = $true
+                }
+
+                $allObject = $script:vcIssuingTemplate
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.issuingTemplateId }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcIssuingTemplate = Get-VcIssuingTemplate -All | Sort-Object -Property name
+                        $thisObject = $script:vcIssuingTemplate | Where-Object { $InputObject -in $_.name, $_.issuingTemplateId }
+                    }
+                }
                 break
             }
 
-            { $_ -match 'Plugin$' } {
-                # for machine, ca, tpp, etc plugins
-                $pluginType = $_.Replace('Plugin', '').ToUpper()
-                
-                $allObject = Invoke-VenafiRestMethod -UriLeaf "plugins?pluginType=$pluginType" |
-                Select-Object -ExpandProperty plugins |
-                Select-Object -Property @{'n' = ('{0}Id' -f $Type); 'e' = { $_.Id } }, * -ExcludeProperty id
+            'Credential' {
+                if ( -not $script:vcCredential ) {
+                    $script:vcCredential = Invoke-VenafiRestMethod -UriLeaf "credentials" |
+                        Select-Object -ExpandProperty credentials |
+                        Select-Object -Property @{'n' = 'credentialId'; 'e' = { $_.Id } }, * -ExcludeProperty id
+                    $latest = $true
+                }
 
-                $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.('{0}Id' -f $Type) }
+                $allObject = $script:vcCredential
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.credentialId }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcCredential = Invoke-VenafiRestMethod -UriLeaf "credentials" |
+                            Select-Object -ExpandProperty credentials |
+                            Select-Object -Property @{'n' = 'credentialId'; 'e' = { $_.Id } }, * -ExcludeProperty id
+                        $thisObject = $script:vcCredential | Where-Object { $InputObject -in $_.name, $_.credentialId }
+                    }
+                }
+                break
+            }
+
+            'Plugin' {
+                if ( -not $script:vcPlugin ) {
+                    $script:vcPlugin = Invoke-VenafiRestMethod -UriLeaf "plugins" |
+                        Select-Object -ExpandProperty plugins |
+                        Select-Object -Property @{'n' = 'pluginId'; 'e' = { $_.Id } }, * -ExcludeProperty id
+                    $latest = $true
+                }
+
+                $allObject = $script:vcPlugin
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.name, $_.pluginId }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcPlugin = Invoke-VenafiRestMethod -UriLeaf "plugins" |
+                            Select-Object -ExpandProperty plugins |
+                            Select-Object -Property @{'n' = 'pluginId'; 'e' = { $_.Id } }, * -ExcludeProperty id
+                        $thisObject = $script:vcPlugin | Where-Object { $InputObject -in $_.name, $_.pluginId }
+                    }
+                }
                 break
             }
 
@@ -106,40 +175,41 @@ function Get-VcData {
             }
 
             'Tag' {
-                try {
-
-                    if ( $InputObject.Contains(':') ) {
-                        $tagName, $tagValue = $InputObject.Split(':')
-                    }
-                    else {
-                        $tagName = $InputObject
-                    }
-                    $tag = Invoke-VenafiRestMethod -UriLeaf "tags/$tagName" |
-                    Select-Object -Property @{'n' = 'tagId'; 'e' = { $_.Id } }, @{'n' = 'values'; 'e' = { $null } }, * -ExcludeProperty id
-
-                    if ( $tag ) {
-                        $values = Invoke-VenafiRestMethod -UriLeaf "tags/$($tag.name)/values"
-
-                        if ( $values.values ) {
-                            $tag.values = ($values.values | Select-Object id, @{'n' = 'name'; 'e' = { $_.value } })
-
-                            # make sure the value, if provided, is valid
-                            if ( $tagValue -and $tagValue -notin $tag.values.name ) {
-                                $tag = $null
-                            }
-                        }
-                        else {
-                            if ( $tagValue ) {
-                                # the tag name exists, but the value does not
-                                $tag = $null
-                            }
-                        }
-                    }
-
-                    $thisObject = $tag
+                if ( -not $script:vcTag ) {
+                    $script:vcTag = Get-VcTag -All | Sort-Object -Property tagId
+                    $latest = $true
                 }
-                catch {
-                    $thisObject = $null
+
+                $allObject = $script:vcTag
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object $InputObject -eq $_.tagId
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vcTag = Get-VcTag -All | Sort-Object -Property tagId
+                        $thisObject = $script:vcTag | Where-Object $InputObject -eq $_.tagId
+                    }
+                }
+                break
+            }
+
+            'Algorithm' {
+                if ( -not $script:vdcAlgorithm ) {
+                    $script:vdcAlgorithm = Invoke-VenafiRestMethod -UriLeaf 'algorithmselector/getglobalalgorithms' -Method Post -Body @{} |
+                        Select-Object -ExpandProperty Selectors |
+                        Select-Object -Property @{'n' = 'AlgorithmId'; 'e' = { $_.PkixParameterSetOid } }, @{'n' = 'Name'; 'e' = { $_.Algorithm } }, * -ExcludeProperty PkixParameterSetOid, Algorithm
+                    $latest = $true
+                }
+
+                $allObject = $script:vdcAlgorithm
+
+                if ( $InputObject ) {
+                    $thisObject = $allObject | Where-Object { $InputObject -in $_.Name, $_.AlgorithmId }
+                    if ( -not $thisObject -and -not $latest ) {
+                        $script:vdcAlgorithm = Invoke-VenafiRestMethod -UriLeaf 'algorithmselector/getglobalalgorithms' -Method Post -Body @{} |
+                            Select-Object -ExpandProperty Selectors |
+                            Select-Object -Property @{'n' = 'AlgorithmId'; 'e' = { $_.PkixParameterSetOid } }, @{'n' = 'Name'; 'e' = { $_.Algorithm } }, * -ExcludeProperty PkixParameterSetOid, Algorithm
+                        $thisObject = $script:vdcAlgorithm | Where-Object { $InputObject -in $_.Name, $_.AlgorithmId }
+                    }
                 }
                 break
             }
@@ -151,7 +221,7 @@ function Get-VcData {
         else {
             $allObject
         }
-        
+
         if ( $FailOnMultiple -and @($returnObject).Count -gt 1 ) {
             throw "Multiple $Type found"
         }

--- a/VenafiPS/Private/Test-VenafiSession.ps1
+++ b/VenafiPS/Private/Test-VenafiSession.ps1
@@ -38,6 +38,9 @@ function Test-VenafiSession {
         elseif ($InvocationInfo.MyCommand -match '-Vdc') {
             'VDC'
         }
+        else {
+            throw 'Venafi Platform, VC or VDC, could not be determined'
+        }
 
         if ( $InvocationInfo.BoundParameters['VenafiSession'] ) {
             $VenafiSession = $InvocationInfo.BoundParameters['VenafiSession']
@@ -84,26 +87,8 @@ function Test-VenafiSession {
 
             'String' {
 
-                if ( Test-IsGuid($VenafiSession) ) {
+                # key or token provided directly, not via New-VenafiSession
 
-                    Write-Verbose 'Session is VC key'
-
-                    if ( $Platform -and $Platform -notmatch '^VC$' ) {
-                        throw "This function or parameter set is only accessible for $Platform"
-                    }
-                }
-                else {
-
-                    # TLSPDC access token
-                    Write-Verbose 'Session is VDC token'
-                    if ( $Platform -and $Platform -notmatch '^VDC' ) {
-                        throw "This function or parameter set is only accessible for $Platform"
-                    }
-                    # get server from environment variable
-                    if ( -not $env:VDC_SERVER ) {
-                        throw 'TLSPDC token provided, but VDC_SERVER environment variable was not found'
-                    }
-                }
                 break
             }
 

--- a/VenafiPS/Public/Add-VcTeamMember.ps1
+++ b/VenafiPS/Public/Add-VcTeamMember.ps1
@@ -6,12 +6,11 @@ function Add-VcTeamMember {
     .DESCRIPTION
     Add members to a TLSPC team
 
-    .PARAMETER ID
-    Team ID to add to
+    .PARAMETER Team
+    Team ID or name to add to
 
     .PARAMETER Member
     1 or more members to add to the team.
-    This is the unique guid obtained from Get-VcIdentity.
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -19,20 +18,13 @@ function Add-VcTeamMember {
     A TLSPC key can also provided.
 
     .INPUTS
-    ID
+    Team
 
     .EXAMPLE
     Add-VcTeamMember -ID 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2' -Member @('ca7ff555-88d2-4bfc-9efa-2630ac44c1f3', 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f4')
 
     Add members to a TLSPC team
 
-    .EXAMPLE
-    Add-VcTeamMember -ID 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e6}' -Member 'local:{803f332e-7576-4696-a5a2-8ac6be6b14e7}'
-
-    Add members to a TLSPDC team
-
-    .LINK
-    https://api.venafi.cloud/webjars/swagger-ui/index.html#/Teams/addMember
     #>
 
     [CmdletBinding()]
@@ -40,7 +32,7 @@ function Add-VcTeamMember {
 
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('PrefixedUniversal', 'Guid')]
-        [string] $ID,
+        [string] $Team,
 
         [Parameter(Mandatory)]
         [string[]] $Member,
@@ -56,8 +48,10 @@ function Add-VcTeamMember {
 
     process {
 
+        $teamId = $Team | Get-VcData -Type Team -FailOnNotFound -FailOnMultiple
+
         $params.Method = 'Post'
-        $params.UriLeaf = "teams/$ID/members"
+        $params.UriLeaf = "teams/$teamId/members"
         $params.Body = @{
             'members' = @($Member)
         }

--- a/VenafiPS/Public/Add-VcTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VcTeamOwner.ps1
@@ -58,7 +58,7 @@ function Add-VcTeamOwner {
 
     process {
 
-        $params.UriLeaf = 'teams/{0}/owners' -f (Get-VcData -InputObject $Team -Type 'Team' -FailOnNotFound)
+        $params.UriLeaf = 'teams/{0}/owners' -f (Get-VcData -InputObject $Team -Type 'Team' -FailOnNotFound -FailOnMultiple)
 
         $null = Invoke-VenafiRestMethod @params
     }

--- a/VenafiPS/Public/Add-VdcAdaptableHash.ps1
+++ b/VenafiPS/Public/Add-VdcAdaptableHash.ps1
@@ -24,8 +24,6 @@ function Add-VdcAdaptableHash {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/Add-VdcCertificateAssociation.ps1
+++ b/VenafiPS/Public/Add-VdcCertificateAssociation.ps1
@@ -23,8 +23,6 @@ function Add-VdcCertificateAssociation {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Add-VdcTeamOwner.ps1
+++ b/VenafiPS/Public/Add-VdcTeamOwner.ps1
@@ -16,8 +16,6 @@ function Add-VdcTeamOwner {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID

--- a/VenafiPS/Public/Convert-VdcObject.ps1
+++ b/VenafiPS/Public/Convert-VdcObject.ps1
@@ -20,8 +20,6 @@ function Convert-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path
@@ -41,7 +39,7 @@ function Convert-VdcObject {
 
     .EXAMPLE
     Find-VdcObject -Class Basic | Convert-VdcObject -Class 'capi' -PassThru | Set-VdcAttribute -Attribute @{'Driver Name'='appcapi'}
-    
+
     Convert multiple objects to a different type, return the updated objects and update attributes
 
     .LINK

--- a/VenafiPS/Public/ConvertTo-VdcGuid.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcGuid.ps1
@@ -11,12 +11,10 @@ function ConvertTo-VdcGuid {
 
     .PARAMETER IncludeType
     Include the object type in the response
-    
+
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/ConvertTo-VdcPath.ps1
+++ b/VenafiPS/Public/ConvertTo-VdcPath.ps1
@@ -11,12 +11,10 @@ function ConvertTo-VdcPath {
 
     .PARAMETER IncludeType
     Include the object type in the response
-    
+
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Guid

--- a/VenafiPS/Public/Export-VdcCertificate.ps1
+++ b/VenafiPS/Public/Export-VdcCertificate.ps1
@@ -72,8 +72,6 @@ function Export-VdcCertificate {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path, VaultId

--- a/VenafiPS/Public/Export-VdcVaultObject.ps1
+++ b/VenafiPS/Public/Export-VdcVaultObject.ps1
@@ -18,8 +18,6 @@ function Export-VdcVaultObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID
@@ -41,7 +39,7 @@ function Export-VdcVaultObject {
     Get-VdcCertificate -Path 'certificates\www.greg.com' -IncludePreviousVersions | Export-VdcVaultObject
 
     Export historical certificates
-    
+
     .EXAMPLE
     Export-VdcVaultObject -ID 12345 -OutPath 'c:\temp'
 
@@ -87,16 +85,16 @@ function Export-VdcVaultObject {
             else {
                 $thisId
             }
-            
+
             $response = Invoke-VenafiRestMethod -Method 'Post' -UriLeaf 'SecretStore/Retrieve' -Body @{ 'VaultID' = $vaultId }
-    
+
             if ( $response.Result -ne 0 ) {
                 Write-Error "Failed to retrieve vault object with a result code of $($response.Result).  Look up this code at https://docs.venafi.com/Docs/currentSDK/TopNav/Content/SDK/WebSDK/r-SDK-SecretStore-ResultCodes.php."
                 return
             }
-    
+
             $ext = $format = $header = $footer = $null
-    
+
             switch ( $response.VaultType ) {
                 { $_ -in 2, 1073741826 } {
                     $ext = 'cer'
@@ -104,16 +102,16 @@ function Export-VdcVaultObject {
                     $header = '-----BEGIN CERTIFICATE-----'
                     $footer = '-----END CERTIFICATE-----'
                 }
-    
+
                 { $_ -in 4, 1073741828 } {
                     $ext = 'p12'
                     $format = 'PKCS12'
                 }
-    
+
                 { $_ -in 32, 1073741856 } {
                     $format = 'Password'
                 }
-    
+
                 { $_ -in 256, 1073742080 } {
                     $ext = 'key'
                     $format = 'PKCS8'
@@ -132,10 +130,10 @@ function Export-VdcVaultObject {
                     Write-Verbose "Unknown vault type $_"
                 }
             }
-    
+
             if ( $OutPath ) {
                 if ( $ext ) {
-    
+
                     $outFile = Join-Path -Path (Resolve-Path -Path $OutPath) -ChildPath ('{0}.{1}' -f $vaultId, $ext)
                     if ($header) {
                         # output text file
@@ -146,7 +144,7 @@ function Export-VdcVaultObject {
                         $bytes = [Convert]::FromBase64String($response.Base64Data)
                         [IO.File]::WriteAllBytes($outFile, $bytes)
                     }
-        
+
                     Write-Verbose "Saved $outFile"
                 }
                 else {

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -209,7 +209,7 @@ function Find-VcCertificate {
         [string] $Issuer,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [Parameter(ParameterSetName = 'All')]
         [Parameter(ParameterSetName = 'Filter')]

--- a/VenafiPS/Public/Find-VcCertificate.ps1
+++ b/VenafiPS/Public/Find-VcCertificate.ps1
@@ -56,6 +56,9 @@ function Find-VcCertificate {
     .PARAMETER Issuer
     Search by issuer name
 
+    .PARAMETER IncludeAny
+    When using multiple filter parameters, combine them with OR logic instead of AND logic
+
     .PARAMETER Filter
     Array or multidimensional array of fields and values to filter on.
     Each array should be of the format @(field, comparison operator, value).

--- a/VenafiPS/Public/Find-VcCertificateInstance.ps1
+++ b/VenafiPS/Public/Find-VcCertificateInstance.ps1
@@ -42,7 +42,7 @@ function Find-VcCertificateInstance {
     Find-VcCertificateInstance
 
     Get all instancese
-    
+
     .OUTPUTS
 
     #>
@@ -65,7 +65,7 @@ function Find-VcCertificateInstance {
         [string] $Status,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
         [psobject[]] $Order,

--- a/VenafiPS/Public/Find-VcCertificateInstance.ps1
+++ b/VenafiPS/Public/Find-VcCertificateInstance.ps1
@@ -47,24 +47,24 @@ function Find-VcCertificateInstance {
 
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'All')]
+    [CmdletBinding(DefaultParameterSetName = 'SimpleFilter')]
 
     param (
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [string] $HostName,
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [ipaddress] $IpAddress,
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [int] $Port,
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [ValidateSet('IN_USE', 'SUPERSEDED')]
         [string] $Status,
 
-        [Parameter(Mandatory, ParameterSetName = 'Filter')]
+        [Parameter(Mandatory, ParameterSetName = 'AdvancedFilter')]
         [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
@@ -81,13 +81,13 @@ function Find-VcCertificateInstance {
     Test-VenafiSession $PSCmdlet.MyInvocation
 
     $params = @{
-        Type = 'CertificateInstance'
+        Type  = 'CertificateInstance'
         First = $First
     }
 
     if ( $Order ) { $params.Order = $Order }
 
-    if ( $PSCmdlet.ParameterSetName -eq 'Filter' ) {
+    if ( $PSCmdlet.ParameterSetName -eq 'AdvancedFilter' ) {
         $params.Filter = $Filter
     }
     else {
@@ -95,10 +95,10 @@ function Find-VcCertificateInstance {
         $newFilter.Add('AND')
 
         switch ($PSBoundParameters.Keys) {
-            'HostName' { $null = $newFilter.Add(@('hostname', 'FIND', $HostName)) ; break}
-            'IpAddress' { $null = $newFilter.Add(@('ipAddress', 'EQ', $IpAddress.IPAddressToString)) ; break}
-            'Port' { $null = $newFilter.Add(@('port', 'EQ', $Port.ToString())) ; break}
-            'Status' { $null = $newFilter.Add(@('deploymentStatus', 'EQ', $Status.ToUpper())) ; break}
+            'HostName' { $null = $newFilter.Add(@('hostname', 'FIND', $HostName)) }
+            'IpAddress' { $null = $newFilter.Add(@('ipAddress', 'EQ', $IpAddress.IPAddressToString)) }
+            'Port' { $null = $newFilter.Add(@('port', 'EQ', $Port.ToString())) }
+            'Status' { $null = $newFilter.Add(@('deploymentStatus', 'EQ', $Status.ToUpper())) }
         }
 
         if ( $newFilter.Count -gt 1 ) { $params.Filter = $newFilter }

--- a/VenafiPS/Public/Find-VcCertificateRequest.ps1
+++ b/VenafiPS/Public/Find-VcCertificateRequest.ps1
@@ -4,7 +4,28 @@ function Find-VcCertificateRequest {
     Find certificate requests
 
     .DESCRIPTION
-    Find certificate requests
+    Find certificate requests via fields directly or provide a string filter
+
+    .PARAMETER Status
+    Request status, one of 'NEW', 'PENDING', 'PENDING_APPROVAL', 'PENDING_FINAL_APPROVAL', 'REJECTED_APPROVAL', 'REQUESTED', 'ISSUED', 'REJECTED', 'CANCELLED', 'REVOKED', 'FAILED', 'DELETED'
+
+    .PARAMETER Application
+    One or more application id or names
+
+    .PARAMETER User
+    One or more owner user id or usernames
+
+    .PARAMETER IssuingTemplate
+    One or more issuing template id or names
+
+    .PARAMETER CreateDateFrom
+    Filter certificate requests from this date/time and forward
+
+    .PARAMETER KeyLength
+    Certificate key length
+
+    .PARAMETER IncludeAny
+    When using multiple filter parameters, combine them with OR logic instead of AND logic
 
     .PARAMETER Filter
     Array or multidimensional array of fields and values to filter on.
@@ -16,12 +37,6 @@ function Find-VcCertificateRequest {
     Array of fields to order on.
     For each item in the array, you can provide a field name by itself; this will default to ascending.
     You can also provide a hashtable with the field name as the key and either asc or desc as the value.
-
-    .PARAMETER Status
-    Request status, one of 'NEW', 'PENDING', 'PENDING_APPROVAL', 'PENDING_FINAL_APPROVAL', 'REJECTED_APPROVAL', 'REQUESTED', 'ISSUED', 'REJECTED', 'CANCELLED', 'REVOKED', 'FAILED', 'DELETED'
-
-    .PARAMETER KeyLength
-    Certificate key length
 
     .PARAMETER First
     Only retrieve this many records
@@ -36,22 +51,42 @@ function Find-VcCertificateRequest {
 
     Get all certificate requests
 
+    .EXAMPLE
+    Find-VcCertificateRequest -Application 'MyApp' -CreateDateFrom (Get-Date).AddDays(-7)
+
+    Find requests for a specific application created in the last 7 days
+
     .OUTPUTS
 
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'All')]
+    [CmdletBinding(DefaultParameterSetName = 'SimpleFilter')]
 
     param (
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [ValidateSet('NEW', 'PENDING', 'PENDING_APPROVAL', 'PENDING_FINAL_APPROVAL', 'REJECTED_APPROVAL', 'REQUESTED', 'ISSUED', 'REJECTED', 'CANCELLED', 'REVOKED', 'FAILED', 'DELETED')]
-        [string] $Status,
+        [string[]] $Status,
 
-        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
+        [string[]] $Application,
+
+        [Parameter(ParameterSetName = 'SimpleFilter')]
+        [string[]] $User,
+
+        [Parameter(ParameterSetName = 'SimpleFilter')]
+        [string[]] $IssuingTemplate,
+
+        [Parameter(ParameterSetName = 'SimpleFilter')]
         [int] $KeyLength,
 
-        [Parameter(Mandatory, ParameterSetName = 'Filter')]
+        [Parameter(ParameterSetName = 'SimpleFilter')]
+        [datetime] $CreateDateFrom,
+
+        [Parameter(ParameterSetName = 'SimpleFilter')]
+        [switch] $IncludeAny,
+
+        [Parameter(Mandatory, ParameterSetName = 'AdvancedFilter')]
         [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
@@ -68,22 +103,33 @@ function Find-VcCertificateRequest {
     Test-VenafiSession $PSCmdlet.MyInvocation
 
     $params = @{
-        Type = 'CertificateRequest'
+        Type  = 'CertificateRequest'
         First = $First
     }
 
     if ( $Order ) { $params.Order = $Order }
 
-    if ( $PSCmdlet.ParameterSetName -eq 'Filter' ) {
+    if ( $PSCmdlet.ParameterSetName -eq 'AdvancedFilter' ) {
         $params.Filter = $Filter
     }
     else {
         $newFilter = [System.Collections.Generic.List[object]]::new()
-        $newFilter.Add('AND')
+        # Use OR or AND based on IncludeAny parameter
+        if ($IncludeAny) {
+            $newFilter.Add('OR')
+        }
+        else {
+            $newFilter.Add('AND')
+        }
+
 
         switch ($PSBoundParameters.Keys) {
-            'Status' { $null = $newFilter.Add(@('status', 'EQ', $Status.ToUpper())) }
+            'Status' { $null = $newFilter.Add(@('status', 'IN', $Status.ToUpper())) }
             'KeyLength' { $null = $newFilter.Add(@('keyLength', 'EQ', $KeyLength.ToString())) }
+            'Application' { $null = $newFilter.Add(@('applicationId', 'IN', @(($Application | Get-VcData -Type Application)))) }
+            'User' { $null = $newFilter.Add(@('certificateOwnerUserId', 'MATCH', @(($User | Get-VcData -Type User)))) }
+            'IssuingTemplate' { $null = $newFilter.Add(@('certificateIssuingTemplateId', 'MATCH', @(($IssuingTemplate | Get-VcData -Type IssuingTemplate)))) }
+            'CreateDateFrom' { $null = $newFilter.Add(@('creationDate', 'GTE', $CreateDateFrom)) }
         }
 
         if ( $newFilter.Count -gt 1 ) { $params.Filter = $newFilter }

--- a/VenafiPS/Public/Find-VcCertificateRequest.ps1
+++ b/VenafiPS/Public/Find-VcCertificateRequest.ps1
@@ -52,7 +52,7 @@ function Find-VcCertificateRequest {
         [int] $KeyLength,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
         [psobject[]] $Order,

--- a/VenafiPS/Public/Find-VcLog.ps1
+++ b/VenafiPS/Public/Find-VcLog.ps1
@@ -23,8 +23,8 @@ function Find-VcLog {
     Filter logs to this date/time
     Combine with DateFrom for a date range.
 
-    .PARAMETER Criticality
-    Filter logs by criticality level
+    .PARAMETER Critical
+    Filter logs by critical or not.
 
     .PARAMETER IncludeAny
     When using multiple filter parameters (Type, Name, Message, Criticality), combine them with OR logic instead of AND logic

--- a/VenafiPS/Public/Find-VcLog.ps1
+++ b/VenafiPS/Public/Find-VcLog.ps1
@@ -17,11 +17,11 @@ function Find-VcLog {
     For each item in the array, you can provide a field name by itself; this will default to ascending.
     You can also provide a hashtable with the field name as the key and either asc or desc as the value.
 
-    .PARAMETER Name
-    Activity name to find via regex match
-
     .PARAMETER Type
-    Activity type
+    Activity type, tab completion supported
+
+    .PARAMETER Name
+    Activity name to find via regex match, tab completion supported
 
     .PARAMETER Message
     Look anywhere in the message for the string provided
@@ -96,7 +96,7 @@ function Find-VcLog {
         [string] $Message,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
         [psobject[]] $Order,

--- a/VenafiPS/Public/Find-VcMachine.ps1
+++ b/VenafiPS/Public/Find-VcMachine.ps1
@@ -38,7 +38,7 @@ function Find-VcMachine {
     Find-VcMachine
 
     Get all machines
-    
+
     .OUTPUTS
 
     #>
@@ -59,7 +59,7 @@ function Find-VcMachine {
         [string] $Status,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [Parameter()]
         [psobject[]] $Order,

--- a/VenafiPS/Public/Find-VcMachine.ps1
+++ b/VenafiPS/Public/Find-VcMachine.ps1
@@ -75,7 +75,7 @@ function Find-VcMachine {
     Test-VenafiSession $PSCmdlet.MyInvocation
 
     $params = @{
-        Type = 'Machine'
+        Type  = 'Machine'
         First = $First
     }
 
@@ -90,7 +90,7 @@ function Find-VcMachine {
 
         switch ($PSBoundParameters.Keys) {
             'Name' { $null = $newFilter.Add(@('machineName', 'FIND', $Name)) }
-            'Type' { $null = $newFilter.Add(@('machineType', 'EQ', $Type)) }
+            'MachineType' { $null = $newFilter.Add(@('pluginName', 'EQ', $MachineType)) }
             'Status' { $null = $newFilter.Add(@('status', 'EQ', $Status.ToUpper())) }
         }
 

--- a/VenafiPS/Public/Find-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Find-VcMachineIdentity.ps1
@@ -32,7 +32,7 @@ function Find-VcMachineIdentity {
     Find-VcMachineIdentity
 
     Get all machine identities
-    
+
     .OUTPUTS
     pscustomobject
     #>
@@ -46,7 +46,7 @@ function Find-VcMachineIdentity {
         [string[]] $Status,
 
         [Parameter(Mandatory, ParameterSetName = 'Filter')]
-        [System.Collections.ArrayList] $Filter,
+        [System.Collections.Generic.List[object]] $Filter,
 
         [parameter()]
         [psobject[]] $Order,

--- a/VenafiPS/Public/Find-VdcCertificate.ps1
+++ b/VenafiPS/Public/Find-VdcCertificate.ps1
@@ -143,14 +143,15 @@ function Find-VdcCertificate {
     .PARAMETER ValidationState
     Find certificates with a validation state of Blank, Success, or Failure.
 
+    .PARAMETER Algorithm
+    Name or OID for the PKIX algorithm, first introduced in v25.1.
+
     .PARAMETER CountOnly
     Return the count of certificates found from the query as opposed to the certificates themselves
 
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path
@@ -391,6 +392,9 @@ function Find-VdcCertificate {
         [String[]] $ValidationState,
 
         [Parameter()]
+        [string] $Algorithm,
+
+        [Parameter()]
         [Switch] $CountOnly,
 
         [Parameter()]
@@ -554,6 +558,10 @@ function Find-VdcCertificate {
             }
             'ValidationState' {
                 $params.Body.Add( 'ValidationState', $ValidationState -join ',' )
+            }
+
+            'Algorithm' {
+                $params.Body.Add('PkixParameterSet', $Algorithm)
             }
         }
     }

--- a/VenafiPS/Public/Find-VdcClient.ps1
+++ b/VenafiPS/Public/Find-VdcClient.ps1
@@ -13,8 +13,6 @@ function Find-VdcClient {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/Find-VdcIdentity.ps1
+++ b/VenafiPS/Public/Find-VdcIdentity.ps1
@@ -25,8 +25,6 @@ function Find-VdcIdentity {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Name

--- a/VenafiPS/Public/Find-VdcObject.ps1
+++ b/VenafiPS/Public/Find-VdcObject.ps1
@@ -38,8 +38,6 @@ function Find-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Find-VdcVaultId.ps1
+++ b/VenafiPS/Public/Find-VdcVaultId.ps1
@@ -12,8 +12,6 @@ function Find-VdcVaultId {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path
@@ -23,9 +21,9 @@ function Find-VdcVaultId {
 
     .EXAMPLE
     Find-VdcVaultId -Path '\ved\policy\awesomeobject.cyberark.com'
-    
+
     Find the vault IDs associated with an object.
-    For certificates with historical references, the vault IDs will 
+    For certificates with historical references, the vault IDs will
 
     .LINK
     http://VenafiPS.readthedocs.io/en/latest/functions/Find-VdcVaultId/

--- a/VenafiPS/Public/Get-VcCertificate.ps1
+++ b/VenafiPS/Public/Get-VcCertificate.ps1
@@ -12,7 +12,7 @@ function Get-VcCertificate {
     .PARAMETER All
     Retrieve all certificates
 
-    .PARAMETER IncludeVaasOwner
+    .PARAMETER OwnerDetail
     Retrieve extended application owner info
 
     .PARAMETER VenafiSession
@@ -42,14 +42,15 @@ function Get-VcCertificate {
     param (
 
         [Parameter(ParameterSetName = 'Id', Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
-        [Alias('certificateId', 'ID')]
+        [Alias('certificateId', 'certificateIds', 'ID')]
         [string] $Certificate,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [Switch] $All,
 
         [Parameter()]
-        [switch] $IncludeVaasOwner,
+        [Alias('IncludeVaasOwner')]
+        [switch] $OwnerDetail,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -67,7 +68,7 @@ function Get-VcCertificate {
     process {
 
         if ( $All ) {
-            return (Find-VcCertificate -IncludeVaasOwner:$IncludeVaasOwner)
+            return (Find-VcCertificate -IncludeVaasOwner:$OwnerDetail)
         }
 
         $params = @{
@@ -81,7 +82,7 @@ function Get-VcCertificate {
         else {
             $findParams = @{
                 Filter           = @('certificateName', 'eq', $Certificate)
-                IncludeVaasOwner = $IncludeVaasOwner
+                IncludeVaasOwner = $OwnerDetail
             }
             return (Find-VcCertificate @findParams | Get-VcCertificate)
         }
@@ -114,7 +115,7 @@ function Get-VcCertificate {
         @{
             'n' = 'owner'
             'e' = {
-                if ( $IncludeVaasOwner ) {
+                if ( $OwnerDetail ) {
 
                     # this scriptblock requires ?ownershipTree=true be part of the url
                     foreach ( $thisOwner in $_.ownership.owningContainers.owningUsers ) {

--- a/VenafiPS/Public/Get-VcTag.ps1
+++ b/VenafiPS/Public/Get-VcTag.ps1
@@ -38,7 +38,8 @@ function Get-VcTag {
     param (
 
         [Parameter(Mandatory, ParameterSetName = 'ID', ValueFromPipelineByPropertyName, Position = 0)]
-        [string] $Name,
+        [Alias('Name')]
+        [string] $Tag,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch] $All,
@@ -59,8 +60,8 @@ function Get-VcTag {
             $response = Invoke-VenafiRestMethod -UriLeaf 'tags' | Select-Object -ExpandProperty tags
         }
         else {
-            $response = Invoke-VenafiRestMethod -UriLeaf "tags/$Name"
-            $values = Invoke-VenafiRestMethod -UriLeaf "tags/$Name/values" | Select-Object -ExpandProperty values
+            $response = Invoke-VenafiRestMethod -UriLeaf "tags/$Tag"
+            $values = Invoke-VenafiRestMethod -UriLeaf "tags/$Tag/values" | Select-Object -ExpandProperty values
         }
 
         if ( $response ) {
@@ -71,7 +72,7 @@ function Get-VcTag {
                     $thisId = $_.id
                     , @(($values | Where-Object { $_.tagId -eq $thisId }).value)
                 }
-            }, * -ExcludeProperty id, name
+            }
         }
     }
 }

--- a/VenafiPS/Public/Get-VcTag.ps1
+++ b/VenafiPS/Public/Get-VcTag.ps1
@@ -7,7 +7,7 @@ function Get-VcTag {
     Get 1 or all tags.
     Tag values will be provided.
 
-    .PARAMETER Name
+    .PARAMETER Tag
     Tag name
 
     .PARAMETER All
@@ -22,7 +22,7 @@ function Get-VcTag {
     Name
 
     .EXAMPLE
-    Get-VcTag -Name 'MyTag'
+    Get-VcTag -Tag 'MyTag'
 
     Get a single tag
 

--- a/VenafiPS/Public/Get-VdcAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcAttribute.ps1
@@ -24,7 +24,7 @@ function Get-VdcAttribute {
     Get policy attributes instead of object attributes.
     Provide the class name to retrieve the value(s) for.
     The Attribute property of the return object will contain the path where the policy was applied.
-    
+
     If unsure of the class name, add the value through the TLSPDC UI and go to Support->Policy Attributes to find it.
 
     .PARAMETER All

--- a/VenafiPS/Public/Get-VdcCertificate.ps1
+++ b/VenafiPS/Public/Get-VdcCertificate.ps1
@@ -33,8 +33,6 @@ function Get-VdcCertificate {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID
@@ -128,7 +126,8 @@ function Get-VdcCertificate {
             if ( $PSItem -like '\ved*' ) {
                 # a path was provided, get the guid
                 $thisGuid = (ConvertTo-VdcObject -Path $PSItem).Guid
-            } else {
+            }
+            else {
                 $thisGuid = ([guid] $PSItem).ToString()
             }
 

--- a/VenafiPS/Public/Get-VdcClassAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcClassAttribute.ps1
@@ -5,16 +5,14 @@ function Get-VdcClassAttribute {
 
     .DESCRIPTION
     List all attributes for a specified class, helpful for validation or to pass to Get-VdcAttribute
-    
+
     .PARAMETER ClassName
     Class name to retrieve attributes for
 
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
-        
+
     .EXAMPLE
     Get-VdcClassAttribute -ClassName 'X509 Server Certificate'
 

--- a/VenafiPS/Public/Get-VdcCredential.ps1
+++ b/VenafiPS/Public/Get-VdcCredential.ps1
@@ -17,8 +17,6 @@ function Get-VdcCredential {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Get-VdcCustomField.ps1
+++ b/VenafiPS/Public/Get-VdcCustomField.ps1
@@ -12,8 +12,6 @@ function Get-VdcCustomField {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/Get-VdcIdentity.ps1
+++ b/VenafiPS/Public/Get-VdcIdentity.ps1
@@ -25,8 +25,6 @@ function Get-VdcIdentity {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID

--- a/VenafiPS/Public/Get-VdcIdentityAttribute.ps1
+++ b/VenafiPS/Public/Get-VdcIdentityAttribute.ps1
@@ -16,8 +16,6 @@ function Get-VdcIdentityAttribute {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID

--- a/VenafiPS/Public/Get-VdcObject.ps1
+++ b/VenafiPS/Public/Get-VdcObject.ps1
@@ -16,8 +16,6 @@ function Get-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path, Guid

--- a/VenafiPS/Public/Get-VdcPermission.ps1
+++ b/VenafiPS/Public/Get-VdcPermission.ps1
@@ -27,8 +27,6 @@ function Get-VdcPermission {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     InputObject, Path, Guid, IdentityId

--- a/VenafiPS/Public/Get-VdcSystemStatus.ps1
+++ b/VenafiPS/Public/Get-VdcSystemStatus.ps1
@@ -9,8 +9,6 @@ function Get-VdcSystemStatus {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     none

--- a/VenafiPS/Public/Get-VdcTeam.ps1
+++ b/VenafiPS/Public/Get-VdcTeam.ps1
@@ -15,8 +15,6 @@ function Get-VdcTeam {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID

--- a/VenafiPS/Public/Get-VdcVersion.ps1
+++ b/VenafiPS/Public/Get-VdcVersion.ps1
@@ -9,8 +9,6 @@ function Get-VdcVersion {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     none

--- a/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
+++ b/VenafiPS/Public/Get-VdcWorkflowTicket.ps1
@@ -12,8 +12,6 @@ function Get-VdcWorkflowTicket {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -59,8 +59,6 @@ function Import-VdcCertificate {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .EXAMPLE
     Import-VdcCertificate -PolicyPath \ved\policy\mycerts -Path c:\www.VenafiPS.com.cer

--- a/VenafiPS/Public/Invoke-VcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VcCertificateAction.ps1
@@ -79,6 +79,12 @@ function Invoke-VcCertificateAction {
     Find all current certificates issued by i1 and renew them with a different issuer.
 
     .EXAMPLE
+    Find-VcCertificate -Version Current -Name 'mycert' | Invoke-VcCertificateAction -Renew -Wait
+
+    Renew a certificate and wait for it to pass the Requested state (and hopefully Issued).
+    This can be helpful if an Issuer takes a bit to enroll the certificate.
+
+    .EXAMPLE
     Invoke-VcCertificateAction -ID '3699b03e-ff62-4772-960d-82e53c34bf60' -Renew -Force
 
     Renewals can only support 1 CN assigned to a certificate.  To force this function to renew and automatically select the first CN, use -Force.

--- a/VenafiPS/Public/Invoke-VdcCertificateAction.ps1
+++ b/VenafiPS/Public/Invoke-VdcCertificateAction.ps1
@@ -47,8 +47,6 @@ function Invoke-VdcCertificateAction {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -26,6 +26,10 @@ function Invoke-VenafiRestMethod {
     .PARAMETER VcRegion
     TLSPC region to target.  Only supported if VenafiSession is an api key otherwise the comes from VenafiSession directly.
 
+    .PARAMETER Platform
+    Venafi Platform to target, either VC or VDC.
+    If not provided, the platform will be determined based on the VenafiSession or the calling function name.
+
     .PARAMETER Server
     Server or url to access vedsdk, venafi.company.com or https://venafi.company.com.
 

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -108,6 +108,10 @@ function Invoke-VenafiRestMethod {
         [string] $VcRegion = 'us',
 
         [Parameter()]
+        [ValidateSet('VC', 'VDC')]
+        [string] $Platform,
+
+        [Parameter()]
         [hashtable] $Header,
 
         [Parameter()]
@@ -122,6 +126,10 @@ function Invoke-VenafiRestMethod {
         [Parameter()]
         [switch] $SkipCertificateCheck
     )
+
+    # VC supports both apiley and token based auth, VDC only token
+
+    $authType = 'token'
 
     $params = @{
         Method          = $Method
@@ -138,13 +146,16 @@ function Invoke-VenafiRestMethod {
         switch ($VenafiSession.GetType().Name) {
             'PSCustomObject' {
                 $Server = $VenafiSession.Server
-                $platform = $VenafiSession.Platform
-                if ( $VenafiSession.Platform -eq 'VC' ) {
+                $thisPlatform = $VenafiSession.Platform
+                if ( $VenafiSession.Key ) {
                     $auth = $VenafiSession.Key.GetNetworkCredential().password
+                    $authType = 'apikey'
+                }
+                elseif ( $VenafiSession.Token ) {
+                    $auth = $VenafiSession.Token.AccessToken.GetNetworkCredential().password
                 }
                 else {
-                    # TLSPDC
-                    $auth = $VenafiSession.Token.AccessToken.GetNetworkCredential().password
+                    throw [System.ArgumentException]::new('Neither an api key or token could be found in VenafiSession')
                 }
                 $SkipCertificateCheck = $VenafiSession.SkipCertificateCheck
                 $params.TimeoutSec = $VenafiSession.TimeoutSec
@@ -158,19 +169,35 @@ function Invoke-VenafiRestMethod {
                     # if we were provided a key directly and not a full session, determine which region to contact
 
                     $Server = ($script:VcRegions).$VcRegion
-                    $platform = 'VC'
+                    $thisPlatform = 'VC'
+                    $authType = 'apikey'
                 }
                 else {
+                    # access token auth for both VC and VDC, determine which one
+                    $thisPlatform = if ( $PSBoundParameters.ContainsKey('Platform') ) {
+                        $Platform
+                    }
+                    elseif ( $MyInvocation.InvocationName -match '-Vdc' ) {
+                        'VDC'
+                    }
+                    elseif ( $MyInvocation.InvocationName -match '-Vc' ) {
+                        'VC'
+                    }
+                    else {
+                        throw 'Venafi Platform, VC or VDC, could not be determined'
+                    }
+
                     # TLSPDC access token
                     # get server from environment variable
-                    if ( -not $env:VDC_SERVER ) {
-                        throw 'VDC_SERVER environment variable was not found'
-                    }
-                    $Server = $env:VDC_SERVER
-                    if ( $Server -notlike 'https://*') {
-                        $Server = 'https://{0}' -f $Server
-                    }
-                    $platform = 'VDC'
+                    # if ( $thisPlatform -eq 'VDC' ) {
+                    #     if ( -not $env:VDC_SERVER ) {
+                    #         throw 'VDC_SERVER environment variable was not found.  When providing an access token directly this is required.'
+                    #     }
+                    #     $Server = $env:VDC_SERVER
+                    #     if ( $Server -notlike 'https://*') {
+                    #         $Server = 'https://{0}' -f $Server
+                    #     }
+                    # }
                 }
             }
 
@@ -179,24 +206,27 @@ function Invoke-VenafiRestMethod {
             }
         }
 
-        # set auth
-        switch ($platform) {
-            'VC' {
+        # set auth header
+        if ( $thisPlatform -eq 'VC' ) {
+            if ( $authType -eq 'token' ) {
+                $allHeaders = @{
+                    'Authorization' = "Bearer $auth"
+                }
+            }
+            else {
                 $allHeaders = @{
                     "tppl-api-key" = $auth
                 }
-                if ( -not $PSBoundParameters.ContainsKey('UriRoot') ) {
-                    $UriRoot = 'v1'
-                }
             }
 
-            'VDC' {
-                $allHeaders = @{
-                    'Authorization' = 'Bearer {0}' -f $auth
-                }
+            if ( -not $PSBoundParameters.ContainsKey('UriRoot') ) {
+                $UriRoot = 'v1'
             }
-
-            Default {}
+        }
+        else {
+            $allHeaders = @{
+                'Authorization' = "Bearer $auth"
+            }
         }
     }
 
@@ -309,7 +339,7 @@ function Invoke-VenafiRestMethod {
                 $permMsg = ''
 
                 # get scope details for tpp
-                if ( $platform -ne 'VC' ) {
+                if ( $thisPlatform -eq 'VDC' ) {
                     $callingFunction = @(Get-PSCallStack)[1].InvocationInfo.MyCommand.Name
                     $callingFunctionScope = ($script:functionConfig).$callingFunction.TppTokenScope
                     if ( $callingFunctionScope ) { $permMsg += "$callingFunction requires a token scope of '$callingFunctionScope'." }

--- a/VenafiPS/Public/Move-VdcObject.ps1
+++ b/VenafiPS/Public/Move-VdcObject.ps1
@@ -16,8 +16,6 @@ function Move-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     SourcePath (Path)

--- a/VenafiPS/Public/New-VcToken.ps1
+++ b/VenafiPS/Public/New-VcToken.ps1
@@ -47,6 +47,7 @@ function New-VcToken {
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'ScriptSession')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Converting to a secure string, its already plaintext')]
     [OutputType([PSCustomObject])]
 
     param (

--- a/VenafiPS/Public/New-VcToken.ps1
+++ b/VenafiPS/Public/New-VcToken.ps1
@@ -1,0 +1,137 @@
+function New-VcToken {
+    <#
+    .SYNOPSIS
+    Get a new access token
+
+    .DESCRIPTION
+    Get a new access token from an endpoint and JWT.
+    You can also provide a VenafiSession, or no session to use the script scoped one, which will use the stored endpoint and jwt to refresh the access token.
+    This only works if the jwt has not expired.
+
+    .PARAMETER Endpoint
+    Token Endpoint URL as shown on the service account details page in TLSPC
+
+    .PARAMETER Jwt
+    JSON web token with access to the configured service account
+
+    .PARAMETER VenafiSession
+    VenafiSession object created from New-VenafiSession method.
+    This can be used to refresh the access token if the JWT has not expired.
+
+    .EXAMPLE
+    New-VcToken
+
+    Refresh the existing access token stored in the script scoped variable VenafiSession
+    Only possible if the JWT has not expired.
+
+    .EXAMPLE
+    New-VcToken -Endpoint 'https://api.venafi.cloud/v1/oauth2/v2.0/2222c771-61f3-11ec-8a47-490a1e43c222/token' -Jwt $Jwt
+
+    Get a new token with OAuth
+
+    .EXAMPLE
+    New-VcToken -VenafiSession $sess
+
+    Refresh the existing access token stored in session.
+    Only possible if the JWT has not expired.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    PSCustomObject with the following properties:
+        Endpoint
+        AccessToken
+        JWT
+        Expires
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'ScriptSession')]
+    [OutputType([PSCustomObject])]
+
+    param (
+        [Parameter(ParameterSetName = 'Endpoint', Mandatory)]
+        [ValidateScript(
+            {
+                try {
+                    $null = [System.Uri]::new($_)
+                    $true
+                }
+                catch {
+                    throw 'Please enter a valid endpoint, eg. https://api.venafi.cloud/v1/oauth2/v2.0/2222c771-61f3-11ec-8a47-490a1e43c222/token'
+                }
+            }
+        )]
+        [string] $Endpoint,
+
+        [Parameter(ParameterSetName = 'Endpoint', Mandatory)]
+        [Parameter(ParameterSetName = 'Session')]
+        [string] $Jwt,
+
+        [Parameter(ParameterSetName = 'Session', Mandatory)]
+        [ValidateScript(
+            {
+                if ( -not $_.Token.Endpoint ) {
+                    throw 'VenafiSession does not have a refresh token.  To get a new access token, create a new session with New-VenafiSession.'
+                }
+                $true
+            }
+        )]
+        [pscustomobject] $VenafiSession
+
+    )
+
+    $params = @{
+        Uri         = $Endpoint
+        Method      = "POST"
+        ContentType = "application/x-www-form-urlencoded"
+        Body        = @{
+            grant_type            = "client_credentials"
+            client_assertion_type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            client_assertion      = $Jwt
+        }
+    }
+
+    if ( $PSCmdlet.ParameterSetName -in 'ScriptSession', 'Session' ) {
+
+        $sess = if ( $PSCmdlet.ParameterSetName -eq 'ScriptSession' ) {
+            $script:VenafiSession
+        }
+        else {
+            $VenafiSession
+        }
+
+        $params.Uri = $sess.Token.Endpoint
+        if ( $sess.Token.JWT ) {
+            $params.Body.client_assertion = $sess.Token.JWT.GetNetworkCredential().password
+        }
+        if ( -not $params.Body.client_assertion ) {
+            throw [System.ArgumentException]::new('-Jwt must be provided directly or via a VenafiSession.')
+        }
+    }
+
+    $response = Invoke-RestMethod @params
+    if ( -not $response ) {
+        return
+    }
+
+    $response | Write-VerboseWithSecret
+
+    $newToken = [PSCustomObject] @{
+        Endpoint    = $params.Uri
+        AccessToken = New-Object System.Management.Automation.PSCredential('AccessToken', ($response.access_token | ConvertTo-SecureString -AsPlainText -Force))
+        JWT         = New-Object System.Management.Automation.PSCredential('JWT', ($params.Body.client_assertion | ConvertTo-SecureString -AsPlainText -Force))
+        Expires     = (Get-Date).AddSeconds($response.expires_in)
+    }
+
+    if ( $PSCmdlet.ParameterSetName -eq 'ScriptSession' ) {
+        $script:VenafiSession.Token = $newToken
+        Write-Verbose 'Refreshed access token in script scoped variable VenafiSession'
+    }
+    else {
+        $newToken
+    }
+
+}
+
+

--- a/VenafiPS/Public/New-VdcCapiApplication.ps1
+++ b/VenafiPS/Public/New-VdcCapiApplication.ps1
@@ -59,8 +59,6 @@ function New-VdcCapiApplication {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/New-VdcCertificate.ps1
+++ b/VenafiPS/Public/New-VdcCertificate.ps1
@@ -78,8 +78,6 @@ function New-VdcCertificate {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/New-VdcCustomField.ps1
+++ b/VenafiPS/Public/New-VdcCustomField.ps1
@@ -82,8 +82,6 @@ function New-VdcCustomField {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/New-VdcDevice.ps1
+++ b/VenafiPS/Public/New-VdcDevice.ps1
@@ -28,8 +28,6 @@ function New-VdcDevice {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/New-VdcObject.ps1
+++ b/VenafiPS/Public/New-VdcObject.ps1
@@ -40,8 +40,6 @@ function New-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .EXAMPLE
     New-VdcObject -Path '\VED\Policy\Test Device' -Class 'Device' -Attribute @{'Description'='new device testing'}

--- a/VenafiPS/Public/New-VdcPolicy.ps1
+++ b/VenafiPS/Public/New-VdcPolicy.ps1
@@ -39,8 +39,6 @@ function New-VdcPolicy {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -39,6 +39,8 @@ function New-VenafiSession {
     You can either provide a String, SecureString, or PSCredential.
     If providing a credential, the username is not used.
 
+    .PARAMETER Endpoint
+
     .PARAMETER Jwt
     JSON web token.
     Available in TLSPDC v22.4 and later.
@@ -78,7 +80,7 @@ function New-VenafiSession {
     If providing a credential, the username is not used.
 
     .PARAMETER VcRegion
-    TLSPC region to connect to.  Valid values are 'us' and 'eu'.  Defaults to 'us'.
+    TLSPC region to connect to, tab-ahead values provided.  Defaults to 'us'.
 
     .PARAMETER VaultVcKeyName
     Name of the SecretManagement vault entry for the TLSPC key.
@@ -253,6 +255,7 @@ function New-VenafiSession {
         [psobject] $RefreshToken,
 
         [Parameter(Mandatory, ParameterSetName = 'TokenJwt')]
+        [Parameter(Mandatory, ParameterSetName = 'VcToken')]
         [string] $Jwt,
 
         [Parameter(Mandatory, ParameterSetName = 'TokenCertificate')]
@@ -310,6 +313,9 @@ function New-VenafiSession {
             }
         )]
         [string] $VcRegion = 'us',
+
+        [Parameter(Mandatory, ParameterSetName = 'VcToken')]
+        [string] $VcEndpoint,
 
         [Parameter(ParameterSetName = 'Vc')]
         [Parameter(Mandatory, ParameterSetName = 'VaultVcKey')]
@@ -436,7 +442,16 @@ function New-VenafiSession {
             }
 
             $token = New-VdcToken @params -Verbose:$isVerbose
-            $newSession | Add-Member @{Token = $token }
+            $newSession | Add-Member @{ Token = $token }
+        }
+
+        'VcToken' {
+            # access token via service account for tlspc
+            $newSession.Platform = 'VC'
+            $systemUri = [System.Uri]::new($VcEndpoint)
+            $newSession.Server = 'https://{0}' -f $systemUri.Host
+            $token = New-VcToken -Endpoint $VcEndpoint -Jwt $Jwt -Verbose:$isVerbose
+            $newSession | Add-Member @{ Token = $token }
         }
 
         'AccessToken' {
@@ -581,13 +596,17 @@ function New-VenafiSession {
     }
     else {
 
-        $newSession | Add-Member @{
-            User = (Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession -ErrorAction SilentlyContinue | Select-Object -ExpandProperty user | Select-Object @{
+        # user might not have access to this api, eg. service account
+        $user = Invoke-VenafiRestMethod -UriLeaf 'useraccounts' -VenafiSession $newSession -ErrorAction SilentlyContinue
+        if ( $user ) {
+            $newSession | Add-Member @{
+                User = $user | Select-Object -ExpandProperty user | Select-Object @{
                     'n' = 'userId'
                     'e' = {
                         $_.Id
                     }
-                }, * -ExcludeProperty id)
+                }, * -ExcludeProperty id
+            }
         }
     }
 

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -82,6 +82,9 @@ function New-VenafiSession {
     .PARAMETER VcRegion
     TLSPC region to connect to, tab-ahead values provided.  Defaults to 'us'.
 
+    .PARAMETER VcEndpoint
+    Token Endpoint URL as shown on the service account details page.
+
     .PARAMETER VaultVcKeyName
     Name of the SecretManagement vault entry for the TLSPC key.
     First time use requires it to be provided with -VcKey to populate the vault.

--- a/VenafiPS/Public/Remove-VdcCertificate.ps1
+++ b/VenafiPS/Public/Remove-VdcCertificate.ps1
@@ -23,8 +23,6 @@ function Remove-VdcCertificate {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path
@@ -101,7 +99,7 @@ function Remove-VdcCertificate {
     end {
 
         Invoke-VenafiParallel -InputObject $allCerts -ScriptBlock {
-            
+
             $guid = $PSItem | ConvertTo-VdcObject -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Guid
             if ( -not $guid ) {
                 Write-Error "'$PSItem' is not a valid path"

--- a/VenafiPS/Public/Remove-VdcObject.ps1
+++ b/VenafiPS/Public/Remove-VdcObject.ps1
@@ -23,8 +23,6 @@ function Remove-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Remove-VdcPermission.ps1
+++ b/VenafiPS/Public/Remove-VdcPermission.ps1
@@ -12,15 +12,13 @@ function Remove-VdcPermission {
 
     .PARAMETER Guid
     Guid that represents an object
-    
+
     .PARAMETER IdentityId
     Prefixed Universal Id of the user or group to have their permissions removed
 
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path, Guid, IdentityId

--- a/VenafiPS/Public/Rename-VdcObject.ps1
+++ b/VenafiPS/Public/Rename-VdcObject.ps1
@@ -15,8 +15,6 @@ function Rename-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     none

--- a/VenafiPS/Public/Revoke-VdcGrant.ps1
+++ b/VenafiPS/Public/Revoke-VdcGrant.ps1
@@ -16,8 +16,6 @@ function Revoke-VdcGrant {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     ID

--- a/VenafiPS/Public/Revoke-VdcToken.ps1
+++ b/VenafiPS/Public/Revoke-VdcToken.ps1
@@ -24,8 +24,6 @@ function Revoke-VdcToken {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     VenafiPsToken

--- a/VenafiPS/Public/Search-VdcHistory.ps1
+++ b/VenafiPS/Public/Search-VdcHistory.ps1
@@ -22,8 +22,6 @@ function Search-VdcHistory {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     None

--- a/VenafiPS/Public/Set-VdcAttribute.ps1
+++ b/VenafiPS/Public/Set-VdcAttribute.ps1
@@ -34,8 +34,6 @@ function Set-VdcAttribute {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Set-VdcCredential.ps1
+++ b/VenafiPS/Public/Set-VdcCredential.ps1
@@ -43,8 +43,6 @@ function Set-VdcCredential {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path

--- a/VenafiPS/Public/Set-VdcPermission.ps1
+++ b/VenafiPS/Public/Set-VdcPermission.ps1
@@ -71,8 +71,6 @@ function Set-VdcPermission {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Guid, IdentityId, Permission

--- a/VenafiPS/Public/Set-VdcWorkflowTicketStatus.ps1
+++ b/VenafiPS/Public/Set-VdcWorkflowTicketStatus.ps1
@@ -27,8 +27,6 @@ function Set-VdcWorkflowTicketStatus {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     TicketGuid

--- a/VenafiPS/Public/Test-VdcIdentity.ps1
+++ b/VenafiPS/Public/Test-VdcIdentity.ps1
@@ -15,8 +15,6 @@ function Test-VdcIdentity {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Identity

--- a/VenafiPS/Public/Test-VdcObject.ps1
+++ b/VenafiPS/Public/Test-VdcObject.ps1
@@ -18,8 +18,6 @@ function Test-VdcObject {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     Path or Guid.

--- a/VenafiPS/Public/Write-VdcLog.ps1
+++ b/VenafiPS/Public/Write-VdcLog.ps1
@@ -45,8 +45,6 @@ function Write-VdcLog {
     .PARAMETER VenafiSession
     Authentication for the function.
     The value defaults to the script session object $VenafiSession created by New-VenafiSession.
-    A TLSPDC token can also be provided.
-    If providing a TLSPDC token, an environment variable named VDC_SERVER must also be set.
 
     .INPUTS
     none

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -109,7 +109,7 @@ FunctionsToExport = 'Add-VcTeamMember', 'Add-VcTeamOwner', 'Add-VdcAdaptableHash
                'Set-VdcWorkflowTicketStatus', 'Test-VdcIdentity', 'Test-VdcObject',
                'Test-VdcToken', 'Write-VdcLog', 'Set-VcCertificate',
                'Get-VcSatelliteWorker', 'Remove-VcSatelliteWorker',
-               'Set-VcCertificateRequest', 'Get-VcCertificateRequest'
+               'Set-VcCertificateRequest', 'Get-VcCertificateRequest', 'New-VcToken'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -67,7 +67,7 @@ $vcGenericArgCompleterSb = {
             }
             $script:vcApplication | Where-Object name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
                 $itemText = "'{0}'" -f $_.name
-                $itemDescription = $_.description
+                $itemDescription = if ( $_.description ) { $_.description } else { $itemText }
 
                 [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
             }
@@ -139,10 +139,18 @@ $vcGenericArgCompleterSb = {
                 [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
             }
         }
+
+        'User' {
+            Get-VcData -Type User | Where-Object username -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.username
+                $itemDescription = 'user type: {0}, system roles: {1}' -f $_.userType, $_.systemRoles -join ','
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
     }
 }
 
-'Application', 'MachineType', 'VSatellite', 'Certificate', 'IssuingTemplate', 'Credential', 'Team', 'Owner', 'Tag' | ForEach-Object {
+'Application', 'MachineType', 'VSatellite', 'Certificate', 'IssuingTemplate', 'Credential', 'Team', 'Owner', 'Tag', 'User' | ForEach-Object {
     Register-ArgumentCompleter -CommandName $vcCommands -ParameterName $_ -ScriptBlock $vcGenericArgCompleterSb
 }
 

--- a/VenafiPS/VenafiPS.psm1
+++ b/VenafiPS/VenafiPS.psm1
@@ -11,6 +11,8 @@ $script:VcRegions = @{
     'eu' = 'https://api.eu.venafi.cloud'
     'au' = 'https://api.au.venafi.cloud'
     'uk' = 'https://api.uk.venafi.cloud'
+    'sg' = 'https://api.sg.venafi.cloud'
+    'ca' = 'https://api.ca.venafi.cloud'
 }
 $Script:VenafiSession = $null
 $script:ThreadJobAvailable = ($null -ne (Get-Module -Name Microsoft.PowerShell.ThreadJob -ListAvailable))
@@ -18,6 +20,213 @@ $script:DevMode = $script:ModuleVersion -match 'NEW_VERSION'
 $script:ParallelImportPath = $PSCommandPath
 
 Export-ModuleMember -Alias * -Variable VenafiSession -Function *
+
+# ModuleVersion will get updated during the build and this will not run
+# this is only needed during development since all files will be merged into one psm1
+if ( $script:DevMode ) {
+    $folders = @('Enum', 'Classes', 'Public', 'Private')
+    $publicFunction = @()
+
+    foreach ( $folder in $folders) {
+
+        $files = Get-ChildItem -Path "$PSScriptRoot\$folder\*.ps1" -Recurse
+
+        Foreach ( $thisFile in $files ) {
+            Try {
+                Write-Verbose ('dot sourcing {0}' -f $thisFile.FullName)
+                . $thisFile.fullname
+                # if ( $folder -eq 'Public' ) {
+                Export-ModuleMember -Function $thisFile.Basename
+                $publicFunction += $thisFile.BaseName
+                # }
+            }
+            Catch {
+                Write-Error ("Failed to import function {0}: {1}" -f $thisFile.fullname, $folder)
+            }
+        }
+    }
+}
+
+$moduleCommands = Get-Command -Module VenafiPS | Select-Object -ExpandProperty Name
+$vdcCommands = $moduleCommands | Where-Object { $_ -like '*-Vdc*' }
+$vcCommands = $moduleCommands | Where-Object { $_ -like '*-Vc*' }
+
+$vcGenericArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    $objectType = $parameterName
+    if ( $parameterName -eq 'ID' ) {
+        # figure out object type based on function name since 'ID' is used in many functions
+
+    }
+
+    switch ($objectType) {
+        'Application' {
+            if ( -not $script:vcApplication ) {
+                $script:vcApplication = Get-VcApplication -All | Sort-Object -Property name
+            }
+            $script:vcApplication | Where-Object name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = $_.description
+
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'MachineType' {
+            if ( -not $script:vcMachineType ) {
+                $script:vcMachineType = Invoke-VenafiRestMethod -UriLeaf 'plugins?pluginTypes=MACHINE' |
+                    Select-Object -ExpandProperty plugins |
+                    Select-Object -Property @{'n' = 'machineTypeId'; 'e' = { $_.Id } }, * -ExcludeProperty id |
+                    Sort-Object -Property name
+            }
+            $script:vcMachineType | Where-Object name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = 'supports: {0}' -f ($_.workTypes -join ', ')
+
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'IssuingTemplate' {
+            Get-VcData -Type IssuingTemplate | Where-Object name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = 'product: {0}, validity: {1}' -f $_.product.productName, $_.product.validityPeriod
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'VSatellite' {
+            Get-VcData -Type VSatellite | Where-Object Name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = 'status: {0}, version: {1}' -f $_.edgeStatus, $_.satelliteVersion
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'Certificate' {
+            # there might be a ton of certs so ensure they provide at least 3 characters
+            if ( $wordToComplete.Length -ge 3 ) {
+                Find-VcCertificate -Name $wordToComplete | ForEach-Object { "'$($_.certificateName)'" }
+            }
+        }
+
+        'Credential' {
+            Get-VcData -Type Credential | Where-Object name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = 'type: {0}, authentication: {1}' -f $_.cmsType, $_.authType
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'Tag' {
+            Get-VcData -Type Tag | Where-Object tagId -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.tagId
+                $itemDescription = if ($_.value) {
+                    'values: {0}' -f ($_.value -join ', ')
+                }
+                else {
+                    'no values set'
+                }
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        { $_ -in 'Team', 'Owner' } {
+            Get-VcData -Type Team | Where-Object Name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.name
+                $itemDescription = 'role: {0}' -f $_.role
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+    }
+}
+
+'Application', 'MachineType', 'VSatellite', 'Certificate', 'IssuingTemplate', 'Credential', 'Team', 'Owner', 'Tag' | ForEach-Object {
+    Register-ArgumentCompleter -CommandName $vcCommands -ParameterName $_ -ScriptBlock $vcGenericArgCompleterSb
+}
+
+$vdcPathArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    if ( -not $wordToComplete ) {
+        # if no word provided, default to \ved\policy
+        $wordToComplete = '\VED\Policy\'
+    }
+
+    # if the path starts with ' or ", that will come along for the ride so ensure we trim that first
+    $fullWord = $wordToComplete.Trim("`"'") | ConvertTo-VdcFullPath
+    $leaf = $fullWord.Split('\')[-1]
+    $parent = $fullWord.Substring(0, $fullWord.LastIndexOf("\$leaf"))
+
+    # get items in parent folder
+    $objs = Find-VdcObject -Path $parent
+    $objs | Where-Object { $_.name -like "$leaf*" } | ForEach-Object {
+        $itemText = if ( $_.TypeName -eq 'Policy' ) {
+            "'$($_.Path)\"
+        }
+        else {
+            "'$($_.Path)"
+        }
+        [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $_.TypeName)
+
+    }
+}
+Register-ArgumentCompleter -CommandName $vdcCommands -ParameterName 'Path' -ScriptBlock $vdcPathArgCompleterSb
+
+$vcLogArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    if ( -not $script:vcActivityType ) {
+        $script:vcActivityType = Invoke-VenafiRestMethod -UriLeaf 'activitytypes' |
+            Select-Object -Property @{'n' = 'type'; 'e' = { $_.key } }, @{'n' = 'name'; 'e' = { $_.values.key } } -ExcludeProperty readableName |
+            Sort-Object -Property type
+    }
+
+    switch ($parameterName) {
+        'Type' {
+            $script:vcActivityType | Where-Object type -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $itemText = "'{0}'" -f $_.type
+                $itemDescription = 'activity names: {0}' -f ($_.name -join ', ')
+                [System.Management.Automation.CompletionResult]::new($itemText, $itemText, 'ParameterValue', $itemDescription)
+            }
+        }
+
+        'Name' {
+            # If Type is provided, filter names for that type only
+            if ($fakeBoundParameters.ContainsKey('Type')) {
+                $typeValue = $fakeBoundParameters['Type'].Trim("'")
+                $names = $script:vcActivityType | Where-Object { $_.type -eq $typeValue } | Select-Object -ExpandProperty name
+            }
+            else {
+                $names = $script:vcActivityType | Select-Object -ExpandProperty name
+            }
+            $names | Where-Object { $_ -like ('{0}*' -f $wordToComplete.Trim("'")) } | ForEach-Object {
+                $itemText = "'{0}'" -f $_
+                [System.Management.Automation.CompletionResult]::new($itemText)
+            }
+        }
+    }
+}
+Register-ArgumentCompleter -CommandName 'Find-VcLog' -ParameterName 'Type' -ScriptBlock $vcLogArgCompleterSb
+Register-ArgumentCompleter -CommandName 'Find-VcLog' -ParameterName 'Name' -ScriptBlock $vcLogArgCompleterSb
+
+$vdcGenericArgCompleterSb = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    switch ($parameterName) {
+        'Algorithm' {
+            Get-VdcData -Type Algorithm | Where-Object Name -like ('{0}*' -f $wordToComplete.Trim("'")) | ForEach-Object {
+                $alg = "'{0}'" -f $_.Name
+                [System.Management.Automation.CompletionResult]::new($alg, $alg, 'ParameterValue', $_.Description)
+            }
+        }
+    }
+}
+
+'Algorithm' | ForEach-Object {
+    Register-ArgumentCompleter -CommandName $vdcCommands -ParameterName $_ -ScriptBlock $vdcGenericArgCompleterSb
+}
 
 # vaas fields to ensure the values are upper case
 $script:vaasValuesToUpper = 'certificateStatus', 'signatureAlgorithm', 'signatureHashAlgorithm', 'encryptionType', 'versionType', 'certificateSource', 'deploymentStatus'
@@ -65,86 +274,6 @@ $script:vaasFields = @(
     'activityName',
     'criticality'
 )
-
-$vcGenericArgCompleterSb = {
-    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-
-    $objectType = $parameterName
-    if ( $parameterName -eq 'ID' ) {
-        # figure out object type based on function name since 'ID' is used in many functions
-
-    }
-
-    switch ($objectType) {
-        'Application' {
-            if ( -not $script:vcApplication ) {
-                $script:vcApplication = Get-VcApplication -All | Sort-Object -Property name
-            }
-            $script:vcApplication | Where-Object name -like "$wordToComplete*" | ForEach-Object { "'$($_.name)'" }
-        }
-
-        'MachineType' {
-            if ( -not $script:vcMachineType ) {
-                $script:vcMachineType = Invoke-VenafiRestMethod -UriLeaf 'plugins?pluginType=MACHINE' |
-                    Select-Object -ExpandProperty machineTypes |
-                    Select-Object -Property @{'n' = 'machineTypeId'; 'e' = { $_.Id } }, * -ExcludeProperty id |
-                    Sort-Object -Property machineType
-            }
-            $script:vcMachineType | Where-Object name -like "$wordToComplete*" | ForEach-Object { "'$($_.machineType)'" }
-        }
-
-        'IssuingTemplate' {
-            if ( -not $script:vcIssuingTemplate ) {
-                $script:vcIssuingTemplate = Get-VcIssuingTemplate -All | Sort-Object -Property name
-            }
-            $script:vcIssuingTemplate | Where-Object name -like "$wordToComplete*" | ForEach-Object { "'$($_.name)'" }
-        }
-
-        'VSatellite' {
-            if ( -not $script:vcVSatellite ) {
-                $script:vcVSatellite = Get-VcSatellite -All | Sort-Object -Property name
-            }
-            $script:vcVSatellite | Where-Object name -like "$wordToComplete*" | ForEach-Object { "'$($_.name)'" }
-        }
-
-        'Certificate' {
-            # there might be a ton of certs so ensure they provide at least 3 characters
-            if ( $wordToComplete.Length -ge 3 ) {
-                Find-VcCertificate -Name $wordToComplete | ForEach-Object { "'$($_.certificateName)'" }
-            }
-        }
-    }
-}
-
-'Application', 'MachineType', 'VSatellite', 'Certificate', 'IssuingTemplate' | ForEach-Object {
-    Register-ArgumentCompleter -ParameterName $_ -ScriptBlock $vcGenericArgCompleterSb
-}
-
-$vdcPathArgCompleterSb = {
-    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-
-    if ( -not $wordToComplete ) {
-        # if no word provided, default to \ved\policy
-        $wordToComplete = '\VED\Policy\'
-    }
-
-    # if the path starts with ' or ", that will come along for the ride so ensure we trim that first
-    $fullWord = $wordToComplete.Trim("`"'") | ConvertTo-VdcFullPath
-    $leaf = $fullWord.Split('\')[-1]
-    $parent = $fullWord.Substring(0, $fullWord.LastIndexOf("\$leaf"))
-
-    # get items in parent folder
-    $objs = Find-VdcObject -Path $parent
-    $objs | Where-Object { $_.name -like "$leaf*" } | ForEach-Object {
-        if ( $_.TypeName -eq 'Policy' ) {
-            "'$($_.Path)\"
-        }
-        else {
-            "'$($_.Path)"
-        }
-    }
-}
-Register-ArgumentCompleter -CommandName '*-Vdc*' -ParameterName 'Path' -ScriptBlock $vdcPathArgCompleterSb
 
 $script:functionConfig = @{
     'Add-VdcAdaptableHash'             = @{
@@ -418,32 +547,6 @@ $script:functionConfig = @{
     'Write-VdcLog'                     = @{
         'TppVersion'    = ''
         'TppTokenScope' = 'any scope'
-    }
-}
-
-# ModuleVersion will get updated during the build and this will not run
-# this is only needed during development since all files will be merged into one psm1
-if ( $script:DevMode ) {
-    $folders = @('Enum', 'Classes', 'Public', 'Private')
-    $publicFunction = @()
-
-    foreach ( $folder in $folders) {
-
-        $files = Get-ChildItem -Path "$PSScriptRoot\$folder\*.ps1" -Recurse
-
-        Foreach ( $thisFile in $files ) {
-            Try {
-                Write-Verbose ('dot sourcing {0}' -f $thisFile.FullName)
-                . $thisFile.fullname
-                # if ( $folder -eq 'Public' ) {
-                Export-ModuleMember -Function $thisFile.Basename
-                $publicFunction += $thisFile.BaseName
-                # }
-            }
-            Catch {
-                Write-Error ("Failed to import function {0}: {1}" -f $thisFile.fullname, $folder)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
- Add token based authentication to VC with `New-VenafiSession -VcEndpoint` and `New-VcToken`.  If the JWT has not expired, but the access token has, `New-VcToken` supports refresh.
- Caching framework for many VC objects (and some VDC ones as well).  If a requested item is not found, the cache will try and refresh in case it's been created.
- Enhanced tab completion now utilizing the newly caching framework.  A lot more objects are now available via tab completion and will also display a description as well.  For example, VSatellite shows the status and version.  Be sure to set your Tab key functionality with `set-PSReadlineKeyHandler -Key Tab -Function MenuComplete`
 
<img width="1613" alt="image" src="https://github.com/user-attachments/assets/04f84e39-c758-4460-8e5b-05d18e61248e" />

- Add many direct filters to `Find-VcLog` and `Find-VcCertificateRequest` so -Filter can be used less (since it's cumbersome).  The other Find functions will get similar treatment in time.  If you have specific filters you'd like to add, please submit an enhancement request
- Add `Find-VdcCertificate -Algorithm` to support the new pkix algorithms introduced in v25.1.  Tab completion is available with full descriptions.  `New-VdcCertificate` and other applicable functions will be updated in time
- All current VC regions have been added