### PR TITLE
ensure parallel calls get a session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Run Pester tests (pwsh)
         run: |
-          Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+          Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSVersion.Minor
           Set-PSRepository psgallery -InstallationPolicy trusted
           Install-Module -Name Pester -confirm:$false -Force
           import-module Pester
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@main
     - name: Run Pester tests (PowerShell)
       run: |
-        Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+        Write-host $PSVersionTable.PSVersion.Major $PSVersionTable.PSVersion.Minor
         Set-PSRepository psgallery -InstallationPolicy trusted
         Install-Module -Name Pester -Confirm:$false -Force
         import-module Pester

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
-- Add `New-VdcCredential` to create a Password, Username Password, or Certificate Credential
-- Add `Invoke-VcCertificateAction -Application` and `-IssuingTemplate` for use during renewal operations to override existing values from certificate request.  The template is optional if only 1 is associated to the application.
-- Enhance `Invoke-VcCertificateAction -Renew` to be smarter about determining the application and issuing template to use.  For example, if the only template on an application was replaced, use the new one for renewal.
-- Fix `Invoke-VcCertificateAction -Renew -Wait` which was not waiting depending on certain statuses.  Add automatic wait for renewal when provisioning afterwards.
+- `Import-VcCertificate` updates:
+    - Fix prompting for VenafiSession even when provided
+    - Remove `-PKCS8` and `-PKCS12`, and soon `-Format`, in favor of autodetection
+    - Add `-Recurse` to bring in certificates in subfolders when importing by path
+    - Add ShouldProcess so `-WhatIf` can be used prior to importing
+    - ThrottleLimit changed to 1 by default as 100 certs are submitted at a time
+- Add PKCS8 support to `Import-VdcCertificate`

