### PR TITLE
fix(ci): pin actions/checkout to immutable SHA (VC-53683 SC-004)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       module_name: VenafiPS
     steps:
-      - uses: actions/checkout@b9e0990d219a03df7633c93f6f005a8fecbcab22 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.CD_TOKEN }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       module_name: VenafiPS
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b9e0990d219a03df7633c93f6f005a8fecbcab22 # v7.0.0
         with:
           token: ${{ secrets.CD_TOKEN }}
 


### PR DESCRIPTION
## Summary

Addresses supply chain security finding SC-004 from Jira ticket VC-53683.

### Changes

- **SC-004**: `.github/workflows/cd.yml` — `actions/checkout@main` pinned to full 40-character commit SHA `b9e0990d219a03df7633c93f6f005a8fecbcab22` (v7.0.0), eliminating the mutable branch ref.

### Already Compliant (no changes needed)

- **SC-003**: `mhausenblas/mkdocs-deploy-gh-pages` already pinned to full SHA `a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5` in `cd.yml`. The `@master` ref in `ci.yml` is in a commented-out block and not active.
- **SC-002 / SC-009**: `Initialize-PSSodium.ps1` already uses `-Repository PSGallery -RequiredVersion $script:pssodiumVersion` with per-file SHA256 hash verification. All CI `Install-Module` calls already include `-RequiredVersion` and `-Repository PSGallery` (PSScriptAnalyzer@1.25.0, Pester@5.7.1, platyPS@0.14.2).

Closes VC-53683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)