### PR TITLE
manage api key in CMSaaS

### DIFF
--- a/Tests/New-TrustClient.Tests.ps1
+++ b/Tests/New-TrustClient.Tests.ps1
@@ -414,10 +414,10 @@ Describe 'TrustClient CanRefresh Negative Cases' -Tags 'Unit' {
         $sess.CanRefresh() | Should -BeFalse
     }
 
-    It 'Should return false for VC ApiKey sessions' {
+    It 'Should return true for CMS ApiKey sessions' {
         $sess = New-TrustClient -CmsKey (New-TestCredential -UserName 'VcKey' -Password 'key') -PassThru
 
-        $sess.CanRefresh() | Should -BeFalse
+        $sess.CanRefresh() | Should -BeTrue
     }
 
     It 'Should return false for NGTS without credential' {
@@ -435,9 +435,9 @@ Describe 'TrustClient IsExpired Edge Cases' -Tags 'Unit' {
         Mock -CommandName 'Invoke-TrustRestMethod' -ModuleName $ModuleName -MockWith { @{} }
     }
 
-    It 'Should return false when Expires is MinValue (never set)' {
+    It 'Should return false when Expires is MaxValue (no expiry set)' {
         $sess = New-TrustClient -CmsKey (New-TestCredential -UserName 'VcKey' -Password 'key') -PassThru
-        # ApiKey sessions have Expires at MinValue
+        # ApiKey sessions have Expires set to MaxValue when no validityEndDate exists
 
         $sess.IsExpired() | Should -BeFalse
     }
@@ -473,5 +473,42 @@ Describe 'NGTS Session Refresh' -Tags 'Unit' {
         $sess.AccessToken.GetNetworkCredential().Password | Should -Be 'ngts-refreshed'
         $sess.Expires | Should -BeGreaterThan ([DateTime]::UtcNow)
         Should -Invoke -CommandName 'New-NgtsToken' -ModuleName $ModuleName -Times 1
+    }
+}
+
+Describe 'CMS ApiKey Session Refresh' -Tags 'Unit' {
+
+    BeforeEach {
+        Mock -CommandName 'Invoke-TrustRestMethod' -ModuleName $ModuleName -MockWith { @{} }
+    }
+
+    It 'Should refresh CMS ApiKey session via Update-CmsApiKey and update ApiKey' {
+        Mock -CommandName 'Update-CmsApiKey' -ModuleName $ModuleName -MockWith {
+            @{
+                ApiKey  = (New-TestCredential -UserName 'ApiKey' -Password 'rotated-key-value')
+                Expires = [DateTime]::UtcNow.AddDays(90)
+            }
+        }
+
+        $sess = New-TrustClient -CmsKey (New-TestCredential -UserName 'VcKey' -Password 'old-key') -PassThru
+        $sess.Expires = [DateTime]::UtcNow.AddSeconds(10)
+
+        & (Get-Module $ModuleName) { Invoke-SessionRefresh -Session $args[0] } $sess
+
+        $sess.ApiKey.GetNetworkCredential().Password | Should -Be 'rotated-key-value'
+        $sess.Expires | Should -BeGreaterThan ([DateTime]::UtcNow)
+        Should -Invoke -CommandName 'Update-CmsApiKey' -ModuleName $ModuleName -Times 1
+    }
+
+    It 'Should not refresh a non-expired CMS ApiKey session' {
+        Mock -CommandName 'Update-CmsApiKey' -ModuleName $ModuleName
+        Mock -CommandName 'Invoke-RestMethod' -ModuleName $ModuleName -MockWith { @{ ok = $true } }
+
+        $sess = New-TrustClient -CmsKey (New-TestCredential -UserName 'VcKey' -Password 'valid-key') -PassThru
+        $sess.Expires = [DateTime]::UtcNow.AddDays(30)
+
+        $null = Invoke-TrustRestMethod -TrustClient $sess -UriLeaf 'useraccounts' -Method Get
+
+        Should -Invoke -CommandName 'Update-CmsApiKey' -ModuleName $ModuleName -Times 0
     }
 }

--- a/VenafiPS/Classes/02-TrustClient.ps1
+++ b/VenafiPS/Classes/02-TrustClient.ps1
@@ -43,10 +43,10 @@
 
     # Valid platform + auth type combinations and their required properties
     static [hashtable] $AuthRules = @{
-        [TrustPlatform]::CM  = @{
+        [TrustPlatform]::CM   = @{
             [TrustAuthType]::BearerToken = @('AccessToken', 'Server')
         }
-        [TrustPlatform]::CMS   = @{
+        [TrustPlatform]::CMS  = @{
             [TrustAuthType]::BearerToken = @('AccessToken', 'Server')
             [TrustAuthType]::ApiKey      = @('ApiKey', 'Server')
         }
@@ -128,6 +128,24 @@
         $client.Server = $server
         $client.AuthType = [TrustAuthType]::ApiKey
         $client.ApiKey = $apiKey
+
+        try {
+            # only have api key at this point, go get the expiry
+            $existingKeys = Invoke-TrustRestMethod -TrustClient $client -Method Get -UriLeaf 'apikeys' | Select-Object -ExpandProperty apiKeys
+            $thisKey = $existingKeys | Where-Object key -eq $apiKey.GetNetworkCredential().Password
+            $client.Expires = if ($thisKey.validityEndDate) {
+                [datetime]::Parse($thisKey.validityEndDate)
+            }
+            else {
+                [datetime]::MaxValue
+            }
+        }
+        catch {
+            # if for any reason the apikeys endpoint isn't available, just set expiry to max value and let it error later when it's used if the key is invalid
+            Write-Warning "Could not retrieve API key expiry date, setting to max value"
+            $client.Expires = [datetime]::MaxValue
+        }
+
         $client.Validate()
         return $client
     }
@@ -166,7 +184,7 @@
             }
 
             'CMS' {
-                if ($this.AuthType -eq 'BearerToken' -and $this.Credential) {
+                if (($this.AuthType -eq 'BearerToken' -and $this.Credential) -or ($this.AuthType -eq 'ApiKey' -and $this.ApiKey)) {
                     return $true
                 }
                 return $false
@@ -206,7 +224,9 @@
                 break
             }
             'CMS' {
-                throw 'Token revocation is not supported for Certificate Manager, SaaS.'
+                if (-not $this.ApiKey) {
+                    throw 'No API key to revoke.'
+                }
             }
             'NGTS' {
                 Write-Warning 'Token revocation is not currently supported for NGTS/SCM.  Clearing tokens locally, but this session may still be valid until the access token expires.'

--- a/VenafiPS/Private/Invoke-SessionRefresh.ps1
+++ b/VenafiPS/Private/Invoke-SessionRefresh.ps1
@@ -35,7 +35,9 @@
         New-NgtsToken @ngtsParams -ErrorAction Stop
     }
     elseif ($Session.Platform -eq 'CMS') {
-        throw 'Automatic token refresh is not available for VC platform'
+        if ( $Session.AuthType -eq 'ApiKey' ) {
+            Update-CmsApiKey -TrustClient $Session -ErrorAction Stop
+        }
     }
     else {
         throw "Unknown platform $($Session.Platform) for token refresh"
@@ -43,6 +45,7 @@
 
     $Session.AccessToken = $newToken.AccessToken
     $Session.Scope = $newToken.Scope
+    $Session.ApiKey = $newToken.ApiKey
     $Session.Expires = $newToken.Expires
     if ($newToken.RefreshToken) { $Session.RefreshToken = $newToken.RefreshToken }
     if ($newToken.RefreshExpires -gt [datetime]::MinValue) { $Session.RefreshExpires = $newToken.RefreshExpires }

--- a/VenafiPS/Private/Update-CmsApiKey.ps1
+++ b/VenafiPS/Private/Update-CmsApiKey.ps1
@@ -1,0 +1,111 @@
+function Update-CmsApiKey {
+    <#
+    .SYNOPSIS
+    Rotate an API key
+
+    .DESCRIPTION
+    Rotate the active API key for a service account.
+    If the key has never been rotated, a rotation request is made; otherwise a replacement is made.
+    The new active key is returned along with its expiration date.
+
+    .PARAMETER TrustClient
+    TrustClient object containing the endpoint and authentication details for the service account.
+
+    .PARAMETER RemoveInactiveKey
+    Delete any inactive (previously rotated) API key after generating the new one.
+
+    .EXAMPLE
+    Update-CmsApiKey -TrustClient $client
+
+    Rotate the API key and return the new active key.
+
+    .EXAMPLE
+    Update-CmsApiKey -TrustClient $client -RemoveInactiveKey
+
+    Rotate the API key and delete the old inactive key from the previous rotation.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    Hashtable with ApiKey (PSCredential) and Expires (datetime)
+    #>
+
+    param (
+        [Parameter()]
+        [switch] $KeepInactiveKey,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [TrustClient] $TrustClient
+    )
+
+    # there will be 2 keys at most.  1 always active.
+    $existingKeys = Invoke-TrustRestMethod -TrustClient $TrustClient -Method Get -UriLeaf 'apikeys' | Select-Object -ExpandProperty apiKeys
+    $existingActiveKey = $existingKeys | Where-Object apiKeyStatus -eq 'ACTIVE'
+    $existingInactiveKey = $existingKeys | Where-Object apiKeyStatus -ne 'ACTIVE'
+
+    # delete inactive key if exists
+    if ( -not $KeepInactiveKey ) {
+        if ( $existingInactiveKey ) {
+            try {
+                $deleteParams = @{
+                    key = $existingInactiveKey.key
+                }
+                $null = Invoke-TrustRestMethod -TrustClient $TrustClient -Method Put -UriLeaf 'apikeys/rotation' -Body $deleteParams
+                Write-Verbose "Deleted inactive API key"
+            }
+            catch {
+                Write-Error "Failed to delete inactive API key, manual cleanup may be required"
+            }
+        }
+        else {
+            Write-Warning 'There are no inactive API keys to delete'
+        }
+    }
+
+    $endpoint = if ( $KeepInactiveKey ) {
+        'replacement'
+    }
+    else {
+        'rotationrequest'
+    }
+
+    # determine validity end date for new key based on provided validity days or existing key validity window, if available
+    if ( $existingActiveKey.validityEndDate ) {
+        $validityEndDate = [datetime]::Parse($existingActiveKey.validityEndDate)
+        $validityStartDate = if ( $existingActiveKey.validityStartDate ) { [datetime]::Parse($existingActiveKey.validityStartDate) } else { [datetime]::MinValue }
+        $validityDays = [math]::Max([int][math]::Ceiling(($validityEndDate - $validityStartDate).TotalDays), 0)
+    }
+    else {
+        $validityDays = 0
+    }
+
+    # regen the existing active key
+    $regenParams = @{
+        apiVersion   = 'ALL'
+        key          = $existingActiveKey.key
+        validityDays = $validityDays
+    }
+    $regenResponse = Invoke-TrustRestMethod -TrustClient $TrustClient -Method Post -UriLeaf "apikeys/$endpoint" -Body $regenParams
+
+    if ( $regenResponse.apiKeys ) {
+        Write-Debug "API key rotation response: $($regenResponse | ConvertTo-Json -Depth 5)"
+        $newKey = $regenResponse.apiKeys | Where-Object apiKeyStatus -eq 'ACTIVE'
+        Write-Verbose 'New API key generated'
+    }
+    else {
+        throw 'Unexpected response from API key rotation endpoint, no apiKeys property found.'
+    }
+
+    $response = @{
+        'ApiKey' = New-Object System.Management.Automation.PSCredential('ApiKey', ($newKey.key | ConvertTo-SecureString -AsPlainText -Force))
+        Expires  = [datetime]::MaxValue
+    }
+
+    if ( $newKey.validityEndDate ) {
+        $response.Expires = [datetime]::Parse($newKey.validityEndDate)
+    }
+
+    $response
+}

--- a/VenafiPS/Private/Update-CmsApiKey.ps1
+++ b/VenafiPS/Private/Update-CmsApiKey.ps1
@@ -31,6 +31,7 @@ function Update-CmsApiKey {
     Hashtable with ApiKey (PSCredential) and Expires (datetime)
     #>
 
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Converting to a secure string, its already plaintext')]
     param (
         [Parameter()]
         [switch] $KeepInactiveKey,

--- a/VenafiPS/Public/New-TrustClient.ps1
+++ b/VenafiPS/Public/New-TrustClient.ps1
@@ -375,7 +375,7 @@ function New-TrustClient {
         [ValidateRange(1000000000, 9999999999)]
         [long] $Tsg,
 
-        [Parameter(ParameterSetName = 'RefreshSession')]
+        [Parameter(Mandatory, ParameterSetName = 'RefreshSession')]
         [switch] $RefreshSession,
 
         [Parameter()]
@@ -436,20 +436,34 @@ function New-TrustClient {
             }
 
             $client = $script:TrustClient
+            switch ($client.Platform ) {
+                'CM' {
+                    # not really needed since refresh happens automatically now, but leaving here in case there are any edge cases where the old refresh token functionality is still needed
+                    if ( -not $client.AuthServer -or -not $client.RefreshToken -or -not $client.ClientId ) {
+                        throw 'In order to refresh an existing session, it must have a Server, RefreshToken, and ClientId.'
+                    }
 
-            if ( -not $client.AuthServer -or -not $client.RefreshToken -or -not $client.ClientId ) {
-                throw 'In order to refresh an existing session, it must have a Server, RefreshToken, and ClientId.'
+                    $refreshParams = @{
+                        Server               = $client.AuthServer
+                        RefreshToken         = $client.RefreshToken
+                        ClientId             = $client.ClientId
+                        SkipCertificateCheck = $client.SkipCertificateCheck
+                    }
+
+                    New-TrustClient @refreshParams
+                    return
+                }
+
+                'CMS' {
+                    if ( $client.AuthType -ne 'ApiKey' ) {
+                        throw 'Session refresh is only supported for CMS sessions authenticated with an API key.'
+                    }
+                    Invoke-SessionRefresh -Session $client
+                    return
+                }
+                Default {}
             }
 
-            $refreshParams = @{
-                Server               = $client.AuthServer
-                RefreshToken         = $client.RefreshToken
-                ClientId             = $client.ClientId
-                SkipCertificateCheck = $client.SkipCertificateCheck
-            }
-
-            New-TrustClient @refreshParams
-            return
         }
 
         { $_ -in 'TokenOAuth', 'TokenIntegrated', 'TokenCertificate', 'TokenJwt' } {


### PR DESCRIPTION
- add support for CMSaaS to `New-TrustClient -RefreshSession`.  the inactive key will be deleted and the active key will be refreshed.  validity, in days, for the new key will be the same as existing.
- auto-refresh is supported for api key expiration
- $TrustClient.Expires is now accurate for api keys
- closes #395 