--- a/Tests/Import-VcCertificate.Tests.ps1
+++ b/Tests/Import-VcCertificate.Tests.ps1
@@ -1,10 +1,17 @@
 ﻿BeforeAll {
     . $PSScriptRoot/ModuleCommonVc.ps1
 
+    # Ensure ConvertTo-SodiumEncryptedString is available in the module scope for mocking
+    # PSSodium may not be installed (e.g., CI runners)
+    InModuleScope $ModuleName {
+        if (-not (Get-Command 'ConvertTo-SodiumEncryptedString' -ErrorAction SilentlyContinue)) {
+            function script:ConvertTo-SodiumEncryptedString { param($Text, $PublicKey) }
+        }
+    }
+
     $testVsatId = '0bc771e1-7abe-4339-9fcd-93fffe9cba7f'
     $testEncKeyId = 'aaaa1111-bbbb-2222-cccc-333344445555'
     $testEncKey = 'dGVzdGVuY3J5cHRpb25rZXk='
-    $testImportId = 'import-1234-5678-abcd'
 
     $mockVSat = [pscustomobject]@{
         vsatelliteId    = $testVsatId
@@ -12,20 +19,13 @@
         encryptionKey   = $testEncKey
     }
 
-    $mockImportResponse = [pscustomobject]@{
-        id = $testImportId
-    }
-
-    $mockJobCompleted = [pscustomobject]@{
-        status  = 'COMPLETED'
-        results = @(
-            [pscustomobject]@{
-                fingerprint = 'AB:CD:EF:12:34:56'
-                status      = 'IMPORTED'
-                reason      = $null
-            }
-        )
-    }
+    $mockKeyImportResults = @(
+        [pscustomobject]@{
+            fingerprint = 'AB:CD:EF:12:34:56'
+            status      = 'IMPORTED'
+            reason      = $null
+        }
+    )
 
     $mockNoKeyImportResponse = [pscustomobject]@{
         certificateInformations = @(
@@ -65,21 +65,14 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
     Context 'PKCS12 import with key' {
 
         BeforeEach {
-            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates/imports' } -MockWith { $mockImportResponse } -ModuleName $ModuleName
-            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -like 'certificates/imports/*' } -MockWith { $mockJobCompleted } -ModuleName $ModuleName
+            # Mock Invoke-VenafiParallel to avoid PSSodium dependency and verify the params passed
+            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockKeyImportResults } -ModuleName $ModuleName
         }
 
-        It 'Should call the keystore import endpoint' {
+        It 'Should call Invoke-VenafiParallel with VenafiSession' {
             Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $UriLeaf -eq 'certificates/imports' -and $Method -eq 'POST'
-            }
-        }
-
-        It 'Should include vSatellite info in the request body' {
-            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $Body.edgeInstanceId -eq $testVsatId -and $Body.encryptionKeyId -eq $testEncKeyId
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $VenafiSession
             }
         }
 
@@ -93,23 +86,16 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
     Context 'Certificate import without key' {
 
         BeforeEach {
-            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates' -and $Method -eq 'POST' } -MockWith { $mockNoKeyImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockNoKeyImportResponse } -ModuleName $ModuleName
             Mock -CommandName 'Split-CertificateData' -MockWith {
                 @{ CertPem = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA'; KeyPem = $null }
             } -ModuleName $ModuleName
         }
 
-        It 'Should call the no-key import endpoint' {
+        It 'Should call Invoke-VenafiParallel with VenafiSession' {
             Import-VcCertificate -Data $testCertPem -Format 'X509'
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $UriLeaf -eq 'certificates' -and $UriRoot -eq 'outagedetection/v1'
-            }
-        }
-
-        It 'Should include overrideBlocklist in the body' {
-            Import-VcCertificate -Data $testCertPem -Format 'X509'
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $null -ne $Body.overrideBlocklist
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $VenafiSession
             }
         }
 
@@ -127,7 +113,7 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
         }
 
         It 'Should throw when importing with key but no password' {
-            Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith { $mockImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiParallel' -MockWith {} -ModuleName $ModuleName
             Mock -CommandName 'Split-CertificateData' -MockWith {
                 @{ CertPem = 'certdata'; KeyPem = 'keydata' }
             } -ModuleName $ModuleName
@@ -138,15 +124,12 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
     Context 'Format parameter' {
 
         BeforeEach {
-            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates/imports' } -MockWith { $mockImportResponse } -ModuleName $ModuleName
-            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -like 'certificates/imports/*' } -MockWith { $mockJobCompleted } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockKeyImportResults } -ModuleName $ModuleName
         }
 
         It 'Should accept PKCS12 format' {
             Import-VcCertificate -Data $testPkcs12Data -Format 'PKCS12' -PrivateKeyPassword 'pass'
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $UriLeaf -eq 'certificates/imports'
-            }
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
         }
 
         It 'Should warn about deprecated PKCS12 switch' {

--- a/Tests/Import-VcCertificate.Tests.ps1
+++ b/Tests/Import-VcCertificate.Tests.ps1
@@ -1,0 +1,157 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testVsatId = '0bc771e1-7abe-4339-9fcd-93fffe9cba7f'
+    $testEncKeyId = 'aaaa1111-bbbb-2222-cccc-333344445555'
+    $testEncKey = 'dGVzdGVuY3J5cHRpb25rZXk='
+    $testImportId = 'import-1234-5678-abcd'
+
+    $mockVSat = [pscustomobject]@{
+        vsatelliteId    = $testVsatId
+        encryptionKeyId = $testEncKeyId
+        encryptionKey   = $testEncKey
+    }
+
+    $mockImportResponse = [pscustomobject]@{
+        id = $testImportId
+    }
+
+    $mockJobCompleted = [pscustomobject]@{
+        status  = 'COMPLETED'
+        results = @(
+            [pscustomobject]@{
+                fingerprint = 'AB:CD:EF:12:34:56'
+                status      = 'IMPORTED'
+                reason      = $null
+            }
+        )
+    }
+
+    $mockNoKeyImportResponse = [pscustomobject]@{
+        certificateInformations = @(
+            [pscustomobject]@{
+                id          = '11111111-2222-3333-4444-555555555555'
+                fingerprint = 'AB:CD:EF:12:34:56'
+            }
+        )
+        statistics = [pscustomobject]@{
+            totalCount   = 1
+            successCount = 1
+            failureCount = 0
+        }
+    }
+
+    # minimal PKCS12 data (base64 placeholder)
+    $testPkcs12Data = 'MIIBIjANBg=='
+
+    # minimal PEM cert (no key)
+    $testCertPem = @"
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+-----END CERTIFICATE-----
+"@
+}
+
+Describe 'Import-VcCertificate' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Initialize-PSSodium' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $mockVSat } -ModuleName $ModuleName
+        Mock -CommandName 'ConvertTo-SodiumEncryptedString' -MockWith { 'encrypted-password' } -ModuleName $ModuleName
+        Mock -CommandName 'ConvertTo-PlaintextString' -MockWith { 'plaintext' } -ModuleName $ModuleName
+    }
+
+    Context 'PKCS12 import with key' {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates/imports' } -MockWith { $mockImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -like 'certificates/imports/*' } -MockWith { $mockJobCompleted } -ModuleName $ModuleName
+        }
+
+        It 'Should call the keystore import endpoint' {
+            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $UriLeaf -eq 'certificates/imports' -and $Method -eq 'POST'
+            }
+        }
+
+        It 'Should include vSatellite info in the request body' {
+            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Body.edgeInstanceId -eq $testVsatId -and $Body.encryptionKeyId -eq $testEncKeyId
+            }
+        }
+
+        It 'Should return fingerprint and status' {
+            $result = Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
+            $result.fingerprint | Should -Be 'AB:CD:EF:12:34:56'
+            $result.status | Should -Be 'IMPORTED'
+        }
+    }
+
+    Context 'Certificate import without key' {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates' -and $Method -eq 'POST' } -MockWith { $mockNoKeyImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Split-CertificateData' -MockWith {
+                @{ CertPem = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA'; KeyPem = $null }
+            } -ModuleName $ModuleName
+        }
+
+        It 'Should call the no-key import endpoint' {
+            Import-VcCertificate -Data $testCertPem -Format 'X509'
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $UriLeaf -eq 'certificates' -and $UriRoot -eq 'outagedetection/v1'
+            }
+        }
+
+        It 'Should include overrideBlocklist in the body' {
+            Import-VcCertificate -Data $testCertPem -Format 'X509'
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $Body.overrideBlocklist
+            }
+        }
+
+        It 'Should return certificate info and statistics' {
+            $result = Import-VcCertificate -Data $testCertPem -Format 'X509'
+            $result.statistics | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Error handling' {
+
+        It 'Should throw when no active VSatellites found' {
+            Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $null } -ModuleName $ModuleName
+            { Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass' } | Should -Throw '*VSatellite*'
+        }
+
+        It 'Should throw when importing with key but no password' {
+            Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith { $mockImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Split-CertificateData' -MockWith {
+                @{ CertPem = 'certdata'; KeyPem = 'keydata' }
+            } -ModuleName $ModuleName
+            { Import-VcCertificate -Data $testCertPem -Format 'PKCS8' } | Should -Throw '*PrivateKeyPassword*'
+        }
+    }
+
+    Context 'Format parameter' {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -eq 'certificates/imports' } -MockWith { $mockImportResponse } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiRestMethod' -ParameterFilter { $UriLeaf -like 'certificates/imports/*' } -MockWith { $mockJobCompleted } -ModuleName $ModuleName
+        }
+
+        It 'Should accept PKCS12 format' {
+            Import-VcCertificate -Data $testPkcs12Data -Format 'PKCS12' -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $UriLeaf -eq 'certificates/imports'
+            }
+        }
+
+        It 'Should warn about deprecated PKCS12 switch' {
+            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass' -WarningVariable warn -WarningAction SilentlyContinue
+            $warn | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Import-VcCertificate.Tests.ps1
+++ b/Tests/Import-VcCertificate.Tests.ps1
@@ -41,15 +41,33 @@
         }
     }
 
-    # minimal PKCS12 data (base64 placeholder)
+    # PKCS12 data (does NOT start with LS0 or -----BEGIN)
     $testPkcs12Data = 'MIIBIjANBg=='
 
-    # minimal PEM cert (no key)
+    # PEM cert only (no key)
     $testCertPem = @"
 -----BEGIN CERTIFICATE-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
 -----END CERTIFICATE-----
 "@
+
+    # PEM cert + encrypted private key
+    $testCertAndKeyPem = @"
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFLjBYBgkqhkiG9w0BBQ0wSzAqBgkqhkiG9w0BBQww
+-----END ENCRYPTED PRIVATE KEY-----
+"@
+
+    # base64-encode PEM strings (simulating Export-VdcCertificate / Export-VcCertificate output)
+    $testCertPemBase64 = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::ASCII.GetBytes($testCertPem)
+    )
+    $testCertAndKeyPemBase64 = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::ASCII.GetBytes($testCertAndKeyPem)
+    )
 }
 
 Describe 'Import-VcCertificate' -Tags 'Unit' {
@@ -60,48 +78,86 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
         Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $mockVSat } -ModuleName $ModuleName
         Mock -CommandName 'ConvertTo-SodiumEncryptedString' -MockWith { 'encrypted-password' } -ModuleName $ModuleName
         Mock -CommandName 'ConvertTo-PlaintextString' -MockWith { 'plaintext' } -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockKeyImportResults } -ModuleName $ModuleName
     }
 
-    Context 'PKCS12 import with key' {
+    Context 'PKCS12 auto-detection' {
 
-        BeforeEach {
-            # Mock Invoke-VenafiParallel to avoid PSSodium dependency and verify the params passed
-            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockKeyImportResults } -ModuleName $ModuleName
-        }
-
-        It 'Should call Invoke-VenafiParallel with VenafiSession' {
-            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
+        It 'Should detect PKCS12 data and import with key' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
             Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
                 $null -ne $VenafiSession
             }
         }
 
         It 'Should return fingerprint and status' {
-            $result = Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass'
+            $result = Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
             $result.fingerprint | Should -Be 'AB:CD:EF:12:34:56'
             $result.status | Should -Be 'IMPORTED'
         }
     }
 
-    Context 'Certificate import without key' {
+    Context 'PEM auto-detection (base64-encoded)' {
 
         BeforeEach {
-            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockNoKeyImportResponse } -ModuleName $ModuleName
             Mock -CommandName 'Split-CertificateData' -MockWith {
-                @{ CertPem = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA'; KeyPem = $null }
+                @{ CertPem = "-----BEGIN CERTIFICATE-----`nMIIBIj`n-----END CERTIFICATE-----"; KeyPem = "-----BEGIN ENCRYPTED PRIVATE KEY-----`nMIIFLj`n-----END ENCRYPTED PRIVATE KEY-----"; ChainPem = @() }
             } -ModuleName $ModuleName
         }
 
-        It 'Should call Invoke-VenafiParallel with VenafiSession' {
-            Import-VcCertificate -Data $testCertPem -Format 'X509'
-            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $null -ne $VenafiSession
-            }
+        It 'Should detect base64-encoded PEM (LS0 prefix) and call Split-CertificateData' {
+            Import-VcCertificate -Data $testCertAndKeyPemBase64 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Split-CertificateData' -Times 1 -ModuleName $ModuleName
         }
 
-        It 'Should return certificate info and statistics' {
-            $result = Import-VcCertificate -Data $testCertPem -Format 'X509'
+        It 'Should add cert with key to keyed imports' {
+            Import-VcCertificate -Data $testCertAndKeyPemBase64 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
+        }
+    }
+
+    Context 'PEM auto-detection (raw PEM)' {
+
+        BeforeEach {
+            Mock -CommandName 'Split-CertificateData' -MockWith {
+                @{ CertPem = "-----BEGIN CERTIFICATE-----`nMIIBIj`n-----END CERTIFICATE-----"; KeyPem = $null; ChainPem = @() }
+            } -ModuleName $ModuleName
+            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockNoKeyImportResponse } -ModuleName $ModuleName
+        }
+
+        It 'Should detect raw PEM and call Split-CertificateData' {
+            Import-VcCertificate -Data $testCertPem
+            Should -Invoke -CommandName 'Split-CertificateData' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should add cert without key to no-key imports' {
+            $result = Import-VcCertificate -Data $testCertPem
             $result.statistics | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'PrivateKeyPassword handling' {
+
+        It 'Should convert PrivateKeyPassword in begin when passed directly' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -ModuleName $ModuleName
+        }
+
+        It 'Should accept SecureString for PrivateKeyPassword' {
+            $secPass = 'pass' | ConvertTo-SecureString -AsPlainText -Force
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword $secPass
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -ModuleName $ModuleName
+        }
+
+        It 'Should accept PSCredential for PrivateKeyPassword' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword $cred
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -ModuleName $ModuleName
+        }
+
+        It 'Should accept PrivateKeyPassword via pipeline' {
+            [pscustomobject]@{ Data = $testPkcs12Data; PrivateKeyPassword = 'pipelinePass' } | Import-VcCertificate
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -ModuleName $ModuleName
         }
     }
 
@@ -109,32 +165,73 @@ Describe 'Import-VcCertificate' -Tags 'Unit' {
 
         It 'Should throw when no active VSatellites found' {
             Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $null } -ModuleName $ModuleName
-            { Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass' } | Should -Throw '*VSatellite*'
+            { Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass' } | Should -Throw '*VSatellite*'
         }
 
         It 'Should throw when importing with key but no password' {
-            Mock -CommandName 'Invoke-VenafiParallel' -MockWith {} -ModuleName $ModuleName
             Mock -CommandName 'Split-CertificateData' -MockWith {
-                @{ CertPem = 'certdata'; KeyPem = 'keydata' }
+                @{ CertPem = 'certdata'; KeyPem = 'keydata'; ChainPem = @() }
             } -ModuleName $ModuleName
-            { Import-VcCertificate -Data $testCertPem -Format 'PKCS8' } | Should -Throw '*PrivateKeyPassword*'
+            { Import-VcCertificate -Data $testCertAndKeyPemBase64 } | Should -Throw '*PrivateKeyPassword*'
         }
     }
 
-    Context 'Format parameter' {
+    Context 'VenafiSession and ThrottleLimit' {
 
-        BeforeEach {
-            Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockKeyImportResults } -ModuleName $ModuleName
+        It 'Should pass VenafiSession to Invoke-VenafiParallel' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $VenafiSession
+            }
         }
 
-        It 'Should accept PKCS12 format' {
-            Import-VcCertificate -Data $testPkcs12Data -Format 'PKCS12' -PrivateKeyPassword 'pass'
+        It 'Should default ThrottleLimit to 1' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $ThrottleLimit -eq 1
+            }
+        }
+    }
+
+    Context 'Pipeline input' {
+
+        It 'Should accept Data via pipeline' {
+            [pscustomobject]@{ Data = $testPkcs12Data; PrivateKeyPassword = 'pass' } | Import-VcCertificate
             Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
         }
 
-        It 'Should warn about deprecated PKCS12 switch' {
-            Import-VcCertificate -Data $testPkcs12Data -PKCS12 -PrivateKeyPassword 'pass' -WarningVariable warn -WarningAction SilentlyContinue
-            $warn | Should -Not -BeNullOrEmpty
+        It 'Should accept multiple objects via pipeline' {
+            @(
+                [pscustomobject]@{ Data = $testPkcs12Data; PrivateKeyPassword = 'pass' }
+                [pscustomobject]@{ Data = $testPkcs12Data; PrivateKeyPassword = 'pass' }
+            ) | Import-VcCertificate
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should accept CertificateData alias via pipeline' {
+            [pscustomobject]@{ certificateData = $testPkcs12Data; PrivateKeyPassword = 'pass' } | Import-VcCertificate
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
+        }
+    }
+
+    Context 'Format parameter (legacy compatibility)' {
+
+        It 'Should accept Format parameter without error' {
+            Import-VcCertificate -Data $testPkcs12Data -Format 'PKCS12' -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
+        }
+    }
+
+    Context 'Sodium encryption' {
+
+        It 'Should call Initialize-PSSodium in begin' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Initialize-PSSodium' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should call ConvertTo-SodiumEncryptedString for keyed imports' {
+            Import-VcCertificate -Data $testPkcs12Data -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'ConvertTo-SodiumEncryptedString' -Times 1 -ModuleName $ModuleName
         }
     }
 }

--- a/Tests/Import-VdcCertificate.Tests.ps1
+++ b/Tests/Import-VdcCertificate.Tests.ps1
@@ -1,0 +1,350 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVdc.ps1
+
+    $testPolicyPath = '\VED\Policy\certificates'
+    $testCertGuid = '{12345678-1234-1234-1234-123456789012}'
+
+    # PEM cert only (no key)
+    $testCertPem = @"
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+-----END CERTIFICATE-----
+"@
+
+    # PEM cert + encrypted private key (PKCS8)
+    $testCertAndKeyPem = @"
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFLjBYBgkqhkiG9w0BBQ0wSzAqBgkqhkiG9w0BBQww
+-----END ENCRYPTED PRIVATE KEY-----
+"@
+
+    # base64-encode the PEM strings (simulating Export-VcCertificate output)
+    $testCertPemBase64 = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::ASCII.GetBytes($testCertPem)
+    )
+    $testCertAndKeyPemBase64 = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::ASCII.GetBytes($testCertAndKeyPem)
+    )
+
+    # PKCS12 data (does NOT start with LS0)
+    $testPkcs12Data = 'MIIKYQIBAzCCCicGCSqGSIb3DQEHAaCCChg=='
+
+    $mockImportResponse = [pscustomobject]@{
+        CertificateDN    = "$testPolicyPath\test.venafi.com"
+        CertificateVaultId = 12345
+        Guid             = $testCertGuid
+        PrivateKeyVaultId = 67890
+    }
+
+    $mockVdcObject = [pscustomobject]@{
+        Path     = "$testPolicyPath\test.venafi.com"
+        Name     = 'test.venafi.com'
+        TypeName = 'X509 Server Certificate'
+        Guid     = $testCertGuid
+    }
+}
+
+Describe 'Import-VdcCertificate' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'ConvertTo-VdcFullPath' -MockWith { $testPolicyPath } -ModuleName $ModuleName
+        Mock -CommandName 'Test-VdcObject' -MockWith { $true } -ModuleName $ModuleName
+        Mock -CommandName 'ConvertTo-PlaintextString' -MockWith { 'plaintext' } -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiParallel' -MockWith {
+            # simulate the scriptblock execution by returning the mock response
+            $mockImportResponse
+        } -ModuleName $ModuleName
+        Mock -CommandName 'Get-VdcObject' -MockWith { $mockVdcObject } -ModuleName $ModuleName
+    }
+
+    Context 'PKCS12 data import via -Data' {
+
+        It 'Should pass PKCS12 data directly as CertificateData' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testPkcs12Data
+            }
+        }
+
+        It 'Should set the policy path in the body' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.Body.PolicyDN -eq $testPolicyPath
+            }
+        }
+
+        It 'Should call certificates/import endpoint' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.UriLeaf -eq 'certificates/import' -and
+                $InputObject[0].InvokeParams.Method -eq 'Post'
+            }
+        }
+    }
+
+    Context 'Base64-encoded PEM cert-only import' {
+
+        It 'Should detect PEM data starting with LS0' {
+            $testCertPemBase64 | Should -Match '^LS0'
+        }
+
+        It 'Should pass base64-encoded PEM to Invoke-VenafiParallel' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testCertPemBase64
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testCertPemBase64
+            }
+        }
+    }
+
+    Context 'Base64-encoded PEM cert+key (PKCS8) import' {
+
+        It 'Should pass full cert+key base64 data to Invoke-VenafiParallel' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testCertAndKeyPemBase64 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testCertAndKeyPemBase64
+            }
+        }
+    }
+
+    Context 'Separate PrivateKey parameter' {
+
+        It 'Should set PrivateKeyData in the body when -PrivateKey is provided' {
+            $testKeyData = 'base64keydata=='
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testCertPemBase64 -PrivateKey $testKeyData -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.Body.PrivateKeyData -eq $testKeyData
+            }
+        }
+    }
+
+    Context 'PrivateKeyPassword handling' {
+
+        It 'Should set Password in body when PrivateKeyPassword provided as string' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -PrivateKeyPassword 'myPassword!'
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -Times 1 -ModuleName $ModuleName
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.Body.Password -eq 'plaintext'
+            }
+        }
+
+        It 'Should accept SecureString for PrivateKeyPassword' {
+            $secPass = 'myPassword!' | ConvertTo-SecureString -AsPlainText -Force
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -PrivateKeyPassword $secPass
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should accept PSCredential for PrivateKeyPassword' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -PrivateKeyPassword $cred
+            Should -Invoke -CommandName 'ConvertTo-PlaintextString' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should not set Password when PrivateKeyPassword not provided' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                -not $InputObject[0].InvokeParams.Body.ContainsKey('Password')
+            }
+        }
+    }
+
+    Context 'Reconcile' {
+
+        It 'Should set Reconcile in body when switch is used' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -Reconcile
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.Body.Reconcile -eq 'true'
+            }
+        }
+
+        It 'Should not set Reconcile when switch is not used' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                -not $InputObject[0].InvokeParams.Body.ContainsKey('Reconcile')
+            }
+        }
+    }
+
+    Context 'Name parameter' {
+
+        It 'Should set ObjectName when -Name is provided' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -Name 'MyCert'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].InvokeParams.Body.ObjectName -eq 'MyCert'
+            }
+        }
+
+        It 'Should not set ObjectName when -Name is not provided' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                -not $InputObject[0].InvokeParams.Body.ContainsKey('ObjectName')
+            }
+        }
+    }
+
+    Context 'EnrollmentAttribute' {
+
+        It 'Should set CASpecificAttributes when EnrollmentAttribute is provided' {
+            $attrs = @{ 'san-dns' = 'test.com'; 'Validity' = '365' }
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -EnrollmentAttribute $attrs
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $InputObject[0].InvokeParams.Body.CASpecificAttributes
+            }
+        }
+    }
+
+    Context 'Policy path handling' {
+
+        It 'Should call ConvertTo-VdcFullPath to normalize the path' {
+            Import-VdcCertificate -PolicyPath 'certificates' -Data $testPkcs12Data
+            Should -Invoke -CommandName 'ConvertTo-VdcFullPath' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should check if the policy path exists' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Test-VdcObject' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Path -eq $testPolicyPath -and $ExistOnly -eq $true
+            }
+        }
+
+        It 'Should write error when policy path does not exist without Force' {
+            Mock -CommandName 'Test-VdcObject' -MockWith { $false } -ModuleName $ModuleName
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -ErrorVariable err -ErrorAction SilentlyContinue
+            $err | Should -Not -BeNullOrEmpty
+            $err[0].Exception.Message | Should -Match 'does not exist'
+        }
+
+        It 'Should create policy path when Force is used and path does not exist' {
+            Mock -CommandName 'Test-VdcObject' -MockWith { $false } -ModuleName $ModuleName
+            Mock -CommandName 'New-VdcPolicy' -MockWith {} -ModuleName $ModuleName
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -Force
+            Should -Invoke -CommandName 'New-VdcPolicy' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Path -eq $testPolicyPath -and $Force -eq $true
+            }
+        }
+
+        It 'Should not create policy path when it already exists' {
+            Mock -CommandName 'New-VdcPolicy' -MockWith {} -ModuleName $ModuleName
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -Force
+            Should -Invoke -CommandName 'New-VdcPolicy' -Times 0 -ModuleName $ModuleName
+        }
+    }
+
+    Context 'VenafiSession parameter' {
+
+        It 'Should pass VenafiSession to Invoke-VenafiParallel' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $VenafiSession
+            }
+        }
+    }
+
+    Context 'ThrottleLimit' {
+
+        It 'Should pass ThrottleLimit to Invoke-VenafiParallel' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data -ThrottleLimit 5
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $ThrottleLimit -eq 5
+            }
+        }
+
+        It 'Should default ThrottleLimit to 100' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $ThrottleLimit -eq 100
+            }
+        }
+    }
+
+    Context 'Pipeline input' {
+
+        It 'Should accept multiple objects via pipeline' {
+            @(
+                [pscustomobject]@{ Data = $testPkcs12Data; PolicyPath = $testPolicyPath }
+                [pscustomobject]@{ Data = $testPkcs12Data; PolicyPath = $testPolicyPath }
+            ) | Import-VdcCertificate
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject.Count -eq 2
+            }
+        }
+
+        It 'Should accept CertificateData alias' {
+            [pscustomobject]@{ CertificateData = $testPkcs12Data; PolicyPath = $testPolicyPath } | Import-VdcCertificate
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testPkcs12Data
+            }
+        }
+    }
+
+    Context 'ScriptBlock PEM splitting logic' {
+
+        # The scriptblock inside Invoke-VenafiParallel does the PEM detection/splitting.
+        # We can't easily test the real scriptblock in isolation, so we verify the
+        # data that flows INTO Invoke-VenafiParallel is correct, and that the
+        # detection patterns work as expected.
+
+        It 'Should detect base64-encoded PEM (LS0 prefix) correctly' {
+            $testCertAndKeyPemBase64 | Should -Match '^LS0'
+        }
+
+        It 'Should NOT detect PKCS12 data as PEM' {
+            $testPkcs12Data | Should -Not -Match '^LS0'
+            $testPkcs12Data | Should -Not -Match '-----BEGIN'
+        }
+
+        It 'Should detect raw PEM data correctly' {
+            $testCertAndKeyPem | Should -Match '-----BEGIN'
+        }
+
+        It 'Should pass base64-encoded cert+key PEM as-is to Invoke-VenafiParallel Data' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testCertAndKeyPemBase64 -PrivateKeyPassword 'pass'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testCertAndKeyPemBase64
+            }
+        }
+
+        It 'Should pass PKCS12 as-is to Invoke-VenafiParallel Data' {
+            Import-VdcCertificate -PolicyPath $testPolicyPath -Data $testPkcs12Data
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].Data -eq $testPkcs12Data
+            }
+        }
+    }
+
+    Context 'Split-CertificateData behavior' {
+
+        # Verify that Split-CertificateData correctly splits the test PEM data
+        # that would be passed through the scriptblock
+
+        It 'Should split base64-encoded cert+key PEM into CertPem and KeyPem' {
+            InModuleScope $ModuleName -Parameters @{ data = $testCertAndKeyPemBase64 } {
+                param($data)
+                $result = Split-CertificateData -InputObject $data
+                $result.CertPem | Should -Match '-----BEGIN CERTIFICATE-----'
+                $result.KeyPem | Should -Match '-----BEGIN ENCRYPTED PRIVATE KEY-----'
+            }
+        }
+
+        It 'Should split base64-encoded cert-only PEM with no key' {
+            InModuleScope $ModuleName -Parameters @{ data = $testCertPemBase64 } {
+                param($data)
+                $result = Split-CertificateData -InputObject $data
+                $result.CertPem | Should -Match '-----BEGIN CERTIFICATE-----'
+                $result.KeyPem | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should split raw PEM cert+key into parts' {
+            InModuleScope $ModuleName -Parameters @{ data = $testCertAndKeyPem } {
+                param($data)
+                $result = Split-CertificateData -InputObject $data
+                $result.CertPem | Should -Match '-----BEGIN CERTIFICATE-----'
+                $result.KeyPem | Should -Match '-----BEGIN ENCRYPTED PRIVATE KEY-----'
+            }
+        }
+    }
+}

--- a/Tests/New-VcMachine.Tests.ps1
+++ b/Tests/New-VcMachine.Tests.ps1
@@ -1,6 +1,14 @@
 ﻿BeforeAll {
     . $PSScriptRoot/ModuleCommonVc.ps1
 
+    # Ensure ConvertTo-SodiumEncryptedString is available in the module scope for mocking
+    # PSSodium may not be installed (e.g., CI runners)
+    InModuleScope $ModuleName {
+        if (-not (Get-Command 'ConvertTo-SodiumEncryptedString' -ErrorAction SilentlyContinue)) {
+            function script:ConvertTo-SodiumEncryptedString { param($Text, $PublicKey) }
+        }
+    }
+
     $testMachineId = 'cf7cfdc0-2b2a-11ee-9546-5136c4b21504'
     $testTeamId = '59920180-a3e2-11ec-8dcd-3fcbf84c7da7'
     $testPluginId = 'ff645e14-bd1a-11ed-a009-ce063932f86d'
@@ -34,10 +42,29 @@
         owningTeamId     = $testTeamId
     }
 
-    $mockWorkflowResponse = [pscustomobject]@{
-        Success    = $true
-        Error      = $null
-        WorkflowID = 'c39310ee-51fc-49f3-8b5b-e504e1bc43d2'
+    # This is the shape returned by Invoke-VenafiParallel after the scriptblock runs
+    $mockParallelResponseNoVerify = [pscustomobject]@{
+        machineId        = $testMachineId
+        companyId        = '20b24f81-b22b-11ea-91f3-ebd6dea5453f'
+        name             = 'c1'
+        machineType      = 'Citrix ADC'
+        pluginId         = $testPluginId
+        integrationId    = 'cf7c8014-2b2a-11ee-9a03-fa8930555887'
+        edgeInstanceId   = $testVsatId
+        creationDate     = (Get-Date).ToString('o')
+        modificationDate = (Get-Date).ToString('o')
+        status           = 'UNVERIFIED'
+        owningTeamId     = $testTeamId
+    }
+
+    $mockParallelResponseWithVerify = [pscustomobject]@{
+        machineId      = $testMachineId
+        testConnection = [pscustomobject]@{
+            Success    = $true
+            Error      = $null
+            WorkflowID = 'c39310ee-51fc-49f3-8b5b-e504e1bc43d2'
+        }
+        name           = 'c1'
     }
 }
 
@@ -50,49 +77,34 @@ Describe 'New-VcMachine' -Tags 'Unit' {
         Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'Team' } -MockWith { $testTeamId } -ModuleName $ModuleName
         Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $mockVSat } -ModuleName $ModuleName
         Mock -CommandName 'ConvertTo-SodiumEncryptedString' -MockWith { 'encrypted' } -ModuleName $ModuleName
-        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith { $mockCreateResponse } -ModuleName $ModuleName
-        Mock -CommandName 'Invoke-VcWorkflow' -MockWith { $mockWorkflowResponse } -ModuleName $ModuleName
+        # Mock Invoke-VenafiParallel to avoid needing Invoke-VenafiRestMethod/Invoke-VcWorkflow inside scriptblock
+        Mock -CommandName 'Invoke-VenafiParallel' -MockWith { $mockParallelResponseWithVerify } -ModuleName $ModuleName
     }
 
     Context 'Basic machine creation' {
 
-        It 'Should call the create API' {
+        It 'Should call Invoke-VenafiParallel with VenafiSession' {
             $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
             New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $Method -eq 'Post' -and $UriLeaf -eq 'machines'
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $null -ne $VenafiSession
             }
         }
 
-        It 'Should use hostname as name when hostname not provided' {
-            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
-            New-VcMachine -Name 'c1.company.com' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $Body.connectionDetails.hostnameOrAddress -eq 'c1.company.com'
-            }
-        }
-
-        It 'Should use explicit hostname when provided' {
-            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
-            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Hostname 'c1.company.com' -Credential $cred
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
-                $Body.connectionDetails.hostnameOrAddress -eq 'c1.company.com'
-            }
-        }
-    }
-
-    Context 'Test connection' {
-
-        It 'Should invoke test workflow by default' {
+        It 'Should pass machine data to Invoke-VenafiParallel' {
             $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
             New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
-            Should -Invoke -CommandName 'Invoke-VcWorkflow' -Times 1 -ModuleName $ModuleName
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject.Count -eq 1 -and $InputObject[0].name -eq 'c1'
+            }
         }
 
-        It 'Should skip test workflow with NoVerify' {
+        It 'Should set pluginId from machine type lookup' {
             $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
-            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify
-            Should -Invoke -CommandName 'Invoke-VcWorkflow' -Times 0 -ModuleName $ModuleName
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $InputObject[0].pluginId -eq $testPluginId
+            }
         }
     }
 
@@ -100,13 +112,13 @@ Describe 'New-VcMachine' -Tags 'Unit' {
 
         It 'Should not return output without PassThru' {
             $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
-            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify
+            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
             $result | Should -BeNullOrEmpty
         }
 
         It 'Should return machine details with PassThru' {
             $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
-            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify -PassThru
+            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -PassThru
             $result | Should -Not -BeNullOrEmpty
             $result.machineId | Should -Be $testMachineId
         }
@@ -138,8 +150,8 @@ Describe 'New-VcMachine' -Tags 'Unit' {
                 MachineType = 'Citrix ADC'
                 Owner       = 'MyTeam'
                 Credential  = $cred
-            } | New-VcMachine -NoVerify
-            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+            } | New-VcMachine
+            Should -Invoke -CommandName 'Invoke-VenafiParallel' -Times 1 -ModuleName $ModuleName
         }
     }
 }

--- a/Tests/New-VcMachine.Tests.ps1
+++ b/Tests/New-VcMachine.Tests.ps1
@@ -1,0 +1,145 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testMachineId = 'cf7cfdc0-2b2a-11ee-9546-5136c4b21504'
+    $testTeamId = '59920180-a3e2-11ec-8dcd-3fcbf84c7da7'
+    $testPluginId = 'ff645e14-bd1a-11ed-a009-ce063932f86d'
+    $testVsatId = '0bc771e1-7abe-4339-9fcd-93fffe9cba7f'
+    $testEncKeyId = 'aaaa1111-bbbb-2222-cccc-333344445555'
+    $testEncKey = 'dGVzdGVuY3J5cHRpb25rZXk='
+
+    $mockPlugin = [pscustomobject]@{
+        pluginId = $testPluginId
+        name     = 'Citrix ADC'
+    }
+
+    $mockVSat = [pscustomobject]@{
+        vsatelliteId    = $testVsatId
+        encryptionKeyId = $testEncKeyId
+        encryptionKey   = $testEncKey
+        edgeStatus      = 'ACTIVE'
+    }
+
+    $mockCreateResponse = [pscustomobject]@{
+        id               = $testMachineId
+        companyId        = '20b24f81-b22b-11ea-91f3-ebd6dea5453f'
+        name             = 'c1'
+        machineType      = 'Citrix ADC'
+        pluginId         = $testPluginId
+        integrationId    = 'cf7c8014-2b2a-11ee-9a03-fa8930555887'
+        edgeInstanceId   = $testVsatId
+        creationDate     = (Get-Date).ToString('o')
+        modificationDate = (Get-Date).ToString('o')
+        status           = 'UNVERIFIED'
+        owningTeamId     = $testTeamId
+    }
+
+    $mockWorkflowResponse = [pscustomobject]@{
+        Success    = $true
+        Error      = $null
+        WorkflowID = 'c39310ee-51fc-49f3-8b5b-e504e1bc43d2'
+    }
+}
+
+Describe 'New-VcMachine' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Initialize-PSSodium' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'Plugin' } -MockWith { $mockPlugin } -ModuleName $ModuleName
+        Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'Team' } -MockWith { $testTeamId } -ModuleName $ModuleName
+        Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'VSatellite' } -MockWith { $mockVSat } -ModuleName $ModuleName
+        Mock -CommandName 'ConvertTo-SodiumEncryptedString' -MockWith { 'encrypted' } -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith { $mockCreateResponse } -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VcWorkflow' -MockWith { $mockWorkflowResponse } -ModuleName $ModuleName
+    }
+
+    Context 'Basic machine creation' {
+
+        It 'Should call the create API' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Method -eq 'Post' -and $UriLeaf -eq 'machines'
+            }
+        }
+
+        It 'Should use hostname as name when hostname not provided' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1.company.com' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Body.connectionDetails.hostnameOrAddress -eq 'c1.company.com'
+            }
+        }
+
+        It 'Should use explicit hostname when provided' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Hostname 'c1.company.com' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+                $Body.connectionDetails.hostnameOrAddress -eq 'c1.company.com'
+            }
+        }
+    }
+
+    Context 'Test connection' {
+
+        It 'Should invoke test workflow by default' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-VcWorkflow' -Times 1 -ModuleName $ModuleName
+        }
+
+        It 'Should skip test workflow with NoVerify' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify
+            Should -Invoke -CommandName 'Invoke-VcWorkflow' -Times 0 -ModuleName $ModuleName
+        }
+    }
+
+    Context 'PassThru' {
+
+        It 'Should not return output without PassThru' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return machine details with PassThru' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            $result = New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'MyTeam' -Credential $cred -NoVerify -PassThru
+            $result | Should -Not -BeNullOrEmpty
+            $result.machineId | Should -Be $testMachineId
+        }
+    }
+
+    Context 'Invalid input' {
+
+        It 'Should error on invalid machine type' {
+            Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'Plugin' } -MockWith { $null } -ModuleName $ModuleName
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'BadType' -Owner 'MyTeam' -Credential $cred -ErrorVariable err -ErrorAction SilentlyContinue
+            $err | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should error on invalid owner' {
+            Mock -CommandName 'Get-VcData' -ParameterFilter { $Type -eq 'Team' } -MockWith { $null } -ModuleName $ModuleName
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            New-VcMachine -Name 'c1' -MachineType 'Citrix ADC' -Owner 'BadTeam' -Credential $cred -ErrorVariable err -ErrorAction SilentlyContinue
+            $err | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Pipeline input' {
+
+        It 'Should accept pipeline input' {
+            $cred = New-Object PSCredential('user', ('pass' | ConvertTo-SecureString -AsPlainText -Force))
+            [pscustomobject]@{
+                Name        = 'c1'
+                MachineType = 'Citrix ADC'
+                Owner       = 'MyTeam'
+                Credential  = $cred
+            } | New-VcMachine -NoVerify
+            Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+        }
+    }
+}

--- a/Tests/Remove-VcApplication.Tests.ps1
+++ b/Tests/Remove-VcApplication.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcApplication' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint and UriRoot' {
+        Remove-VcApplication -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriRoot -eq 'outagedetection/v1' -and $UriLeaf -eq "applications/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcApplication -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcApplication -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcApplication -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcIssuingTemplate.Tests.ps1
+++ b/Tests/Remove-VcIssuingTemplate.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcIssuingTemplate' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcIssuingTemplate -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "certificateissuingtemplates/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcIssuingTemplate -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcIssuingTemplate -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcIssuingTemplate -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcMachine.Tests.ps1
+++ b/Tests/Remove-VcMachine.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcMachine' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcMachine -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "machines/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcMachine -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcMachine -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcMachine -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcMachineIdentity.Tests.ps1
+++ b/Tests/Remove-VcMachineIdentity.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcMachineIdentity' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcMachineIdentity -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "machineidentities/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcMachineIdentity -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcMachineIdentity -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcMachineIdentity -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcTag.Tests.ps1
+++ b/Tests/Remove-VcTag.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'MyTag'
+    $testId2 = 'AnotherTag'
+}
+
+Describe 'Remove-VcTag' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcTag -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "tags/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcTag -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcTag -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcTag -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcTeam.Tests.ps1
+++ b/Tests/Remove-VcTeam.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcTeam' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcTeam -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "teams/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcTeam -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcTeam -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcTeam -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Remove-VcWebhook.Tests.ps1
+++ b/Tests/Remove-VcWebhook.Tests.ps1
@@ -1,0 +1,36 @@
+﻿BeforeAll {
+    . $PSScriptRoot/ModuleCommonVc.ps1
+
+    $testId = 'ca7ff555-88d2-4bfc-9efa-2630ac44c1f2'
+    $testId2 = 'da8ff666-99e3-5cfd-a0fb-3741bd55d2e3'
+}
+
+Describe 'Remove-VcWebhook' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Test-VenafiSession' -MockWith {} -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-VenafiRestMethod' -MockWith {} -ModuleName $ModuleName
+    }
+
+    It 'Should call the delete API with the correct endpoint' {
+        Remove-VcWebhook -ID $testId -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName -ParameterFilter {
+            $Method -eq 'Delete' -and $UriLeaf -eq "connectors/$testId"
+        }
+    }
+
+    It 'Should accept pipeline input' {
+        $testId | Remove-VcWebhook -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 1 -ModuleName $ModuleName
+    }
+
+    It 'Should process multiple items' {
+        $testId, $testId2 | Remove-VcWebhook -Confirm:$false
+        Should -Invoke -CommandName 'Invoke-VenafiRestMethod' -Times 2 -ModuleName $ModuleName
+    }
+
+    It 'Should not produce output' {
+        $result = Remove-VcWebhook -ID $testId -Confirm:$false
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/VenafiPS/Private/Split-CertificateData.ps1
+++ b/VenafiPS/Private/Split-CertificateData.ps1
@@ -4,13 +4,16 @@ function Split-CertificateData {
     .SYNOPSIS
         Convert PEM data into its cert, key, and chain parts
     #>
-    
+
     [CmdletBinding()]
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [Alias('CertificateData')]
-        [String] $InputObject
+        [String] $InputObject,
+
+        [Parameter()]
+        [switch] $NoHeaders
     )
 
     begin {
@@ -31,11 +34,14 @@ function Split-CertificateData {
 
         for ($i = 0; $i -lt $pemLines.Count; $i++) {
             if ($pemLines[$i].Contains('-----BEGIN')) {
-                $iStart = $i
+                $iStart = if ( $NoHeaders ) { $i + 1 } else { $i }
                 continue
             }
             if ($pemLines[$i].Contains('-----END')) {
-                $thisPemLines = $pemLines[$iStart..$i]
+
+                $iEnd = if ( $NoHeaders ) { $i - 1 } else { $i }
+                $thisPemLines = $pemLines[$iStart..$iEnd]
+
                 if ( $pemLines[$i].Contains('KEY-----')) {
                     $keyPem = ($thisPemLines -join "`n") -replace "`r"
                 }

--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData', 'certificate', 'dekEncryptedPassword')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData', 'certificate', 'dekEncryptedPassword', 'PrivateKeyData')
     )
 
     begin {

--- a/VenafiPS/Public/Import-VcCertificate.ps1
+++ b/VenafiPS/Public/Import-VcCertificate.ps1
@@ -16,24 +16,20 @@ function Import-VcCertificate {
     Contents of a certificate/key to import.
     Provide either this or -Path.
 
-    .PARAMETER PKCS8
-    Provided -Data is in PKCS #8 format.
-    This parameter will be deprecated in a future release.  Use -Format PKCS8.
-
-    .PARAMETER PKCS12
-    Provided -Data is in PKCS #12 format
-    This parameter will be deprecated in a future release.  Use -Format PKCS12.
-
     .PARAMETER Format
     Specify the format provided in -Data.
     PKCS12, PKCS8, and X509 are supported.
-    This will replace -PKCS8 and -PKCS12 in a future release.
+
+    The format is now automatically detected, so this parameter is not required or used.
 
     .PARAMETER PrivateKeyPassword
     Password the private key was encrypted with
 
+    .PARAMETER Recurse
+    When providing a folder path, include subfolders in the search for certificates to import.
+
     .PARAMETER ThrottleLimit
-    Limit the number of threads when running in parallel; the default is 10.  Applicable to PS v7+ only.
+    Limit the number of threads when running in parallel; the default is 10.
     100 keystores will be imported at a time so it's less important to have a very high throttle limit.
 
     .PARAMETER Force
@@ -82,7 +78,7 @@ function Import-VcCertificate {
     To honor the blocklist, set the environment variable VC_ENABLE_BLOCKLIST to 'true'.
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'ByFile')]
+    [CmdletBinding(DefaultParameterSetName = 'ByFile', SupportsShouldProcess)]
     [Alias('Import-VaasCertificate')]
 
     param (
@@ -92,25 +88,14 @@ function Import-VcCertificate {
         [Alias('FullName', 'CertificatePath', 'FilePath')]
         [String] $Path,
 
-        [Parameter(Mandatory, ParameterSetName = 'PKCS12', ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory, ParameterSetName = 'PKCS8', ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory, ParameterSetName = 'Format', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ByData', ValueFromPipelineByPropertyName)]
         [Alias('certificateData')]
         [String] $Data,
 
-        [Parameter(Mandatory, ParameterSetName = 'PKCS8')]
-        [switch] $PKCS8,
-
-        [Parameter(Mandatory, ParameterSetName = 'PKCS12')]
-        [switch] $PKCS12,
-
-        [Parameter(Mandatory, ParameterSetName = 'Format', ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'ByData')]
         [String] $Format,
 
-        [Parameter(Mandatory, ParameterSetName = 'PKCS8')]
-        [Parameter(Mandatory, ParameterSetName = 'PKCS12')]
-        [Parameter(ParameterSetName = 'ByFile')]
-        [Parameter(ParameterSetName = 'Format', ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [ValidateScript(
             {
                 if ( $_ -is [string] -or $_ -is [securestring] -or $_ -is [pscredential] ) {
@@ -126,6 +111,9 @@ function Import-VcCertificate {
         [Parameter()]
         [int32] $ThrottleLimit = 10,
 
+        [Parameter(ParameterSetName = 'ByFile')]
+        [switch] $Recurse,
+
         [Parameter()]
         [switch] $Force,
 
@@ -135,10 +123,6 @@ function Import-VcCertificate {
     )
 
     begin {
-
-        if ( $PSBoundParameters.ContainsKey('PKCS12') -or $PSBoundParameters.ContainsKey('PKCS8') ) {
-            Write-Warning '-PKCS8 and -PKCS12 will soon be deprecated.  Utilize -Format instead.'
-        }
 
         Test-VenafiSession $PSCmdlet.MyInvocation
 
@@ -160,9 +144,11 @@ function Import-VcCertificate {
     process {
 
         if ( $PSCmdlet.ParameterSetName -eq 'ByFile' ) {
+
             $resolvedPath = Resolve-Path -Path $Path -ErrorAction Stop
+
             $files = if (Test-Path -Path $resolvedPath -PathType Container) {
-                Get-ChildItem -Path $resolvedPath -File | Select-Object -ExpandProperty FullName
+                Get-ChildItem -Path $resolvedPath -Recurse:$Recurse -File | Select-Object -ExpandProperty FullName
             }
             else {
                 @($resolvedPath)
@@ -183,7 +169,6 @@ function Import-VcCertificate {
 
                         $allCerts.Add(@{
                                 'CertData' = [System.Convert]::ToBase64String($cert)
-                                'Format'   = 'PKCS12'
                             }
                         )
                     }
@@ -193,15 +178,14 @@ function Import-VcCertificate {
 
                         if ( $split.KeyPem ) {
                             $allCerts.Add(@{
-                                    'CertPem' = $split.CertPem
-                                    'KeyPem'  = $split.KeyPem
-                                    'Format'  = 'PKCS8'
+                                    'CertData' = $split.CertPem
+                                    'KeyData'  = $split.KeyPem
                                 }
                             )
                         }
                         else {
                             $allNoKeyCerts.Add(@{
-                                    'CertPem' = $split.CertPem -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
+                                    'CertData' = $split.CertPem -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
                                 }
                             )
                         }
@@ -217,48 +201,36 @@ function Import-VcCertificate {
             # check if Data exists since we allow null/empty in case piping from another function and data is not there
             if ( $Data ) {
 
-                $addMe = @{
-                    'Format' = ''
+                if ( $PrivateKeyPassword ) {
+                    $pkPassString = ConvertTo-PlaintextString -InputObject $PrivateKeyPassword
                 }
 
-                if ( $Format ) {
-                    $addMe.Format = $Format
-                    # privatekeypassword might have been provided via pipeline so this must be in process block
-                    if ( $PrivateKeyPassword ) {
-                        $pkPassString = ConvertTo-PlaintextString -InputObject $PrivateKeyPassword
+                if ( $Data -match '^LS0' -or $Data -match '-----BEGIN' ) {
+                    # PEM or Base64-encoded PKCS8
+                    $splitData = Split-CertificateData -InputObject $Data
+
+                    if ( $splitData.KeyPem ) {
+                        $allCerts.Add(
+                            @{
+                                'CertData' = $splitData.CertPem
+                                'KeyData'  = $splitData.KeyPem
+                            }
+                        )
+                    }
+                    else {
+                        $allNoKeyCerts.Add(@{
+                                'CertData' = $splitData.CertPem -replace "`r|`n|-----(BEGIN|END)[\w\s]+-----"
+                            }
+                        )
                     }
                 }
                 else {
-                    $addMe.Format = $PSCmdlet.ParameterSetName
-                }
-
-                switch ($addMe.Format) {
-                    'PKCS12' {
-                        $addMe.'CertData' = $Data -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
-                        $allCerts.Add($addMe)
-                    }
-
-                    # X509 and PKCS8 both use Base64, but 'Base64' is how Certificate Manager, Self-Hosted refers to x509
-                    # this allows us to pipe from Certificate Manager, Self-Hosted to Certificate Manager, SaaS
-                    { $_ -in 'PKCS8', 'X509', 'Base64' } {
-                        $splitData = Split-CertificateData -InputObject $Data
-
-                        if ( $splitData.KeyPem ) {
-                            $addMe.CertPem = $splitData.CertPem
-                            $addMe.KeyPem = $splitData.KeyPem
-                            $allCerts.Add($addMe)
+                    #PKCS12
+                    $allCerts.Add(
+                        @{
+                            'CertData' = $Data -replace "`r|`n|-----(BEGIN|END)[\w\s]+-----"
                         }
-                        else {
-                            $allNoKeyCerts.Add(@{
-                                    'CertPem' = $splitData.CertPem -replace "`r|`n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----"
-                                }
-                            )
-                        }
-                    }
-
-                    default {
-                        Write-Error "Unknown format '$_'"
-                    }
+                    )
                 }
             }
         }
@@ -267,7 +239,9 @@ function Import-VcCertificate {
     end {
         if ( $allCerts.Count -eq 0 -and $allNoKeyCerts.Count -eq 0 ) { return }
 
-        Write-Verbose ('Importing {0} certificates' -f ($allCerts.Count + $allNoKeyCerts.Count))
+        if ( -not ($PSCmdlet.ShouldProcess(('{0} certificates, {1} with private keys' -f ($allCerts.Count + $allNoKeyCerts.Count), $allCerts.Count)) ) ) {
+            return
+        }
 
         if ( $allCerts.Count -gt 0 ) {
             # process all certs with keys
@@ -296,20 +270,17 @@ function Import-VcCertificate {
                 }
 
                 $keystores = foreach ($thisCert in $allCerts[$i..($i + 99)]) {
-                    switch ($thisCert.Format) {
-                        'PKCS12' {
-                            @{
-                                'pkcs12Keystore'       = $thisCert.CertData
-                                'dekEncryptedPassword' = $dekEncryptedPassword
-                            }
+                    if ( $thisCert.KeyData ) {
+                        @{
+                            'certificate'                 = $thisCert.CertData
+                            'passwordEncryptedPrivateKey' = $thisCert.KeyData
+                            'dekEncryptedPassword'        = $dekEncryptedPassword
                         }
-
-                        'PKCS8' {
-                            @{
-                                'certificate'                 = $thisCert.CertPem
-                                'passwordEncryptedPrivateKey' = $thisCert.KeyPem
-                                'dekEncryptedPassword'        = $dekEncryptedPassword
-                            }
+                    }
+                    else {
+                        @{
+                            'pkcs12Keystore'       = $thisCert.CertData
+                            'dekEncryptedPassword' = $dekEncryptedPassword
                         }
                     }
                 }
@@ -387,7 +358,7 @@ function Import-VcCertificate {
 
                 $importCertPayload = foreach ($thisCert in $allNoKeyCerts[$i..($i + 99)]) {
                     @{
-                        'certificate' = $thisCert.CertPem
+                        'certificate' = $thisCert.CertData
                     }
                 }
 

--- a/VenafiPS/Public/Import-VcCertificate.ps1
+++ b/VenafiPS/Public/Import-VcCertificate.ps1
@@ -6,6 +6,7 @@ function Import-VcCertificate {
     .DESCRIPTION
     Import one or more certificates and their private keys.
     PKCS8 (.pem), PKCS12 (.pfx or .p12), and X509 (.pem, .cer, or .crt) certificates are supported.
+    Certificates/keys can be imported from a file or from data provided directly to the function, eg. exporting from Certificate Manager, Self-Hosted and importing into Certificate Manager, SaaS.
 
     .PARAMETER Path
     Path to a certificate file or folder with multiple certificates.
@@ -29,7 +30,7 @@ function Import-VcCertificate {
     When providing a folder path, include subfolders in the search for certificates to import.
 
     .PARAMETER ThrottleLimit
-    Limit the number of threads when running in parallel; the default is 10.
+    Limit the number of threads when running in parallel; the default is 1.
     100 keystores will be imported at a time so it's less important to have a very high throttle limit.
 
     .PARAMETER Force
@@ -109,7 +110,7 @@ function Import-VcCertificate {
         [psobject] $PrivateKeyPassword,
 
         [Parameter()]
-        [int32] $ThrottleLimit = 10,
+        [int32] $ThrottleLimit = 1,
 
         [Parameter(ParameterSetName = 'ByFile')]
         [switch] $Recurse,
@@ -271,6 +272,7 @@ function Import-VcCertificate {
 
                 $keystores = foreach ($thisCert in $allCerts[$i..($i + 99)]) {
                     if ( $thisCert.KeyData ) {
+                        #PKCS8
                         @{
                             'certificate'                 = $thisCert.CertData
                             'passwordEncryptedPrivateKey' = $thisCert.KeyData
@@ -278,6 +280,7 @@ function Import-VcCertificate {
                         }
                     }
                     else {
+                        #PKCS12
                         @{
                             'pkcs12Keystore'       = $thisCert.CertData
                             'dekEncryptedPassword' = $dekEncryptedPassword

--- a/VenafiPS/Public/Import-VcCertificate.ps1
+++ b/VenafiPS/Public/Import-VcCertificate.ps1
@@ -131,7 +131,7 @@ function Import-VcCertificate {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -318,47 +318,47 @@ function Import-VcCertificate {
                 $importList.Add($params)
             }
 
-            $sb = {
-                $params = $PSItem
-
-                $requestResponse = Invoke-VenafiRestMethod @params
-
-                do {
-                    try {
-                        $jobResponse = Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf "certificates/imports/$($requestResponse.id)"
-                        Write-Verbose ('import id: {0}, status: {1}' -f $requestResponse.id, $jobResponse.status)
-                    }
-                    catch {
-                        if ( $_.Exception.StatusCode -eq 500 -and $_.ErrorDetails.Message -match 'Unexpected error encountered' ) {
-                            # issue in api where it returns a 500 even though it hasn't actually failed
-                            # perhaps it takes longer for the import process to get started and provide a 'processing' state
-                            Write-Verbose ('import id: {0}, status: no status yet' -f $requestResponse.id)
-                        }
-                        else {
-                            throw $_
-                        }
-                    }
-
-                    Start-Sleep 2
-                } until (
-                    $jobResponse.status -in 'COMPLETED', 'FAILED'
-                )
-
-                if ( $jobResponse.status -eq 'COMPLETED' ) {
-                    $jobResponse.results
-                }
-                else {
-                    # importing only 1 keycert that fails does not give us any results to return to the user :(
-                    throw 'Import failed'
-                }
-            }
-
             $invokeParams = @{
                 InputObject   = $importList
-                ScriptBlock   = $sb
                 ThrottleLimit = $ThrottleLimit
                 ProgressTitle = 'Importing certificates with private keys'
+                VenafiSession = $VenafiSession
+                ScriptBlock   = {
+                    $params = $PSItem
+
+                    $requestResponse = Invoke-VenafiRestMethod @params
+
+                    do {
+                        try {
+                            $jobResponse = Invoke-VenafiRestMethod -UriRoot 'outagedetection/v1' -UriLeaf "certificates/imports/$($requestResponse.id)"
+                            Write-Verbose ('import id: {0}, status: {1}' -f $requestResponse.id, $jobResponse.status)
+                        }
+                        catch {
+                            if ( $_.Exception.StatusCode -eq 500 -and $_.ErrorDetails.Message -match 'Unexpected error encountered' ) {
+                                # issue in api where it returns a 500 even though it hasn't actually failed
+                                # perhaps it takes longer for the import process to get started and provide a 'processing' state
+                                Write-Verbose ('import id: {0}, status: no status yet' -f $requestResponse.id)
+                            }
+                            else {
+                                throw $_
+                            }
+                        }
+
+                        Start-Sleep 2
+                    } until (
+                        $jobResponse.status -in 'COMPLETED', 'FAILED'
+                    )
+
+                    if ( $jobResponse.status -eq 'COMPLETED' ) {
+                        $jobResponse.results
+                    }
+                    else {
+                        # importing only 1 keycert that fails does not give us any results to return to the user :(
+                        throw 'Import failed'
+                    }
+                }
             }
+
             $invokeResponse = Invoke-VenafiParallel @invokeParams
 
             $keyOut = $invokeResponse | Select-Object -Property fingerprint, status, reason
@@ -395,16 +395,15 @@ function Import-VcCertificate {
                 $importList.Add($params)
             }
 
-            $sb = {
-                $params = $PSItem
-                Invoke-VenafiRestMethod @params
-            }
-
             $invokeParams = @{
                 InputObject   = $importList
-                ScriptBlock   = $sb
                 ThrottleLimit = $ThrottleLimit
                 ProgressTitle = 'Importing certificates without private keys'
+                VenafiSession = $VenafiSession
+                ScriptBlock   = {
+                    $params = $PSItem
+                    Invoke-VenafiRestMethod @params
+                }
             }
             $invokeNoKeyResponse = Invoke-VenafiParallel @invokeParams
 

--- a/VenafiPS/Public/Import-VdcCertificate.ps1
+++ b/VenafiPS/Public/Import-VdcCertificate.ps1
@@ -11,7 +11,7 @@ function Import-VdcCertificate {
     Path to a certificate file.  Provide either this or -Data.
 
     .PARAMETER Data
-    Contents of a certificate to import.  Provide either this or -Path.
+    Contents of a certificate or certificate/key to import in Base64.  Provide either this or -Path.
 
     .PARAMETER PolicyPath
     Policy path to import the certificate to.
@@ -31,7 +31,7 @@ function Import-VdcCertificate {
     .PARAMETER PrivateKey
     Private key data; requires a value for PrivateKeyPassword.
     For a PEM certificate, the private key is in either the RSA or PKCS#8 format.
-    Do not provide for a PKCS#12 certificate as the private key is already included.
+    Do not provide when the value for -Data is PKCS12 or PKCS8 as the private key is already included.
 
     .PARAMETER PrivateKeyPassword
     Password required if providing a private key.
@@ -83,7 +83,7 @@ function Import-VdcCertificate {
     Export 1 or more certificates from Certificate Manager, SaaS and import to Certificate Manager, Self-Hosted.  Note the use of 2 sessions at once where the Certificate Manager, Self-Hosted session is stored in a variable.
 
     .INPUTS
-    Path, Data
+    Path, Data, PolicyPath, PrivateKeyPassword
 
     .OUTPUTS
     PSCustomObject, if PassThru provided
@@ -256,7 +256,25 @@ function Import-VdcCertificate {
                 }
 
                 $params = $thisItem.InvokeParams
-                $params.Body.CertificateData = $certData
+
+                # check if the data is PEM/PKCS8 (base64-encoded or raw) vs PKCS12
+                # PEM data starts with '-----BEGIN' or 'LS0' (base64 of '---')
+                # PKCS12 can be passed directly as CertificateData
+                # but PEM/PKCS8 needs to be split into cert and key parts due to api limitation
+                if ( $certData -match '^LS0' -or $certData -match '-----BEGIN' ) {
+                    $pemParts = Split-CertificateData -InputObject $certData
+
+                    if ( $pemParts.CertPem ) {
+                        $params.Body.CertificateData = $pemParts.CertPem
+                    }
+
+                    if ( $pemParts.KeyPem ) {
+                        $params.Body.PrivateKeyData = $pemParts.KeyPem
+                    }
+                }
+                else {
+                    $params.Body.CertificateData = $certData
+                }
 
                 try {
                     $response = Invoke-VenafiRestMethod @params

--- a/VenafiPS/Public/Invoke-VcWorkflow.ps1
+++ b/VenafiPS/Public/Invoke-VcWorkflow.ps1
@@ -90,7 +90,7 @@ function Invoke-VcWorkflow {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -104,123 +104,132 @@ function Invoke-VcWorkflow {
 
     end {
 
-        Invoke-VenafiParallel -InputObject $allIDs -ScriptBlock {
-            $workflow = $using:Workflow
-            # $allIDs | ForEach-Object {
-            $thisID = $PSItem
-            $thisWebSocketID = (New-Guid).Guid
+        $params = @{
+            InputObject   = $allIDs
+            ThrottleLimit = $ThrottleLimit
+            ProgressTitle = 'Invoking workflow'
+            VenafiSession = $VenafiSession
+            ScriptBlock   = {
+                $workflow = $using:Workflow
+                # $allIDs | ForEach-Object {
+                $thisID = $PSItem
+                $thisWebSocketID = (New-Guid).Guid
 
-            try {
+                try {
 
-                $WS = New-Object System.Net.WebSockets.ClientWebSocket
-                $CT = New-Object System.Threading.CancellationToken
+                    $WS = New-Object System.Net.WebSockets.ClientWebSocket
+                    $CT = New-Object System.Threading.CancellationToken
 
-                if ( $script:VenafiSession -is [PSCustomObject] ) {
-                    $server = $script:VenafiSession.Server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession.Key.GetNetworkCredential().password)
-                }
-                else {
-                    # TODO: defaults to US, add other region support
-                    # for other regions, create a session first
-                    $server = ($script:VcRegions).'us'
-                    $server = $server.Replace('https://', '')
-                    $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession)
-                }
-                $URL = 'wss://{0}/ws/notificationclients/{1}' -f $server, $thisWebSocketID
+                    if ( $script:VenafiSession -is [PSCustomObject] ) {
+                        $server = $script:VenafiSession.Server.Replace('https://', '')
+                        $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession.Key.GetNetworkCredential().password)
+                    }
+                    else {
+                        # TODO: defaults to US, add other region support
+                        # for other regions, create a session first
+                        $server = ($script:VcRegions).'us'
+                        $server = $server.Replace('https://', '')
+                        $WS.Options.SetRequestHeader("tppl-api-key", $script:VenafiSession)
+                    }
+                    $URL = 'wss://{0}/ws/notificationclients/{1}' -f $server, $thisWebSocketID
 
-                #Get connected
-                $Conn = $WS.ConnectAsync($URL, $CT)
+                    #Get connected
+                    $Conn = $WS.ConnectAsync($URL, $CT)
 
-                While ( !$Conn.IsCompleted ) {
-                    Start-Sleep -Milliseconds 100
-                }
+                    While ( !$Conn.IsCompleted ) {
+                        Start-Sleep -Milliseconds 100
+                    }
 
-                Write-Verbose "Connecting to $($URL)..."
-                $Size = 8192
-                $Array = [byte[]] @(, 0) * $Size
+                    Write-Verbose "Connecting to $($URL)..."
+                    $Size = 8192
+                    $Array = [byte[]] @(, 0) * $Size
 
-                #Send Starting Request
-                $Command = [System.Text.Encoding]::UTF8.GetBytes("ACTION=Command")
-                $Send = New-Object System.ArraySegment[byte] -ArgumentList @(, $Command)
-                $Conn = $WS.SendAsync($Send, [System.Net.WebSockets.WebSocketMessageType]::Text, $true, $CT)
+                    #Send Starting Request
+                    $Command = [System.Text.Encoding]::UTF8.GetBytes("ACTION=Command")
+                    $Send = New-Object System.ArraySegment[byte] -ArgumentList @(, $Command)
+                    $Conn = $WS.SendAsync($Send, [System.Net.WebSockets.WebSocketMessageType]::Text, $true, $CT)
 
-                While (!$Conn.IsCompleted) {
-                    Start-Sleep -Milliseconds 100
-                }
+                    While (!$Conn.IsCompleted) {
+                        Start-Sleep -Milliseconds 100
+                    }
 
-                #Start reading the received items
-                $Recv = New-Object System.ArraySegment[byte] -ArgumentList @(, $Array)
-                $Conn = $WS.ReceiveAsync($Recv, $CT)
+                    #Start reading the received items
+                    $Recv = New-Object System.ArraySegment[byte] -ArgumentList @(, $Array)
+                    $Conn = $WS.ReceiveAsync($Recv, $CT)
 
-                Write-Verbose 'Triggering workflow'
+                    Write-Verbose 'Triggering workflow'
 
-                $triggerParams = @{
-                    UriLeaf = "machines/$thisID/workflows"
-                    Method  = 'Post'
-                    Body    = @{
-                        'workflowInput' = @{
-                            'wsClientId' = $thisWebSocketID
+                    $triggerParams = @{
+                        UriLeaf = "machines/$thisID/workflows"
+                        Method  = 'Post'
+                        Body    = @{
+                            'workflowInput' = @{
+                                'wsClientId' = $thisWebSocketID
+                            }
+                            'workflowName'  = 'testConnection'
                         }
-                        'workflowName'  = 'testConnection'
+
                     }
+
+                    switch ($Workflow) {
+                        'GetConfig' {
+                            $triggerParams.Body.workflowName = 'getTargetConfiguration'
+                        }
+
+                        'Provision' {
+                            $triggerParams.Body.workflowName = 'provisionCertificate'
+                            $triggerParams.UriLeaf = "machineidentities/$thisID/workflows"
+                        }
+
+                        'Discover' {
+                            $triggerParams.Body.workflowName = 'discoverCertificates'
+                            $triggerParams.UriLeaf = "machines/$thisID/workflows"
+                        }
+                    }
+
+                    $null = Invoke-VenafiRestMethod @triggerParams
+
+                    While (!$Conn.IsCompleted) {
+                        Start-Sleep -Milliseconds 100
+                    }
+
+                    $response = ''
+                    $Recv.Array[0..($Conn.Result.Count - 1)] | ForEach-Object { $response += [char]$_ }
+
+                    Write-Verbose $response
+
+                    $responseObj = $response | ConvertFrom-Json
+
+                    $out = [pscustomobject]@{
+                        ID           = $thisID
+                        Success      = $true
+                        WorkflowName = $Workflow
+                        WorkflowID   = $thisWebSocketID
+                    }
+
+                    if ( $responseObj.data.result -ne $true ) {
+                        $out.Success = $false
+                        try {
+                            $out | Add-Member @{'Error' = $responseObj.data.result.message | ConvertFrom-Json }
+                        }
+                        catch {
+                            $out | Add-Member @{'Error' = $responseObj.data.result.message }
+                        }
+                    }
+
+                    $out
 
                 }
-
-                switch ($Workflow) {
-                    'GetConfig' {
-                        $triggerParams.Body.workflowName = 'getTargetConfiguration'
-                    }
-
-                    'Provision' {
-                        $triggerParams.Body.workflowName = 'provisionCertificate'
-                        $triggerParams.UriLeaf = "machineidentities/$thisID/workflows"
-                    }
-
-                    'Discover' {
-                        $triggerParams.Body.workflowName = 'discoverCertificates'
-                        $triggerParams.UriLeaf = "machines/$thisID/workflows"
+                finally {
+                    if ( $WS ) {
+                        $WS.Dispose()
                     }
                 }
-
-                $null = Invoke-VenafiRestMethod @triggerParams
-
-                While (!$Conn.IsCompleted) {
-                    Start-Sleep -Milliseconds 100
-                }
-
-                $response = ''
-                $Recv.Array[0..($Conn.Result.Count - 1)] | ForEach-Object { $response += [char]$_ }
-
-                Write-Verbose $response
-
-                $responseObj = $response | ConvertFrom-Json
-
-                $out = [pscustomobject]@{
-                    ID           = $thisID
-                    Success      = $true
-                    WorkflowName = $Workflow
-                    WorkflowID   = $thisWebSocketID
-                }
-
-                if ( $responseObj.data.result -ne $true ) {
-                    $out.Success = $false
-                    try {
-                        $out | Add-Member @{'Error' = $responseObj.data.result.message | ConvertFrom-Json }
-                    }
-                    catch {
-                        $out | Add-Member @{'Error' = $responseObj.data.result.message }
-                    }
-                }
-
-                $out
-
             }
-            finally {
-                if ( $WS ) {
-                    $WS.Dispose()
-                }
-            }
-        } -ThrottleLimit $ThrottleLimit -ProgressTitle 'Invoking workflow'
+
+        }
+
+        Invoke-VenafiParallel @params
     }
 }
 

--- a/VenafiPS/Public/New-VcMachine.ps1
+++ b/VenafiPS/Public/New-VcMachine.ps1
@@ -173,7 +173,7 @@ function New-VcMachine {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -278,27 +278,35 @@ function New-VcMachine {
 
     end {
 
-        $response = Invoke-VenafiParallel -InputObject $allMachines -ScriptBlock {
-            $response = Invoke-VenafiRestMethod -Method 'Post' -UriLeaf 'machines' -Body $PSItem
+        $params = @{
+            InputObject   = $allMachines
+            ThrottleLimit = $ThrottleLimit
+            VenafiSession = $VenafiSession
+            ProgressTitle = 'Creating machines'
+            ScriptBlock   = {
+                $response = Invoke-VenafiRestMethod -Method 'Post' -UriLeaf 'machines' -Body $PSItem
 
-            if ( $using:NoVerify ) {
-                $response | Select-Object @{
-                    'n' = 'machineId'
-                    'e' = { $_.id }
-                }, * -ExcludeProperty id
+                if ( $using:NoVerify ) {
+                    $response | Select-Object @{
+                        'n' = 'machineId'
+                        'e' = { $_.id }
+                    }, * -ExcludeProperty id
+                }
+                else {
+                    $workflowResponse = Invoke-VcWorkflow -ID $response.id -Workflow 'Test'
+                    $response | Select-Object @{
+                        'n' = 'machineId'
+                        'e' = { $_.id }
+                    },
+                    @{
+                        'n' = 'testConnection'
+                        'e' = { $workflowResponse | Select-Object Success, Error, WorkflowID }
+                    }, * -ExcludeProperty id
+                }
             }
-            else {
-                $workflowResponse = Invoke-VcWorkflow -ID $response.id -Workflow 'Test'
-                $response | Select-Object @{
-                    'n' = 'machineId'
-                    'e' = { $_.id }
-                },
-                @{
-                    'n' = 'testConnection'
-                    'e' = { $workflowResponse | Select-Object Success, Error, WorkflowID }
-                }, * -ExcludeProperty id
-            }
-        } -ThrottleLimit $ThrottleLimit
+        }
+
+        $response = Invoke-VenafiParallel @params
 
         if ( $PassThru ) {
             $response

--- a/VenafiPS/Public/Remove-VcApplication.ps1
+++ b/VenafiPS/Public/Remove-VcApplication.ps1
@@ -44,7 +44,7 @@ function Remove-VcApplication {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcApplication {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriRoot 'outagedetection/v1' -UriLeaf "applications/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
+++ b/VenafiPS/Public/Remove-VcIssuingTemplate.ps1
@@ -44,7 +44,7 @@ function Remove-VcIssuingTemplate {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcIssuingTemplate {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "certificateissuingtemplates/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcMachine.ps1
+++ b/VenafiPS/Public/Remove-VcMachine.ps1
@@ -44,7 +44,7 @@ function Remove-VcMachine {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcMachine {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "machines/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcMachineIdentity.ps1
+++ b/VenafiPS/Public/Remove-VcMachineIdentity.ps1
@@ -44,7 +44,7 @@ function Remove-VcMachineIdentity {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcMachineIdentity {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "machineidentities/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcTag.ps1
+++ b/VenafiPS/Public/Remove-VcTag.ps1
@@ -44,7 +44,7 @@ function Remove-VcTag {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcTag {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "tags/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcTeam.ps1
+++ b/VenafiPS/Public/Remove-VcTeam.ps1
@@ -44,7 +44,7 @@ function Remove-VcTeam {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcTeam {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "teams/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 

--- a/VenafiPS/Public/Remove-VcWebhook.ps1
+++ b/VenafiPS/Public/Remove-VcWebhook.ps1
@@ -44,7 +44,7 @@ function Remove-VcWebhook {
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [psobject] $VenafiSession
+        [psobject] $VenafiSession = (Get-VenafiSession)
     )
 
     begin {
@@ -61,7 +61,7 @@ function Remove-VcWebhook {
     end {
         Invoke-VenafiParallel -InputObject $allObjects -ScriptBlock {
             $null = Invoke-VenafiRestMethod -Method 'Delete' -UriLeaf "connectors/$PSItem"
-        } -ThrottleLimit $ThrottleLimit
+        } -ThrottleLimit $ThrottleLimit -VenafiSession $VenafiSession
     }
 }
 


### PR DESCRIPTION
- `Import-VcCertificate` updates:
    - Fix prompting for VenafiSession even when provided
    - Remove `-PKCS8` and `-PKCS12`, and soon `-Format`, in favor of autodetection
    - Add `-Recurse` to bring in certificates in subfolders when importing by path
    - Add ShouldProcess so `-WhatIf` can be used prior to importing
    - ThrottleLimit changed to 1 by default as 100 certs are submitted at a time
- Add PKCS8 support to `Import-VdcCertificate`