### PR TITLE
New-VcCertificate defaults, key params

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,2 @@
-- Add cloud provider and keystore management functions `Get-VcCloudProvider`, `Get-VcCloudKeystore`, `New-VcCloudProvider`, `New-VcCloudKeystore`, `Remove-VcCloudProvider`, and `Remove-VcCloudKeystore`, [#352](https://github.com/Venafi/VenafiPS/issues/352)
-- Argument completers added for CloudProvider and CloudKeystore
-- Better graphql error handling and messaging in `Invoke-VcGraphQL`
+- Add support to `New-VcCertificate` for default subject and key values if assigned in template, [#360](https://github.com/Venafi/VenafiPS/issues/360)
+- Add `New-VcCertificate -KeySize` and `New-VcCertificate -KeyCurve`

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -68,7 +68,7 @@ function New-VcCertificate {
 
     .PARAMETER PassThru
     Return the certificate request.
-    If the certificate was successfully issued, it will be returned as the property 'certificate'.
+    If the certificate was successfully issued, it will be returned as the property 'certificate' along with 'certificateId'.
 
     .PARAMETER VenafiSession
     Authentication for the function.
@@ -76,7 +76,7 @@ function New-VcCertificate {
     A TLSPC key can also provided directly.
 
     .INPUTS
-    CommonName
+    none
 
     .OUTPUTS
     pscustomobject, if PassThru is provided

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -303,7 +303,7 @@ function New-VcCertificate {
                     $params.Body.csrAttributes.organizationalUnits = @($OrganizationalUnit)
                 }
                 elseif ( $thisTemplate.recommendedSettings.subjectOUValue ) {
-                    $params.Body.csrAttributes.organizationalUnits = $thisTemplate.recommendedSettings.subjectOUValue
+                    $params.Body.csrAttributes.organizationalUnits = @($thisTemplate.recommendedSettings.subjectOUValue)
                 }
 
                 if ( $PSBoundParameters.ContainsKey('City') ) {

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -128,9 +128,11 @@ function New-VcCertificate {
     param (
 
         [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [String] $Application,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [String] $IssuingTemplate,
 
         [Parameter(ParameterSetName = 'ASK', Mandatory)]
@@ -157,7 +159,16 @@ function New-VcCertificate {
         [ValidateNotNullOrEmpty()]
         [String] $Country,
 
+        [Parameter(ParameterSetName = 'ASK')]
+        [ValidateSet(2048, 3072, 4096)]
+        [Int32] $KeySize,
+
+        [Parameter(ParameterSetName = 'ASK')]
+        [ValidateSet('P256', 'P384', 'P521', 'ED25519')]
+        [string] $KeyCurve,
+
         [Parameter(ParameterSetName = 'CSR', Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string] $Csr,
 
         # [Parameter(ParameterSetName = 'ExistingCSR', Mandatory, ValueFromPipelineByPropertyName)]
@@ -179,14 +190,6 @@ function New-VcCertificate {
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String[]] $SanEmail,
-
-        [Parameter(ParameterSetName = 'ASK')]
-        [ValidateSet(2048, 3072, 4096)]
-        [Int32] $KeySize,
-
-        [Parameter(ParameterSetName = 'ASK')]
-        [ValidateSet('P256', 'P384', 'P521', 'ED25519')]
-        [string] $KeyCurve,
 
         [Parameter()]
         [ValidateScript(
@@ -345,8 +348,8 @@ function New-VcCertificate {
                 }
                 elseif ( $thisTemplate.recommendedSettings.key.type -eq 'EC' ) {
                     $params.Body.csrAttributes.keyTypeParameters = @{
-                        keyType   = 'EC'
-                        keyLength = $thisTemplate.recommendedSettings.key.curve
+                        keyType  = 'EC'
+                        keyCurve = $thisTemplate.recommendedSettings.key.curve
                     }
                 }
             }

--- a/VenafiPS/Public/New-VcCertificate.ps1
+++ b/VenafiPS/Public/New-VcCertificate.ps1
@@ -180,11 +180,11 @@ function New-VcCertificate {
         [ValidateNotNullOrEmpty()]
         [String[]] $SanEmail,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ASK')]
         [ValidateSet(2048, 3072, 4096)]
         [Int32] $KeySize,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ASK')]
         [ValidateSet('P256', 'P384', 'P521', 'ED25519')]
         [string] $KeyCurve,
 


### PR DESCRIPTION
- Add support to `New-VcCertificate` for default subject and key values if assigned in template, closes #360 
- Add `New-VcCertificate -KeySize` and `New-VcCertificate -KeyCurve`