### PR TITLE
security: CWE-22: Path traversal in Export-TrustCertificate — VC-53778

### DIFF
--- a/VenafiPS/Public/Export-TrustCertificate.ps1
+++ b/VenafiPS/Public/Export-TrustCertificate.ps1
@@ -220,7 +220,11 @@ function Export-TrustCertificate {
                 # pkcs12 is a byte array of a pfx file so its easy to handle
                 if ( $using:pset -eq 'PKCS12' ) {
                     if ( $using:OutPath ) {
-                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath ('{0}.pfx' -f $thisCert.certificateName)
+                        $safeName = [IO.Path]::GetFileName($thisCert.certificateName)
+                        if ([string]::IsNullOrEmpty($safeName) -or $safeName -ne $thisCert.certificateName) {
+                            throw "Invalid certificate name: path traversal detected in '$($thisCert.certificateName)'"
+                        }
+                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath ('{0}.pfx' -f $safeName)
                         [IO.File]::WriteAllBytes($dest, $innerResponse.Content)
                         $out | Add-Member @{'outPath' = $dest }
                     }
@@ -267,7 +271,11 @@ function Export-TrustCertificate {
                         }
                         else {
                             # copy files from zip to final desination since they are already in pem format
-                            $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath $thisCert.certificateName
+                            $safeName = [IO.Path]::GetFileName($thisCert.certificateName)
+                            if ([string]::IsNullOrEmpty($safeName) -or $safeName -ne $thisCert.certificateName) {
+                                throw "Invalid certificate name: path traversal detected in '$($thisCert.certificateName)'"
+                            }
+                            $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath $safeName
                             $null = New-Item -Path $dest -ItemType Directory -Force
                             $unzipFiles | Copy-Item -Destination $dest -Force
                             $out | Add-Member @{'outPath' = $dest }
@@ -336,7 +344,11 @@ function Export-TrustCertificate {
 
                 if ( $certificateData ) {
                     if ( $using:OutPath ) {
-                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath $thisCert.certificateName
+                        $safeName = [IO.Path]::GetFileName($thisCert.certificateName)
+                        if ([string]::IsNullOrEmpty($safeName) -or $safeName -ne $thisCert.certificateName) {
+                            throw "Invalid certificate name: path traversal detected in '$($thisCert.certificateName)'"
+                        }
+                        $dest = Join-Path -Path (Resolve-Path -Path $using:OutPath) -ChildPath $safeName
                         $null = New-Item -Path $dest -ItemType Directory -Force
                         $outFile = Join-Path -Path $dest -ChildPath ('{0}.{1}' -f $PSItem, $params.Body.format)
                         try {


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability (CWE-22) in `Export-TrustCertificate` where unsanitized server-supplied `certificateName` values were used directly in file path construction.

## Finding

**CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')**

The `Export-TrustCertificate` function (alias `Export-VcCertificate`) joined server-returned `certificateName` field to the operator's `-OutPath` parameter without sanitization at three locations:

1. Line 223: PKCS12 export format
2. Line 270: PEM with private key export
3. Line 339: Certificate-only export

An attacker controlling `certificateName` could use path traversal sequences (e.g., `../../../etc/passwd`) to write files outside the intended output directory, potentially overwriting critical system files.

## Remediation

Applied fail-closed validation at all three vulnerable sites:

1. Extract the leaf filename using `[IO.Path]::GetFileName()`
2. Validate the result is non-empty and matches the original input
3. Throw an error if validation fails, preventing the path traversal

This approach:
- Rejects any path containing directory separators (`/`, `\`)
- Rejects empty or null certificate names
- Preserves legitimate certificate names (e.g., `app.example.com`)
- Fails safely on any suspicious input

## Verification

- Build: not run (PowerShell module - no build detected)
- Tests: not run (no test framework detected)
- Manual review: All three vulnerable `Join-Path` callsites now use sanitized `$safeName` variable